### PR TITLE
feat: Predefined Chaos Scenarios (--chaos-scenario, --chaos-list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--chaos-mode`: Enable the Chaos Engine to inject deliberate structural anomalies into load files. Requires `--loadfile-only`
 - `--chaos-amount <N|N%>`: Number or percentage of records to corrupt. Requires `--chaos-mode`. Example: `5` (exact count) or `10%` (percentage)
 - `--chaos-types <type1,type2,...>`: Comma-separated filter for specific anomaly types. Requires `--chaos-mode`. DAT types: `mixed-delimiters`, `quotes`, `columns`, `eol`, `encoding`. OPT types: `opt-boundary`, `opt-columns`, `opt-pagecount`
+- `--chaos-scenario <name>`: Use a predefined chaos scenario instead of manual `--chaos-types`. Requires `--chaos-mode`. Conflicts with `--chaos-types`. Use `--chaos-list` to see available scenarios
+- `--chaos-list`: List all available chaos scenarios with descriptions and exit
 
 ### Arguments Quick Reference
 
@@ -144,6 +146,8 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 | `--chaos-mode` | false | flag | Enable Chaos Engine |
 | `--chaos-amount` | 1% | N or N% | Anomaly count/percentage |
 | `--chaos-types` | all | comma-separated types | Anomaly type filter |
+| `--chaos-scenario` | none | scenario name | Predefined chaos scenario |
+| `--chaos-list` | false | flag | List scenarios and exit |
 
 ### Argument Interactions
 
@@ -166,6 +170,8 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 | `--col-delim`, `--quote-delim`, etc. | Require `--loadfile-only`; use `ascii:N` or `char:C` prefix |
 | `--chaos-mode` | Requires `--loadfile-only` |
 | `--chaos-amount`, `--chaos-types` | Require `--chaos-mode` |
+| `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
+| `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
 
 ### Column Profiles
 
@@ -320,6 +326,27 @@ zipper --loadfile-only --count 50000 --output-path ./chaos_targeted \
 # OPT chaos: corrupt document boundaries and page counts
 zipper --loadfile-only --loadfile-format opt --count 10000 --output-path ./opt_chaos \
     --chaos-mode --chaos-types "opt-boundary,opt-pagecount"
+
+# ── Chaos Scenarios ─────────────────────────────
+
+# List all available chaos scenarios
+zipper --chaos-list
+
+# Simulate common Relativity ingestion failures
+zipper --loadfile-only --count 100000 --output-path ./relativity_test \
+    --chaos-mode --chaos-scenario relativity-import --seed 42
+
+# Simulate NUIX export errors with custom anomaly amount
+zipper --loadfile-only --count 50000 --output-path ./nuix_test \
+    --chaos-mode --chaos-scenario nuix-export --chaos-amount "15%"
+
+# Full chaos: all anomaly types at 10% density
+zipper --loadfile-only --count 100000 --output-path ./full_chaos \
+    --chaos-mode --chaos-scenario full-chaos
+
+# OPT boundary corruption scenario
+zipper --loadfile-only --loadfile-format opt --count 10000 --output-path ./opt_test \
+    --chaos-mode --chaos-scenario broken-boundaries
 ```
 
 ## Performance

--- a/Requirements.md
+++ b/Requirements.md
@@ -516,6 +516,8 @@ This section clarifies behavior when multiple arguments interact:
 | `--col-delim`, `--quote-delim`, etc. | Require `--loadfile-only`; use `ascii:N` or `char:C` prefix |
 | `--chaos-mode` | Requires `--loadfile-only` |
 | `--chaos-amount`, `--chaos-types` | Require `--chaos-mode` |
+| `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
+| `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` |
 
 ---
 
@@ -579,3 +581,26 @@ This section clarifies behavior when multiple arguments interact:
 ### FR-021: Path Traversal Prevention
 
 - **REQ-106**: The application shall validate the `--output-path` argument to prevent directory traversal attacks. Paths containing `..` components that resolve outside the intended base directory shall be rejected with a clear error message.
+
+---
+
+## 15. Chaos Scenarios
+
+### FR-022: Predefined Chaos Scenarios
+
+- **REQ-107**: A new optional command-line argument `--chaos-scenario <name>` shall be introduced. Requires `--chaos-mode`.
+- **REQ-108**: When `--chaos-scenario` is specified, the application shall resolve the named scenario to predefined `ChaosTypes` and a default `ChaosAmount`, which are passed to the Chaos Engine.
+- **REQ-109**: `--chaos-scenario` shall conflict with `--chaos-types`. The application must reject this combination with a clear error message.
+- **REQ-110**: `--chaos-amount` shall override the scenario's default amount when both are specified.
+- **REQ-111**: Each scenario may specify a required `LoadFileFormat`. If the scenario's required format does not match the current `--loadfile-format`, the application must exit with a clear error message.
+- **REQ-112**: A new command-line argument `--chaos-list` shall be introduced. When specified, the application shall print all available chaos scenarios with their descriptions and exit.
+- **REQ-113**: The following built-in chaos scenarios shall be provided:
+
+| Scenario Name | Description | Chaos Types | Default Amount | Required Format |
+|---|---|---|---|---|
+| `relativity-import` | Common Relativity ingestion failures | `mixed-delimiters`, `quotes`, `columns` | 3% | DAT |
+| `encoding-nightmare` | Multi-encoding source data | `encoding`, `mixed-delimiters` | 5% | DAT |
+| `broken-boundaries` | OPT document boundary corruption | `opt-boundary`, `opt-pagecount` | 8% | OPT |
+| `field-overflow` | Unescaped newlines and extra columns | `eol`, `columns` | 2% | DAT |
+| `full-chaos` | All anomaly types at high density | all types enabled | 10% | Any |
+| `nuix-export` | NUIX-to-platform transfer errors | `mixed-delimiters`, `encoding`, `quotes` | 4% | DAT |

--- a/src/ChaosScenario.cs
+++ b/src/ChaosScenario.cs
@@ -59,10 +59,12 @@ internal static class ChaosScenarios
             RequiredFormat: LoadFileFormat.Dat),
     };
 
+    private static readonly string[] CachedScenarioNames = All.Select(s => s.Name).ToArray();
+
     /// <summary>
     /// Gets all available scenario names.
     /// </summary>
-    public static string[] ScenarioNames => All.Select(s => s.Name).ToArray();
+    public static string[] ScenarioNames => CachedScenarioNames;
 
     /// <summary>
     /// Looks up a scenario by name (case-insensitive).

--- a/src/ChaosScenario.cs
+++ b/src/ChaosScenario.cs
@@ -1,0 +1,102 @@
+namespace Zipper;
+
+/// <summary>
+/// Defines a named chaos scenario with predefined anomaly types and amounts.
+/// </summary>
+internal record ChaosScenarioDefinition(
+    string Name,
+    string Description,
+    string ChaosTypes,
+    string DefaultAmount,
+    LoadFileFormat? RequiredFormat);
+
+/// <summary>
+/// Registry of built-in chaos scenarios that bundle realistic combinations
+/// of anomaly types modeled after real-world platform ingestion failures.
+/// </summary>
+internal static class ChaosScenarios
+{
+    /// <summary>
+    /// All available built-in chaos scenarios.
+    /// </summary>
+    public static readonly ChaosScenarioDefinition[] All =
+    {
+        new(
+            Name: "relativity-import",
+            Description: "Common Relativity ingestion failures: delimiter mismatches, unclosed quotes, column count errors",
+            ChaosTypes: "mixed-delimiters,quotes,columns",
+            DefaultAmount: "3%",
+            RequiredFormat: LoadFileFormat.Dat),
+        new(
+            Name: "encoding-nightmare",
+            Description: "Multi-encoding source data: invalid byte sequences and mixed delimiters",
+            ChaosTypes: "encoding,mixed-delimiters",
+            DefaultAmount: "5%",
+            RequiredFormat: LoadFileFormat.Dat),
+        new(
+            Name: "broken-boundaries",
+            Description: "OPT document boundary corruption: flipped break flags and invalid page counts",
+            ChaosTypes: "opt-boundary,opt-pagecount",
+            DefaultAmount: "8%",
+            RequiredFormat: LoadFileFormat.Opt),
+        new(
+            Name: "field-overflow",
+            Description: "Unescaped newlines and extra columns that break row parsing",
+            ChaosTypes: "eol,columns",
+            DefaultAmount: "2%",
+            RequiredFormat: LoadFileFormat.Dat),
+        new(
+            Name: "full-chaos",
+            Description: "All anomaly types enabled at high density for stress testing",
+            ChaosTypes: string.Empty,
+            DefaultAmount: "10%",
+            RequiredFormat: null),
+        new(
+            Name: "nuix-export",
+            Description: "NUIX-to-platform transfer errors: mixed delimiters, encoding issues, unclosed quotes",
+            ChaosTypes: "mixed-delimiters,encoding,quotes",
+            DefaultAmount: "4%",
+            RequiredFormat: LoadFileFormat.Dat),
+    };
+
+    /// <summary>
+    /// Gets all available scenario names.
+    /// </summary>
+    public static string[] ScenarioNames => All.Select(s => s.Name).ToArray();
+
+    /// <summary>
+    /// Looks up a scenario by name (case-insensitive).
+    /// </summary>
+    /// <param name="name">Scenario name to look up.</param>
+    /// <returns>Matching scenario definition, or null if not found.</returns>
+    public static ChaosScenarioDefinition? GetByName(string name)
+    {
+        return All.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Prints the list of available scenarios to stdout.
+    /// </summary>
+    public static void PrintScenarioList()
+    {
+        Console.WriteLine("Available Chaos Scenarios:");
+        Console.WriteLine();
+        Console.WriteLine($"  {"Name",-25} {"Format",-8} {"Default",-10} Description");
+        Console.WriteLine($"  {new string('-', 25)} {new string('-', 8)} {new string('-', 10)} {new string('-', 50)}");
+
+        foreach (var scenario in All)
+        {
+            var format = scenario.RequiredFormat?.ToString() ?? "Any";
+            Console.WriteLine($"  {scenario.Name,-25} {format,-8} {scenario.DefaultAmount,-10} {scenario.Description}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Usage: zipper --loadfile-only --count <N> --output-path <path> --chaos-mode --chaos-scenario <name>");
+        Console.WriteLine();
+        Console.WriteLine("Notes:");
+        Console.WriteLine("  - --chaos-scenario requires --chaos-mode and --loadfile-only");
+        Console.WriteLine("  - --chaos-scenario conflicts with --chaos-types (use one or the other)");
+        Console.WriteLine("  - --chaos-amount overrides the scenario's default amount");
+        Console.WriteLine("  - 'full-chaos' enables all types for the selected format");
+    }
+}

--- a/src/ChaosScenario.cs
+++ b/src/ChaosScenario.cs
@@ -16,10 +16,7 @@ internal record ChaosScenarioDefinition(
 /// </summary>
 internal static class ChaosScenarios
 {
-    /// <summary>
-    /// All available built-in chaos scenarios.
-    /// </summary>
-    public static readonly ChaosScenarioDefinition[] All =
+    private static readonly ChaosScenarioDefinition[] ScenariosArray =
     {
         new(
             Name: "relativity-import",
@@ -59,12 +56,18 @@ internal static class ChaosScenarios
             RequiredFormat: LoadFileFormat.Dat),
     };
 
-    private static readonly string[] CachedScenarioNames = All.Select(s => s.Name).ToArray();
+    private static readonly IReadOnlyList<string> CachedScenarioNames =
+        Array.AsReadOnly(ScenariosArray.Select(s => s.Name).ToArray());
 
     /// <summary>
-    /// Gets all available scenario names.
+    /// All available built-in chaos scenarios (read-only).
     /// </summary>
-    public static string[] ScenarioNames => CachedScenarioNames;
+    public static IReadOnlyList<ChaosScenarioDefinition> All { get; } = Array.AsReadOnly(ScenariosArray);
+
+    /// <summary>
+    /// Gets all available scenario names (read-only).
+    /// </summary>
+    public static IReadOnlyList<string> ScenarioNames => CachedScenarioNames;
 
     /// <summary>
     /// Looks up a scenario by name (case-insensitive).
@@ -73,7 +76,7 @@ internal static class ChaosScenarios
     /// <returns>Matching scenario definition, or null if not found.</returns>
     public static ChaosScenarioDefinition? GetByName(string name)
     {
-        return All.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return ScenariosArray.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -86,7 +89,7 @@ internal static class ChaosScenarios
         Console.WriteLine($"  {"Name",-25} {"Format",-8} {"Default",-10} Description");
         Console.WriteLine($"  {new string('-', 25)} {new string('-', 8)} {new string('-', 10)} {new string('-', 50)}");
 
-        foreach (var scenario in All)
+        foreach (var scenario in ScenariosArray)
         {
             var format = scenario.RequiredFormat?.ToString() ?? "Any";
             Console.WriteLine($"  {scenario.Name,-25} {format,-8} {scenario.DefaultAmount,-10} {scenario.Description}");

--- a/src/CommandLineValidator.cs
+++ b/src/CommandLineValidator.cs
@@ -99,6 +99,8 @@ namespace Zipper
             Console.Error.WriteLine("  --chaos-mode             Activate deliberate anomaly injection");
             Console.Error.WriteLine("  --chaos-amount <value>   Anomaly count: percentage (1%) or exact (500)");
             Console.Error.WriteLine("  --chaos-types <list>     Comma-separated anomaly types to inject");
+            Console.Error.WriteLine("  --chaos-scenario <name>  Use a predefined chaos scenario (conflicts with --chaos-types)");
+            Console.Error.WriteLine("  --chaos-list             List available chaos scenarios and exit");
             Console.Error.WriteLine();
             Console.Error.WriteLine("Bates Numbering:");
             Console.Error.WriteLine("  --bates-prefix <string>  Bates number prefix (e.g., CLIENT001)");
@@ -437,6 +439,17 @@ namespace Zipper
                         }
 
                         break;
+                    case "--chaos-scenario":
+                        if (TryGetValue(args, i, out var chaosScenarioVal))
+                        {
+                            parsed.ChaosScenario = chaosScenarioVal;
+                            i++;
+                        }
+
+                        break;
+                    case "--chaos-list":
+                        parsed.ChaosList = true;
+                        break;
                     default:
                         Console.Error.WriteLine($"Warning: Unknown argument or unconsumed value '{args[i]}' ignored.");
                         break;
@@ -676,6 +689,40 @@ namespace Zipper
             {
                 Console.Error.WriteLine("Error: --chaos-types requires --chaos-mode.");
                 return false;
+            }
+
+            // Chaos scenario requires --chaos-mode
+            if (!string.IsNullOrEmpty(parsed.ChaosScenario) && !parsed.ChaosMode)
+            {
+                Console.Error.WriteLine("Error: --chaos-scenario requires --chaos-mode.");
+                return false;
+            }
+
+            // Chaos scenario conflicts with --chaos-types
+            if (!string.IsNullOrEmpty(parsed.ChaosScenario) && !string.IsNullOrEmpty(parsed.ChaosTypes))
+            {
+                Console.Error.WriteLine("Error: --chaos-scenario conflicts with --chaos-types. Use one or the other.");
+                return false;
+            }
+
+            // Validate chaos scenario name
+            if (!string.IsNullOrEmpty(parsed.ChaosScenario))
+            {
+                var scenario = ChaosScenarios.GetByName(parsed.ChaosScenario);
+                if (scenario == null)
+                {
+                    Console.Error.WriteLine($"Error: Unknown chaos scenario '{parsed.ChaosScenario}'.");
+                    Console.Error.WriteLine($"       Available scenarios: {string.Join(", ", ChaosScenarios.ScenarioNames)}");
+                    return false;
+                }
+
+                // Validate format compatibility
+                var currentFormat = GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat;
+                if (scenario.RequiredFormat.HasValue && scenario.RequiredFormat.Value != currentFormat)
+                {
+                    Console.Error.WriteLine($"Error: Chaos scenario '{parsed.ChaosScenario}' requires --loadfile-format {scenario.RequiredFormat.Value.ToString().ToLowerInvariant()} but got {currentFormat.ToString().ToLowerInvariant()}.");
+                    return false;
+                }
             }
 
             // Loadfile-only conflicts with ZIP-related options
@@ -936,6 +983,7 @@ namespace Zipper
                 ChaosMode = parsed.ChaosMode,
                 ChaosAmount = parsed.ChaosAmount,
                 ChaosTypes = parsed.ChaosTypes,
+                ChaosScenario = parsed.ChaosScenario,
             };
         }
 
@@ -1156,6 +1204,10 @@ namespace Zipper
             public string? ChaosAmount { get; set; }
 
             public string? ChaosTypes { get; set; }
+
+            public string? ChaosScenario { get; set; }
+
+            public bool ChaosList { get; set; }
         }
     }
 }

--- a/src/FileGenerationRequest.cs
+++ b/src/FileGenerationRequest.cs
@@ -167,6 +167,12 @@ namespace Zipper
         /// Gets or sets the comma-separated list of chaos types to inject.
         /// </summary>
         public string? ChaosTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the named chaos scenario (e.g., "relativity-import", "encoding-nightmare").
+        /// When set, resolves to predefined ChaosTypes and default ChaosAmount.
+        /// </summary>
+        public string? ChaosScenario { get; set; }
     }
 
     /// <summary>

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -34,10 +34,32 @@ internal static class LoadfileOnlyGenerator
         ChaosEngine? chaosEngine = null;
         if (request.ChaosMode)
         {
+            // Resolve chaos scenario to types and amount
+            string? resolvedTypes = request.ChaosTypes;
+            string? resolvedAmount = request.ChaosAmount;
+
+            if (!string.IsNullOrEmpty(request.ChaosScenario))
+            {
+                var scenario = ChaosScenarios.GetByName(request.ChaosScenario);
+                if (scenario != null)
+                {
+                    // Scenario types replace manual types; empty string means "all types"
+                    resolvedTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes;
+
+                    // Use scenario default amount unless user explicitly set one
+                    if (string.IsNullOrEmpty(resolvedAmount))
+                    {
+                        resolvedAmount = scenario.DefaultAmount;
+                    }
+
+                    Console.WriteLine(string.Format("  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
+                }
+            }
+
             chaosEngine = new ChaosEngine(
                 totalLines,
-                request.ChaosAmount,
-                request.ChaosTypes,
+                resolvedAmount,
+                resolvedTypes,
                 request.LoadFileFormat,
                 request.ColumnDelimiter,
                 request.QuoteDelimiter,

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -52,6 +52,10 @@ internal static class LoadfileOnlyGenerator
                         resolvedAmount = scenario.DefaultAmount;
                     }
 
+                    // Persist resolved values back to request for accurate audit metadata
+                    request.ChaosAmount = resolvedAmount;
+                    request.ChaosTypes = resolvedTypes;
+
                     Console.WriteLine(string.Format("  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
                 }
             }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,7 +10,7 @@ namespace Zipper
             Console.WriteLine($"Zipper v{version} https://github.com/dwojtaszek/zipper/");
             Console.WriteLine();
 
-            if (args.Contains("--benchmark"))
+            if (args.Contains("--benchmark", StringComparer.OrdinalIgnoreCase))
             {
                 try
                 {
@@ -24,7 +24,7 @@ namespace Zipper
                 }
             }
 
-            if (args.Contains("--chaos-list"))
+            if (args.Contains("--chaos-list", StringComparer.OrdinalIgnoreCase))
             {
                 ChaosScenarios.PrintScenarioList();
                 return 0;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -24,6 +24,12 @@ namespace Zipper
                 }
             }
 
+            if (args.Contains("--chaos-list"))
+            {
+                ChaosScenarios.PrintScenarioList();
+                return 0;
+            }
+
             // Validate and parse command line arguments
             var request = CommandLineValidator.ValidateAndParseArguments(args);
             if (request == null)

--- a/src/Zipper.Tests/ChaosScenarioTests.cs
+++ b/src/Zipper.Tests/ChaosScenarioTests.cs
@@ -1,0 +1,336 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Zipper;
+
+[Collection("ConsoleTests")]
+public class ChaosScenarioTests
+{
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> RunWithCapture(string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        try
+        {
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+            int exitCode = await Program.Main(args);
+            return (exitCode, outWriter.ToString(), errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    // --- Scenario registry tests ---
+    [Fact]
+    public void GetByName_ValidName_ReturnsScenario()
+    {
+        var scenario = ChaosScenarios.GetByName("relativity-import");
+        Assert.NotNull(scenario);
+        Assert.Equal("relativity-import", scenario.Name);
+        Assert.Contains("mixed-delimiters", scenario.ChaosTypes);
+    }
+
+    [Fact]
+    public void GetByName_CaseInsensitive_ReturnsScenario()
+    {
+        var scenario = ChaosScenarios.GetByName("RELATIVITY-IMPORT");
+        Assert.NotNull(scenario);
+        Assert.Equal("relativity-import", scenario.Name);
+    }
+
+    [Fact]
+    public void GetByName_InvalidName_ReturnsNull()
+    {
+        var scenario = ChaosScenarios.GetByName("nonexistent-scenario");
+        Assert.Null(scenario);
+    }
+
+    [Fact]
+    public void AllScenarios_HaveRequiredFields()
+    {
+        foreach (var scenario in ChaosScenarios.All)
+        {
+            Assert.False(string.IsNullOrEmpty(scenario.Name), "Scenario name must not be empty");
+            Assert.False(string.IsNullOrEmpty(scenario.Description), "Scenario description must not be empty");
+            Assert.False(string.IsNullOrEmpty(scenario.DefaultAmount), "Scenario default amount must not be empty");
+        }
+    }
+
+    [Fact]
+    public void ScenarioNames_AreUnique()
+    {
+        var names = ChaosScenarios.All.Select(s => s.Name).ToList();
+        Assert.Equal(names.Count, names.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void FullChaos_HasEmptyChaosTypes()
+    {
+        var scenario = ChaosScenarios.GetByName("full-chaos");
+        Assert.NotNull(scenario);
+        Assert.True(string.IsNullOrEmpty(scenario.ChaosTypes), "full-chaos should have empty ChaosTypes to enable all types");
+        Assert.Null(scenario.RequiredFormat);
+    }
+
+    [Fact]
+    public void BrokenBoundaries_RequiresOptFormat()
+    {
+        var scenario = ChaosScenarios.GetByName("broken-boundaries");
+        Assert.NotNull(scenario);
+        Assert.Equal(LoadFileFormat.Opt, scenario.RequiredFormat);
+    }
+
+    // --- CLI integration tests ---
+    [Fact]
+    public async Task ChaosList_PrintsScenariosAndExitsZero()
+    {
+        var (exitCode, stdout, _) = await RunWithCapture(new[] { "--chaos-list" });
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Available Chaos Scenarios", stdout);
+        Assert.Contains("relativity-import", stdout);
+        Assert.Contains("full-chaos", stdout);
+    }
+
+    [Fact]
+    public async Task ChaosScenario_WithoutChaosMode_ReturnsError()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, stderr) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "100", "--output-path", tempPath,
+                "--chaos-scenario", "relativity-import",
+            });
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--chaos-scenario requires --chaos-mode", stderr);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_WithChaosTypes_ReturnsConflictError()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, stderr) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "100", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "relativity-import",
+                "--chaos-types", "quotes",
+            });
+            Assert.Equal(1, exitCode);
+            Assert.Contains("conflicts with --chaos-types", stderr);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_InvalidName_ReturnsError()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, stderr) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "100", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "fake-scenario",
+            });
+            Assert.Equal(1, exitCode);
+            Assert.Contains("Unknown chaos scenario 'fake-scenario'", stderr);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_FormatMismatch_ReturnsError()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, stderr) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "100", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "broken-boundaries",
+                "--loadfile-format", "dat",
+            });
+            Assert.Equal(1, exitCode);
+            Assert.Contains("requires --loadfile-format opt", stderr);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_ValidRun_GeneratesLoadFileWithAnomalies()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, stdout, _) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "1000", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "relativity-import", "--seed", "42",
+            });
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Chaos Scenario: relativity-import", stdout);
+
+            // Verify load file was created
+            var datFiles = Directory.GetFiles(tempPath, "*.dat");
+            Assert.Single(datFiles);
+
+            // Verify properties JSON was created with anomalies
+            var jsonFiles = Directory.GetFiles(tempPath, "*_properties.json");
+            Assert.Single(jsonFiles);
+
+            var json = await File.ReadAllTextAsync(jsonFiles[0]);
+            using var doc = JsonDocument.Parse(json);
+            var chaosMode = doc.RootElement.GetProperty("ChaosMode");
+            Assert.True(chaosMode.GetProperty("Enabled").GetBoolean());
+            Assert.True(chaosMode.GetProperty("TotalAnomalies").GetInt32() > 0);
+
+            // Verify anomaly types match scenario (mixed-delimiters, quotes, columns)
+            var anomalies = chaosMode.GetProperty("InjectedAnomalies");
+            var errorTypes = new HashSet<string>();
+            foreach (var anomaly in anomalies.EnumerateArray())
+            {
+                errorTypes.Add(anomaly.GetProperty("ErrorType").GetString()!);
+            }
+
+            // Should only contain types from the relativity-import scenario
+            Assert.Subset(
+                new HashSet<string> { "mixed-delimiters", "quotes", "columns" },
+                errorTypes);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_AmountOverride_UsesCustomAmount()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, _) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "1000", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "relativity-import",
+                "--chaos-amount", "20%", "--seed", "42",
+            });
+            Assert.Equal(0, exitCode);
+
+            // Verify properties JSON shows the anomaly count reflecting ~20%
+            var jsonFiles = Directory.GetFiles(tempPath, "*_properties.json");
+            Assert.Single(jsonFiles);
+
+            var json = await File.ReadAllTextAsync(jsonFiles[0]);
+            using var doc = JsonDocument.Parse(json);
+            var totalAnomalies = doc.RootElement.GetProperty("ChaosMode").GetProperty("TotalAnomalies").GetInt32();
+
+            // 20% of 1001 lines (1000 records + 1 header) ≈ 200
+            Assert.True(totalAnomalies >= 100, $"Expected at least 100 anomalies with 20% amount, got {totalAnomalies}");
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_FullChaos_EnablesAllTypes()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, _, _) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "500", "--output-path", tempPath,
+                "--chaos-mode", "--chaos-scenario", "full-chaos", "--seed", "42",
+            });
+            Assert.Equal(0, exitCode);
+
+            var jsonFiles = Directory.GetFiles(tempPath, "*_properties.json");
+            Assert.Single(jsonFiles);
+
+            var json = await File.ReadAllTextAsync(jsonFiles[0]);
+            using var doc = JsonDocument.Parse(json);
+            var totalAnomalies = doc.RootElement.GetProperty("ChaosMode").GetProperty("TotalAnomalies").GetInt32();
+
+            // full-chaos at 10% of ~501 lines ≈ 50 anomalies
+            Assert.True(totalAnomalies > 0, "full-chaos should inject anomalies");
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChaosScenario_BrokenBoundaries_WorksWithOpt()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var (exitCode, stdout, _) = await RunWithCapture(new[]
+            {
+                "--loadfile-only", "--count", "500", "--output-path", tempPath,
+                "--loadfile-format", "opt",
+                "--chaos-mode", "--chaos-scenario", "broken-boundaries", "--seed", "42",
+            });
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Chaos Scenario: broken-boundaries", stdout);
+
+            var optFiles = Directory.GetFiles(tempPath, "*.opt");
+            Assert.Single(optFiles);
+        }
+        finally
+        {
+            if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds predefined chaos scenarios that bundle realistic combinations of anomaly types modeled after real-world eDiscovery platform ingestion failures.

### What Changed

- **New `ChaosScenario.cs`**: 6 built-in scenarios (`relativity-import`, `encoding-nightmare`, `broken-boundaries`, `field-overflow`, `full-chaos`, `nuix-export`)
- **New CLI args**: `--chaos-scenario <name>` (select a scenario), `--chaos-list` (print all scenarios and exit)
- **Validation**: scenario ↔ chaos-types conflict detection, format compatibility checks, amount override support
- **Documentation**: Updated README.md (args table, interactions, examples) and Requirements.md (FR-022, REQ-107–113)
- **Tests**: 16 new unit tests covering registry, validation, and end-to-end scenario execution

### Use Cases

```bash
# List available scenarios
zipper --chaos-list

# Simulate Relativity ingestion failures
zipper --loadfile-only --count 100000 --output-path ./test \
    --chaos-mode --chaos-scenario relativity-import --seed 42

# Override scenario default amount
zipper --loadfile-only --count 50000 --output-path ./test \
    --chaos-mode --chaos-scenario nuix-export --chaos-amount 15%
```

## Test Plan

- [x] `dotnet build zipper.sln` — 0 warnings, 0 errors
- [x] `dotnet test` — 429/429 tests passed (413 existing + 16 new)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Manual smoke test of all 6 scenarios
- [x] Validation error cases (conflict, invalid name, format mismatch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --chaos-scenario to select predefined scenarios (six built-ins) and --chaos-list to print scenarios and exit.
  * Scenario defaults resolve chaos types and default amount; explicit --chaos-amount overrides scenario default.
  * --chaos-scenario requires --chaos-mode and conflicts with --chaos-types; some scenarios require specific loadfile formats.

* **Documentation**
  * README and requirements updated with usage, argument interactions, examples (including seed usage) and scenario details.

* **Tests**
  * New tests cover registry, CLI validation, format checks, and end-to-end scenario runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->