### PR TITLE
fix: eliminate duplicate CI runs on PR branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -249,28 +249,3 @@ jobs:
             artifacts/zipper-linux-x64/zipper-linux-x64
             artifacts/zipper-osx-arm64/zipper-osx-arm64
 
-  release:
-    needs: [prepare, lint, build, test]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v7
-        with:
-          path: artifacts
-
-      - uses: softprops/action-gh-release@v2.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          files: |
-            artifacts/zipper-win-x64/zipper-win-x64.exe
-            artifacts/zipper-linux-x64/zipper-linux-x64
-            artifacts/zipper-osx-arm64/zipper-osx-arm64

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -204,7 +204,12 @@ function verify_zip_size() {
         print_error "No .zip file found in $test_dir"
     fi
 
-    local actual_size_bytes=$(stat -c%s "$zip_file")
+    local actual_size_bytes
+    if [ "$(uname)" == "Darwin" ]; then
+        actual_size_bytes=$(stat -f%z "$zip_file")
+    else
+        actual_size_bytes=$(stat -c%s "$zip_file")
+    fi
     local min_size=$((target_size_bytes - tolerance_bytes))
     local max_size=$((target_size_bytes + tolerance_bytes))
 

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -85,8 +85,8 @@ verify_attachments() {
     attachment_dat_count=$(tail -n +2 "$dat_file" | cut -d$'\024' -f"$attachment_col_index" | grep -c -v '^þþ$')
     
     local attachment_zip_count
-    # Use portable unzip -l instead of unzip -Z -1
-    attachment_zip_count=$(unzip -l "$zip_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -c -v -E '\.eml$|\.txt$')
+    # Robustly get filenames and count attachments
+    attachment_zip_count=$(unzip -l "$zip_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$' | grep -c -v -E '\.eml$|\.txt$')
 
     echo "  - Attachments found in ZIP: $attachment_zip_count"
     echo "  - Attachments referenced in DAT: $attachment_dat_count"
@@ -169,13 +169,13 @@ run_test() {
             if [ "$check_text" = true ]; then
                 echo "  - Verifying extracted text files..."
                 local zip_files
-                zip_files=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}')
+                zip_files=$(unzip -l "$archive_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$')
                 local eml_count
-                eml_count=$(echo "$zip_files" | grep -c '\.eml$')
+                eml_count=$(echo "$zip_files" | grep -c '\.eml$' || true)
                 local txt_count
-                txt_count=$(echo "$zip_files" | grep -c '\.txt$')
+                txt_count=$(echo "$zip_files" | grep -c '\.txt$' || true)
                 local attachment_count
-                attachment_count=$(echo "$zip_files" | grep -c -v -E '\.eml$|\.txt$')
+                attachment_count=$(echo "$zip_files" | grep -c -v -E '\.eml$|\.txt$' || true)
                 local expected_txt_count=$((eml_count + attachment_count))
 
                 if [ "$expected_txt_count" -eq "$txt_count" ]; then
@@ -188,7 +188,7 @@ run_test() {
 
             if [ "$check_attachments" = true ]; then
                 local eml_count
-                eml_count=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -c '\.eml$')
+                eml_count=$(unzip -l "$archive_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$' | grep -c '\.eml$')
                 if ! verify_attachments "$dat_file" "$archive_file" "$attachment_rate" "$eml_count"; then
                     all_checks_passed=false
                 fi

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -61,6 +61,12 @@ verify_headers() {
     return $([ "$all_found" = true ] && echo 0 || echo 1)
 }
 
+# Helper function to count zip attachments, explicitly filtering out directory entries
+count_zip_attachments() {
+    local zip_file="$1"
+    unzip -l "$zip_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -v '/$' | grep -c -v -E '\.eml$|\.txt$' || true
+}
+
 # Function to verify attachments
 verify_attachments() {
     local dat_file="$1"
@@ -86,7 +92,7 @@ verify_attachments() {
     
     local attachment_zip_count
     # Robustly get filenames and count attachments
-    attachment_zip_count=$(unzip -l "$zip_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$' | grep -c -v -E '\.eml$|\.txt$')
+    attachment_zip_count=$(count_zip_attachments "$zip_file")
 
     echo "  - Attachments found in ZIP: $attachment_zip_count"
     echo "  - Attachments referenced in DAT: $attachment_dat_count"
@@ -169,13 +175,12 @@ run_test() {
             if [ "$check_text" = true ]; then
                 echo "  - Verifying extracted text files..."
                 local zip_files
-                zip_files=$(unzip -l "$archive_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$')
+                zip_files=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -v '/$')
                 local eml_count
                 eml_count=$(echo "$zip_files" | grep -c '\.eml$' || true)
                 local txt_count
                 txt_count=$(echo "$zip_files" | grep -c '\.txt$' || true)
-                local attachment_count
-                attachment_count=$(echo "$zip_files" | grep -c -v -E '\.eml$|\.txt$' || true)
+                local attachment_count=$(count_zip_attachments "$archive_file")
                 local expected_txt_count=$((eml_count + attachment_count))
 
                 if [ "$expected_txt_count" -eq "$txt_count" ]; then
@@ -188,7 +193,7 @@ run_test() {
 
             if [ "$check_attachments" = true ]; then
                 local eml_count
-                eml_count=$(unzip -l "$archive_file" | awk '{print $NF}' | grep -E '\.[a-zA-Z0-9]+$' | grep -c '\.eml$')
+                eml_count=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -v '/$' | grep -c '\.eml$')
                 if ! verify_attachments "$dat_file" "$archive_file" "$attachment_rate" "$eml_count"; then
                     all_checks_passed=false
                 fi

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -85,7 +85,8 @@ verify_attachments() {
     attachment_dat_count=$(tail -n +2 "$dat_file" | cut -d$'\024' -f"$attachment_col_index" | grep -c -v '^þþ$')
     
     local attachment_zip_count
-    attachment_zip_count=$(unzip -Z -1 "$zip_file" | grep -c -v -E '\.eml$|\.txt$')
+    # Use portable unzip -l instead of unzip -Z -1
+    attachment_zip_count=$(unzip -l "$zip_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}' | grep -c -v -E '\.eml$|\.txt$')
 
     echo "  - Attachments found in ZIP: $attachment_zip_count"
     echo "  - Attachments referenced in DAT: $attachment_dat_count"
@@ -167,12 +168,14 @@ run_test() {
             
             if [ "$check_text" = true ]; then
                 echo "  - Verifying extracted text files..."
+                local zip_files
+                zip_files=$(unzip -l "$archive_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}')
                 local eml_count
-                eml_count=$(unzip -Z -1 "$archive_file" | grep -c '\.eml$')
+                eml_count=$(echo "$zip_files" | grep -c '\.eml$')
                 local txt_count
-                txt_count=$(unzip -Z -1 "$archive_file" | grep -c '\.txt$')
+                txt_count=$(echo "$zip_files" | grep -c '\.txt$')
                 local attachment_count
-                attachment_count=$(unzip -Z -1 "$archive_file" | grep -c -v -E '\.eml$|\.txt$')
+                attachment_count=$(echo "$zip_files" | grep -c -v -E '\.eml$|\.txt$')
                 local expected_txt_count=$((eml_count + attachment_count))
 
                 if [ "$expected_txt_count" -eq "$txt_count" ]; then
@@ -185,7 +188,7 @@ run_test() {
 
             if [ "$check_attachments" = true ]; then
                 local eml_count
-                eml_count=$(unzip -Z -1 "$archive_file" | grep -c '\.eml$')
+                eml_count=$(unzip -l "$archive_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}' | grep -c '\.eml$')
                 if ! verify_attachments "$dat_file" "$archive_file" "$attachment_rate" "$eml_count"; then
                     all_checks_passed=false
                 fi

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -86,7 +86,7 @@ verify_attachments() {
     
     local attachment_zip_count
     # Use portable unzip -l instead of unzip -Z -1
-    attachment_zip_count=$(unzip -l "$zip_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}' | grep -c -v -E '\.eml$|\.txt$')
+    attachment_zip_count=$(unzip -l "$zip_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -c -v -E '\.eml$|\.txt$')
 
     echo "  - Attachments found in ZIP: $attachment_zip_count"
     echo "  - Attachments referenced in DAT: $attachment_dat_count"
@@ -169,7 +169,7 @@ run_test() {
             if [ "$check_text" = true ]; then
                 echo "  - Verifying extracted text files..."
                 local zip_files
-                zip_files=$(unzip -l "$archive_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}')
+                zip_files=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}')
                 local eml_count
                 eml_count=$(echo "$zip_files" | grep -c '\.eml$')
                 local txt_count
@@ -188,7 +188,7 @@ run_test() {
 
             if [ "$check_attachments" = true ]; then
                 local eml_count
-                eml_count=$(unzip -l "$archive_file" | awk '/[0-9]{2}:[0-9]{2}/ {print $4}' | grep -c '\.eml$')
+                eml_count=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -c '\.eml$')
                 if ! verify_attachments "$dat_file" "$archive_file" "$attachment_rate" "$eml_count"; then
                     all_checks_passed=false
                 fi

--- a/tests/test-unified-workflow.sh
+++ b/tests/test-unified-workflow.sh
@@ -42,7 +42,7 @@ fi
 
 # Check for all required jobs
 echo "4. Checking for all required jobs..."
-REQUIRED_JOBS=("lint:" "build:" "test:" "release:")
+REQUIRED_JOBS=("lint:" "build:" "test:" "tag-and-release:")
 
 for job in "${REQUIRED_JOBS[@]}"; do
     if grep -q "$job" .github/workflows/build-and-test.yml; then
@@ -150,10 +150,10 @@ fi
 
 # Check for release conditions
 echo "12. Checking release conditions..."
-if grep -q "if: startsWith(github.ref, 'refs/tags/v')" .github/workflows/build-and-test.yml; then
-    echo "✓ Release job runs on tags"
+if grep -q "if: github.ref == 'refs/heads/main'" .github/workflows/build-and-test.yml; then
+    echo "✓ Release job runs on main"
 else
-    echo "✗ Release job missing tag condition"
+    echo "✗ Release job missing main branch condition"
     exit 1
 fi
 


### PR DESCRIPTION
- Narrow push trigger from `['**']` to `[main]` so feature branches are only tested via `pull_request` events (not both push + PR)
- Remove dead `release` job that could never fire (`GITHUB_TOKEN` tags don't re-trigger workflows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow: push-triggered runs limited to main; separate automated release job for tagged versions removed.

* **Tests**
  * Improved cross-platform ZIP size detection for macOS and Unix; more reliable archive entry counting and consolidated attachment/extracted-text checks.
  * Updated workflow tests to expect the renamed release job and the revised main-branch release condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->