### PR TITLE
feat(cli): Add production set generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ This will place the executable (`zipper.exe` on Windows, `zipper` on Linux/macOS
 
 After building the project, you can run the executable directly. The examples below assume the executable is in your system's PATH. Alternatively, you can still use `dotnet run` from the project directory.
 
-### Syntax
+### Basic Usage
 
 ```bash
-zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>]
+zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>] [--production-set] [--production-zip] [--volume-size <number>]
 ```
 
 ### Arguments
@@ -148,6 +148,9 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 | `--chaos-types` | all | comma-separated types | Anomaly type filter |
 | `--chaos-scenario` | none | scenario name | Predefined chaos scenario |
 | `--chaos-list` | false | flag | List scenarios and exit |
+| `--production-set` | false | flag | Generate structured production with DATA/IMAGES/NATIVES/TEXT |
+| `--production-zip` | false | flag | Wrap production set output in a ZIP archive |
+| `--volume-size` | 5000 | number | Max files per volume subfolder |
 
 ### Argument Interactions
 
@@ -172,6 +175,8 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 | `--chaos-amount`, `--chaos-types` | Require `--chaos-mode` |
 | `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
+| `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
+| `--production-zip`, `--volume-size` | Require `--production-set` |
 
 ### Column Profiles
 

--- a/Requirements.md
+++ b/Requirements.md
@@ -604,3 +604,17 @@ This section clarifies behavior when multiple arguments interact:
 | `field-overflow` | Unescaped newlines and extra columns | `eol`, `columns` | 2% | DAT |
 | `full-chaos` | All anomaly types at high density | all types enabled | 10% | Any |
 | `nuix-export` | NUIX-to-platform transfer errors | `mixed-delimiters`, `encoding`, `quotes` | 4% | DAT |
+
+---
+
+## 16. Production Sets
+
+### FR-023: Production Set Generator
+
+- **REQ-114**: A new command-line argument `--production-set` shall be introduced to generate structured production deliveries instead of flat mock files.
+- **REQ-115**: When `--production-set` is specified, the application shall create a root production directory (e.g., `PRODUCTION_YYYYMMDD_HHMMSS`) and distribute generated files into `DATA`, `IMAGES`, `NATIVES`, and `TEXT` subdirectories.
+- **REQ-116**: A new command-line argument `--volume-size <number>` shall control the maximum number of files per volume (e.g., `VOL001`, `VOL002`) within the output directories. Defaults to 5,000.
+- **REQ-117**: The generator shall create both a standard DAT load file (metadata) and an OPT load file (image cross-reference) within the `DATA` directory.
+- **REQ-118**: A `_manifest.json` file shall be generated at the root of the production folder containing top-level properties like volume structure, document counts, and the Bates numbering range.
+- **REQ-119**: A new command-line argument `--production-zip` shall be introduced. When specified alongside `--production-set`, the application shall compress the entire production set folder structure into a single ZIP archive named after the production root directory.
+- **REQ-120**: `--production-set` requires `--bates-prefix` to be specified and conflicts with `--loadfile-only`.

--- a/src/CommandLineValidator.cs
+++ b/src/CommandLineValidator.cs
@@ -102,6 +102,11 @@ namespace Zipper
             Console.Error.WriteLine("  --chaos-scenario <name>  Use a predefined chaos scenario (conflicts with --chaos-types)");
             Console.Error.WriteLine("  --chaos-list             List available chaos scenarios and exit");
             Console.Error.WriteLine();
+            Console.Error.WriteLine("Production Set Options:");
+            Console.Error.WriteLine("  --production-set         Generate structured production with DATA/IMAGES/NATIVES/TEXT");
+            Console.Error.WriteLine("  --production-zip         Wrap production set output in a ZIP archive");
+            Console.Error.WriteLine("  --volume-size <number>   Max files per volume subfolder (default: 5000)");
+            Console.Error.WriteLine();
             Console.Error.WriteLine("Bates Numbering:");
             Console.Error.WriteLine("  --bates-prefix <string>  Bates number prefix (e.g., CLIENT001)");
             Console.Error.WriteLine("  --bates-start <number>   Bates start number (default: 1)");
@@ -450,6 +455,20 @@ namespace Zipper
                     case "--chaos-list":
                         parsed.ChaosList = true;
                         break;
+                    case "--production-set":
+                        parsed.ProductionSet = true;
+                        break;
+                    case "--production-zip":
+                        parsed.ProductionZip = true;
+                        break;
+                    case "--volume-size":
+                        if (TryGetValue(args, i, out var volumeSizeVal) && int.TryParse(volumeSizeVal, out var volumeSize))
+                        {
+                            parsed.VolumeSize = volumeSize;
+                            i++;
+                        }
+
+                        break;
                     default:
                         Console.Error.WriteLine($"Warning: Unknown argument or unconsumed value '{args[i]}' ignored.");
                         break;
@@ -486,6 +505,8 @@ namespace Zipper
                 "--with-families" => true,
                 "--loadfile-only" => true,
                 "--chaos-mode" => true,
+                "--production-set" => true,
+                "--production-zip" => true,
                 _ => false,
             };
         }
@@ -495,8 +516,8 @@ namespace Zipper
         /// </summary>
         private static bool ValidateRequiredArguments(ParsedArguments parsed)
         {
-            // In loadfile-only mode, --type is optional (defaults to pdf for schema)
-            if (string.IsNullOrEmpty(parsed.FileType) && !parsed.LoadfileOnly)
+            // In loadfile-only mode and production-set mode, --type is optional (defaults to pdf)
+            if (string.IsNullOrEmpty(parsed.FileType) && !parsed.LoadfileOnly && !parsed.ProductionSet)
             {
                 Console.Error.WriteLine("Error: --type is required.");
                 return false;
@@ -735,6 +756,45 @@ namespace Zipper
             if (parsed.LoadfileOnly && parsed.IncludeLoadFile)
             {
                 Console.Error.WriteLine("Error: --loadfile-only conflicts with --include-load-file.");
+                return false;
+            }
+
+            // === Production set validation ===
+            if (parsed.ProductionSet)
+            {
+                // Production set conflicts with loadfile-only
+                if (parsed.LoadfileOnly)
+                {
+                    Console.Error.WriteLine("Error: --production-set conflicts with --loadfile-only.");
+                    return false;
+                }
+
+                // Production set requires bates prefix
+                if (string.IsNullOrEmpty(parsed.BatesPrefix))
+                {
+                    Console.Error.WriteLine("Error: --production-set requires --bates-prefix.");
+                    return false;
+                }
+
+                // Volume size must be positive
+                if (parsed.VolumeSize.HasValue && parsed.VolumeSize.Value < 1)
+                {
+                    Console.Error.WriteLine("Error: --volume-size must be at least 1.");
+                    return false;
+                }
+            }
+
+            // --production-zip requires --production-set
+            if (parsed.ProductionZip && !parsed.ProductionSet)
+            {
+                Console.Error.WriteLine("Error: --production-zip requires --production-set.");
+                return false;
+            }
+
+            // --volume-size requires --production-set
+            if (parsed.VolumeSize.HasValue && !parsed.ProductionSet)
+            {
+                Console.Error.WriteLine("Error: --volume-size requires --production-set.");
                 return false;
             }
 
@@ -984,6 +1044,9 @@ namespace Zipper
                 ChaosAmount = parsed.ChaosAmount,
                 ChaosTypes = parsed.ChaosTypes,
                 ChaosScenario = parsed.ChaosScenario,
+                ProductionSet = parsed.ProductionSet,
+                ProductionZip = parsed.ProductionZip,
+                VolumeSize = parsed.VolumeSize ?? 5000,
             };
         }
 
@@ -1208,6 +1271,13 @@ namespace Zipper
             public string? ChaosScenario { get; set; }
 
             public bool ChaosList { get; set; }
+
+            // Production set arguments
+            public bool ProductionSet { get; set; }
+
+            public bool ProductionZip { get; set; }
+
+            public int? VolumeSize { get; set; }
         }
     }
 }

--- a/src/FileGenerationRequest.cs
+++ b/src/FileGenerationRequest.cs
@@ -173,6 +173,22 @@ namespace Zipper
         /// When set, resolves to predefined ChaosTypes and default ChaosAmount.
         /// </summary>
         public string? ChaosScenario { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to generate a production set
+        /// with structured DATA/IMAGES/NATIVES/TEXT directories.
+        /// </summary>
+        public bool ProductionSet { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to wrap the production set in a ZIP archive.
+        /// </summary>
+        public bool ProductionZip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of files per volume subfolder (default 5000).
+        /// </summary>
+        public int VolumeSize { get; set; } = 5000;
     }
 
     /// <summary>

--- a/src/ProductionManifestWriter.cs
+++ b/src/ProductionManifestWriter.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Zipper;
+
+/// <summary>
+/// Writes a _manifest.json file describing a generated production set.
+/// </summary>
+internal static class ProductionManifestWriter
+{
+    /// <summary>
+    /// Writes the production manifest to the specified directory.
+    /// </summary>
+    /// <param name="productionPath">Root directory of the production set.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="batesStart">First Bates number in the production.</param>
+    /// <param name="batesEnd">Last Bates number in the production.</param>
+    /// <param name="volumeCount">Number of volume subfolders created.</param>
+    /// <param name="generationTime">Total time for generation.</param>
+    /// <returns>Path to the manifest file.</returns>
+    public static async Task<string> WriteAsync(
+        string productionPath,
+        FileGenerationRequest request,
+        string batesStart,
+        string batesEnd,
+        int volumeCount,
+        TimeSpan generationTime)
+    {
+        var manifestPath = Path.Combine(productionPath, "_manifest.json");
+
+        var manifest = new ProductionManifest
+        {
+            ProductionDate = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+            BatesRange = new BatesRange
+            {
+                Start = batesStart,
+                End = batesEnd,
+                Prefix = request.BatesConfig?.Prefix ?? string.Empty,
+                Digits = request.BatesConfig?.Digits ?? 8,
+            },
+            DocumentCount = request.FileCount,
+            FileType = request.FileType,
+            VolumeCount = volumeCount,
+            VolumeSize = request.VolumeSize,
+            Directories = new ProductionDirectories
+            {
+                Data = "DATA",
+                Natives = "NATIVES",
+                Text = "TEXT",
+                Images = "IMAGES",
+            },
+            LoadFiles = new ProductionLoadFiles
+            {
+                Dat = "DATA/loadfile.dat",
+                Opt = "DATA/loadfile.opt",
+            },
+            Settings = new ProductionSettings
+            {
+                Encoding = request.Encoding,
+                ColumnDelimiter = FormatDelimiter(request.ColumnDelimiter),
+                QuoteDelimiter = FormatDelimiter(request.QuoteDelimiter),
+                ColumnProfile = request.ColumnProfile?.Name,
+                Seed = request.Seed,
+            },
+            GenerationTime = $"{generationTime.TotalSeconds:F1}s",
+        };
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        var json = JsonSerializer.Serialize(manifest, options);
+        await File.WriteAllTextAsync(manifestPath, json);
+
+        return manifestPath;
+    }
+
+    private static string FormatDelimiter(string delimiter)
+    {
+        if (string.IsNullOrEmpty(delimiter))
+        {
+            return string.Empty;
+        }
+
+        if (delimiter.Length == 1 && delimiter[0] < 32)
+        {
+            return $"ascii:{(int)delimiter[0]}";
+        }
+
+        return $"char:{delimiter}";
+    }
+}
+
+internal class ProductionManifest
+{
+    [JsonPropertyName("productionDate")]
+    public string ProductionDate { get; set; } = string.Empty;
+
+    [JsonPropertyName("batesRange")]
+    public BatesRange BatesRange { get; set; } = new();
+
+    [JsonPropertyName("documentCount")]
+    public long DocumentCount { get; set; }
+
+    [JsonPropertyName("fileType")]
+    public string FileType { get; set; } = string.Empty;
+
+    [JsonPropertyName("volumeCount")]
+    public int VolumeCount { get; set; }
+
+    [JsonPropertyName("volumeSize")]
+    public int VolumeSize { get; set; }
+
+    [JsonPropertyName("directories")]
+    public ProductionDirectories Directories { get; set; } = new();
+
+    [JsonPropertyName("loadFiles")]
+    public ProductionLoadFiles LoadFiles { get; set; } = new();
+
+    [JsonPropertyName("settings")]
+    public ProductionSettings Settings { get; set; } = new();
+
+    [JsonPropertyName("generationTime")]
+    public string GenerationTime { get; set; } = string.Empty;
+}
+
+internal class BatesRange
+{
+    [JsonPropertyName("start")]
+    public string Start { get; set; } = string.Empty;
+
+    [JsonPropertyName("end")]
+    public string End { get; set; } = string.Empty;
+
+    [JsonPropertyName("prefix")]
+    public string Prefix { get; set; } = string.Empty;
+
+    [JsonPropertyName("digits")]
+    public int Digits { get; set; }
+}
+
+internal class ProductionDirectories
+{
+    [JsonPropertyName("data")]
+    public string Data { get; set; } = string.Empty;
+
+    [JsonPropertyName("natives")]
+    public string Natives { get; set; } = string.Empty;
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+
+    [JsonPropertyName("images")]
+    public string Images { get; set; } = string.Empty;
+}
+
+internal class ProductionLoadFiles
+{
+    [JsonPropertyName("dat")]
+    public string Dat { get; set; } = string.Empty;
+
+    [JsonPropertyName("opt")]
+    public string Opt { get; set; } = string.Empty;
+}
+
+internal class ProductionSettings
+{
+    [JsonPropertyName("encoding")]
+    public string Encoding { get; set; } = string.Empty;
+
+    [JsonPropertyName("columnDelimiter")]
+    public string ColumnDelimiter { get; set; } = string.Empty;
+
+    [JsonPropertyName("quoteDelimiter")]
+    public string QuoteDelimiter { get; set; } = string.Empty;
+
+    [JsonPropertyName("columnProfile")]
+    public string? ColumnProfile { get; set; }
+
+    [JsonPropertyName("seed")]
+    public int? Seed { get; set; }
+}

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -1,0 +1,276 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+
+namespace Zipper;
+
+/// <summary>
+/// Generates a structured production set with DATA, NATIVES, TEXT, and IMAGES directories,
+/// cross-referenced DAT and OPT load files, and an optional ZIP wrapper.
+/// </summary>
+internal static class ProductionSetGenerator
+{
+    /// <summary>
+    /// Generates a complete production set.
+    /// </summary>
+    /// <param name="request">File generation request with production set settings.</param>
+    /// <returns>Result containing paths and performance metrics.</returns>
+    public static async Task<ProductionSetResult> GenerateAsync(FileGenerationRequest request)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var productionName = $"PRODUCTION_{DateTime.Now:yyyyMMdd_HHmmss}";
+        var productionPath = Path.Combine(request.OutputPath, productionName);
+
+        // Create directory structure
+        var dataDir = Path.Combine(productionPath, "DATA");
+        var nativesDir = Path.Combine(productionPath, "NATIVES");
+        var textDir = Path.Combine(productionPath, "TEXT");
+        var imagesDir = Path.Combine(productionPath, "IMAGES");
+
+        Directory.CreateDirectory(dataDir);
+        Directory.CreateDirectory(nativesDir);
+        Directory.CreateDirectory(textDir);
+        Directory.CreateDirectory(imagesDir);
+
+        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
+        var batesConfig = request.BatesConfig!;
+
+        // Calculate volume distribution
+        int volumeCount = (int)Math.Ceiling((double)request.FileCount / request.VolumeSize);
+
+        // Pre-create volume subdirectories
+        for (int v = 1; v <= volumeCount; v++)
+        {
+            var volName = $"VOL{v:D3}";
+            Directory.CreateDirectory(Path.Combine(nativesDir, volName));
+            Directory.CreateDirectory(Path.Combine(textDir, volName));
+            Directory.CreateDirectory(Path.Combine(imagesDir, volName));
+        }
+
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var placeholder = PlaceholderFiles.GetContent(request.FileType.ToLowerInvariant());
+
+        // Generate files and collect records for load files
+        var datRecords = new List<ProductionRecord>();
+        var optRecords = new List<string>();
+
+        for (long i = 0; i < request.FileCount; i++)
+        {
+            int volumeIndex = (int)(i / request.VolumeSize) + 1;
+            var volName = $"VOL{volumeIndex:D3}";
+            var batesNumber = BatesNumberGenerator.Generate(batesConfig, i);
+
+            var nativeExt = request.FileType.ToLowerInvariant();
+            var nativeRelPath = Path.Combine("NATIVES", volName, $"{batesNumber}.{nativeExt}");
+            var textRelPath = Path.Combine("TEXT", volName, $"{batesNumber}.txt");
+            var imageRelPath = Path.Combine("IMAGES", volName, $"{batesNumber}.tif");
+
+            // Write native file
+            var nativeFullPath = Path.Combine(productionPath, nativeRelPath);
+            byte[] nativeContent;
+            if (OfficeFileGenerator.IsOfficeFormat(request.FileType))
+            {
+                var workItem = new FileWorkItem
+                {
+                    Index = i + 1,
+                    FolderNumber = volumeIndex,
+                    FolderName = volName,
+                    FileName = $"{batesNumber}.{nativeExt}",
+                    FilePathInZip = nativeRelPath,
+                };
+                nativeContent = OfficeFileGenerator.GenerateContent(request.FileType, workItem);
+            }
+            else
+            {
+                nativeContent = placeholder;
+            }
+
+            await File.WriteAllBytesAsync(nativeFullPath, nativeContent);
+
+            // Write text file
+            var textFullPath = Path.Combine(productionPath, textRelPath);
+            var textContent = $"Extracted text for document {batesNumber}. " +
+                              Profiles.LoremIpsum.GetParagraph(random);
+            await File.WriteAllTextAsync(textFullPath, textContent, encoding);
+
+            // Write placeholder TIFF image (single-pixel stub)
+            var imageFullPath = Path.Combine(productionPath, imageRelPath);
+            await File.WriteAllBytesAsync(imageFullPath, PlaceholderFiles.GetContent("tiff"));
+
+            // Collect DAT record data
+            var record = new ProductionRecord
+            {
+                BatesNumber = batesNumber,
+                NativePath = nativeRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
+                TextPath = textRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
+                ImagePath = imageRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
+                Custodian = $"Custodian {random.Next(1, Math.Max(2, request.CustodianCountOverride ?? 10))}",
+                DateCreated = DateTime.Now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd"),
+                FileSize = nativeContent.Length,
+                FileType = nativeExt.ToUpperInvariant(),
+                VolumeName = volName,
+            };
+            datRecords.Add(record);
+
+            // OPT line: Bates,VolumeName,ImagePath,DocBreak,BoxBreak,FolderBreak,PageCount
+            var docBreak = "Y";
+            optRecords.Add($"{batesNumber},{volName},{imageRelPath.Replace(Path.DirectorySeparatorChar, '\\')},{docBreak},,1");
+
+            // Progress reporting
+            if ((i + 1) % 1000 == 0 || i == request.FileCount - 1)
+            {
+                Console.Write($"\r  Progress: {i + 1:N0} / {request.FileCount:N0} documents");
+            }
+        }
+
+        Console.WriteLine();
+
+        // Write DAT load file
+        var datPath = Path.Combine(dataDir, "loadfile.dat");
+        await WriteDatLoadFile(datPath, request, datRecords, encoding);
+
+        // Write OPT load file
+        var optPath = Path.Combine(dataDir, "loadfile.opt");
+        await WriteOptLoadFile(optPath, optRecords, encoding);
+
+        // Write manifest
+        var batesStart = BatesNumberGenerator.Generate(batesConfig, 0);
+        var batesEnd = BatesNumberGenerator.Generate(batesConfig, request.FileCount - 1);
+        var manifestPath = await ProductionManifestWriter.WriteAsync(
+            productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed);
+
+        // Optionally wrap in ZIP
+        string? zipPath = null;
+        if (request.ProductionZip)
+        {
+            zipPath = Path.Combine(request.OutputPath, $"{productionName}.zip");
+            Console.Write("  Creating ZIP archive...");
+            ZipFile.CreateFromDirectory(productionPath, zipPath, CompressionLevel.Optimal, true);
+            Console.WriteLine(" done.");
+        }
+
+        stopwatch.Stop();
+
+        return new ProductionSetResult
+        {
+            ProductionPath = productionPath,
+            ZipFilePath = zipPath,
+            DatFilePath = datPath,
+            OptFilePath = optPath,
+            ManifestPath = manifestPath,
+            TotalDocuments = request.FileCount,
+            BatesRange = $"{batesStart} - {batesEnd}",
+            VolumeCount = volumeCount,
+            GenerationTime = stopwatch.Elapsed,
+        };
+    }
+
+    private static async Task WriteDatLoadFile(
+        string datPath,
+        FileGenerationRequest request,
+        List<ProductionRecord> records,
+        Encoding encoding)
+    {
+        var col = request.ColumnDelimiter;
+        var quote = request.QuoteDelimiter;
+
+        await using var stream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
+        await using var writer = new StreamWriter(stream, encoding);
+
+        // Header
+        var headers = new[]
+        {
+            "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH",
+            "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE",
+        };
+        var headerLine = string.Join(col, headers.Select(h => $"{quote}{h}{quote}"));
+        await writer.WriteLineAsync(headerLine);
+
+        // Data rows
+        foreach (var record in records)
+        {
+            var fields = new[]
+            {
+                record.BatesNumber,
+                record.BatesNumber,
+                record.VolumeName,
+                record.NativePath,
+                record.TextPath,
+                record.ImagePath,
+                record.Custodian,
+                record.DateCreated,
+                record.FileSize.ToString(),
+                record.FileType,
+            };
+            var line = string.Join(col, fields.Select(f => $"{quote}{f}{quote}"));
+            await writer.WriteLineAsync(line);
+        }
+
+        await writer.FlushAsync();
+    }
+
+    private static async Task WriteOptLoadFile(
+        string optPath,
+        List<string> optLines,
+        Encoding encoding)
+    {
+        await using var stream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
+        await using var writer = new StreamWriter(stream, encoding);
+
+        foreach (var line in optLines)
+        {
+            await writer.WriteLineAsync(line);
+        }
+
+        await writer.FlushAsync();
+    }
+}
+
+/// <summary>
+/// Data record for a single document in a production set DAT.
+/// </summary>
+internal class ProductionRecord
+{
+    public string BatesNumber { get; set; } = string.Empty;
+
+    public string NativePath { get; set; } = string.Empty;
+
+    public string TextPath { get; set; } = string.Empty;
+
+    public string ImagePath { get; set; } = string.Empty;
+
+    public string Custodian { get; set; } = string.Empty;
+
+    public string DateCreated { get; set; } = string.Empty;
+
+    public long FileSize { get; set; }
+
+    public string FileType { get; set; } = string.Empty;
+
+    public string VolumeName { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Result of a production set generation operation.
+/// </summary>
+internal class ProductionSetResult
+{
+    public string ProductionPath { get; set; } = string.Empty;
+
+    public string? ZipFilePath { get; set; }
+
+    public string DatFilePath { get; set; } = string.Empty;
+
+    public string OptFilePath { get; set; } = string.Empty;
+
+    public string ManifestPath { get; set; } = string.Empty;
+
+    public long TotalDocuments { get; set; }
+
+    public string BatesRange { get; set; } = string.Empty;
+
+    public int VolumeCount { get; set; }
+
+    public TimeSpan GenerationTime { get; set; }
+}

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -33,7 +33,9 @@ internal static class ProductionSetGenerator
         Directory.CreateDirectory(textDir);
         Directory.CreateDirectory(imagesDir);
 
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
+#pragma warning restore S2245
         var batesConfig = request.BatesConfig!;
 
         // Calculate volume distribution

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -42,8 +42,55 @@ namespace Zipper
                 return await RunLoadfileOnly(request);
             }
 
+            if (request.ProductionSet)
+            {
+                return await RunProductionSet(request);
+            }
+
             bool success = await GenerateFiles(request);
             return success ? 0 : 1;
+        }
+
+        private static async Task<int> RunProductionSet(FileGenerationRequest request)
+        {
+            Console.WriteLine("Starting production set generation...");
+            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
+            Console.WriteLine(string.Format("  Volume Size: {0:N0} files/volume", request.VolumeSize));
+            var batesPrefix = request.BatesConfig?.Prefix ?? string.Empty;
+            var batesStart = request.BatesConfig?.Start ?? 1;
+            var batesDigits = request.BatesConfig?.Digits ?? 8;
+            Console.WriteLine(string.Format("  Bates: {0}{1}", batesPrefix, batesStart.ToString($"D{batesDigits}")));
+            if (request.ProductionZip)
+            {
+                Console.WriteLine("  ZIP Output: Enabled");
+            }
+
+            try
+            {
+                var result = await ProductionSetGenerator.GenerateAsync(request);
+
+                Console.WriteLine(string.Format("\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+                Console.WriteLine(string.Format("  Production: {0}", result.ProductionPath));
+                Console.WriteLine(string.Format("  Documents: {0:N0}", result.TotalDocuments));
+                Console.WriteLine(string.Format("  Bates Range: {0}", result.BatesRange));
+                Console.WriteLine(string.Format("  Volumes: {0}", result.VolumeCount));
+                Console.WriteLine(string.Format("  DAT: {0}", result.DatFilePath));
+                Console.WriteLine(string.Format("  OPT: {0}", result.OptFilePath));
+                Console.WriteLine(string.Format("  Manifest: {0}", result.ManifestPath));
+                if (result.ZipFilePath != null)
+                {
+                    Console.WriteLine(string.Format("  ZIP: {0}", result.ZipFilePath));
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(string.Format("\nAn error occurred: {0}", ex.Message));
+                return 1;
+            }
         }
 
         private static async Task<int> RunLoadfileOnly(FileGenerationRequest request)

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -1,0 +1,317 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Zipper.Tests;
+
+[Collection("ConsoleTests")]
+public class ProductionSetTests : IDisposable
+{
+    private readonly string testOutputPath;
+
+    public ProductionSetTests()
+    {
+        this.testOutputPath = Path.Combine(Path.GetTempPath(), $"zipper_prod_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(this.testOutputPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.testOutputPath))
+        {
+            Directory.Delete(this.testOutputPath, true);
+        }
+    }
+
+    // === CLI Validation Tests ===
+    [Fact]
+    public void ProductionSet_RequiresBatesPrefix()
+    {
+        var args = new[] { "--production-set", "--count", "10", "--output-path", this.testOutputPath };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void ProductionSet_ConflictsWithLoadfileOnly()
+    {
+        var args = new[] { "--production-set", "--loadfile-only", "--count", "10", "--output-path", this.testOutputPath, "--bates-prefix", "TEST" };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void ProductionZip_RequiresProductionSet()
+    {
+        var args = new[] { "--production-zip", "--count", "10", "--output-path", this.testOutputPath, "--type", "pdf", "--bates-prefix", "TEST" };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void VolumeSize_RequiresProductionSet()
+    {
+        var args = new[] { "--volume-size", "100", "--count", "10", "--output-path", this.testOutputPath, "--type", "pdf", "--bates-prefix", "TEST" };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void ProductionSet_ValidArgs_ParsesCorrectly()
+    {
+        var args = new[]
+        {
+            "--production-set", "--count", "50", "--output-path", this.testOutputPath,
+            "--bates-prefix", "PROD", "--bates-start", "1", "--bates-digits", "6",
+            "--volume-size", "25", "--type", "pdf",
+        };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+
+        Assert.NotNull(request);
+        Assert.True(request.ProductionSet);
+        Assert.Equal(50L, request.FileCount);
+        Assert.Equal("PROD", request.BatesConfig!.Prefix);
+        Assert.Equal(6, request.BatesConfig.Digits);
+        Assert.Equal(25, request.VolumeSize);
+    }
+
+    [Fact]
+    public void ProductionSet_DefaultVolumeSize_Is5000()
+    {
+        var args = new[]
+        {
+            "--production-set", "--count", "10", "--output-path", this.testOutputPath,
+            "--bates-prefix", "TEST", "--type", "pdf",
+        };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+
+        Assert.NotNull(request);
+        Assert.Equal(5000, request.VolumeSize);
+    }
+
+    [Fact]
+    public void ProductionSet_DefaultFileType_IsPdf()
+    {
+        var args = new[]
+        {
+            "--production-set", "--count", "10", "--output-path", this.testOutputPath,
+            "--bates-prefix", "TEST",
+        };
+        var request = CommandLineValidator.ValidateAndParseArguments(args);
+
+        Assert.NotNull(request);
+        Assert.Equal("pdf", request.FileType);
+    }
+
+    // === End-to-End Generation Tests ===
+    [Fact]
+    public async Task ProductionSet_GeneratesDirectoryStructure()
+    {
+        var request = this.CreateTestRequest(count: 5);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        // Verify directory structure
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "DATA")));
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "NATIVES")));
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "TEXT")));
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "IMAGES")));
+    }
+
+    [Fact]
+    public async Task ProductionSet_CreatesCorrectFileCount()
+    {
+        var request = this.CreateTestRequest(count: 10);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.*", SearchOption.AllDirectories);
+        var textFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "TEXT"), "*.*", SearchOption.AllDirectories);
+        var imageFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "IMAGES"), "*.*", SearchOption.AllDirectories);
+
+        Assert.Equal(10, nativeFiles.Length);
+        Assert.Equal(10, textFiles.Length);
+        Assert.Equal(10, imageFiles.Length);
+    }
+
+    [Fact]
+    public async Task ProductionSet_BatesNumberingIsCorrect()
+    {
+        var request = this.CreateTestRequest(count: 3, batesPrefix: "DOC", batesStart: 1, batesDigits: 6);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.*", SearchOption.AllDirectories)
+            .Select(Path.GetFileNameWithoutExtension)
+            .OrderBy(f => f)
+            .ToArray();
+
+        Assert.Equal("DOC000001", nativeFiles[0]);
+        Assert.Equal("DOC000002", nativeFiles[1]);
+        Assert.Equal("DOC000003", nativeFiles[2]);
+    }
+
+    [Fact]
+    public async Task ProductionSet_VolumeSubfoldersCreated()
+    {
+        var request = this.CreateTestRequest(count: 10, volumeSize: 3);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        // 10 docs / 3 per volume = 4 volumes
+        Assert.Equal(4, result.VolumeCount);
+
+        var volDirs = Directory.GetDirectories(Path.Combine(result.ProductionPath, "NATIVES"));
+        Assert.Equal(4, volDirs.Length);
+        Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL001");
+        Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL004");
+    }
+
+    [Fact]
+    public async Task ProductionSet_DatLoadFileIsValid()
+    {
+        var request = this.CreateTestRequest(count: 5);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllLinesAsync(result.DatFilePath);
+
+        // Header + 5 data rows
+        Assert.Equal(6, datContent.Length);
+
+        // Header should contain expected columns
+        var header = datContent[0];
+        Assert.Contains("DOCID", header);
+        Assert.Contains("BATES_NUMBER", header);
+        Assert.Contains("NATIVE_PATH", header);
+        Assert.Contains("IMAGE_PATH", header);
+    }
+
+    [Fact]
+    public async Task ProductionSet_OptLoadFileIsValid()
+    {
+        var request = this.CreateTestRequest(count: 5);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var optContent = await File.ReadAllLinesAsync(result.OptFilePath);
+
+        // 5 data rows (no header in OPT)
+        Assert.Equal(5, optContent.Length);
+
+        // Each line should contain the Bates number
+        Assert.StartsWith("TEST", optContent[0]);
+        Assert.Contains(".tif", optContent[0]);
+    }
+
+    [Fact]
+    public async Task ProductionSet_ManifestJsonIsValid()
+    {
+        var request = this.CreateTestRequest(count: 8, volumeSize: 5);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var json = await File.ReadAllTextAsync(result.ManifestPath);
+        var manifest = JsonSerializer.Deserialize<JsonElement>(json);
+
+        Assert.Equal(8, manifest.GetProperty("documentCount").GetInt64());
+        Assert.Equal(2, manifest.GetProperty("volumeCount").GetInt32());
+        Assert.Equal(5, manifest.GetProperty("volumeSize").GetInt32());
+        Assert.Equal("TEST", manifest.GetProperty("batesRange").GetProperty("prefix").GetString());
+        Assert.Equal("DATA", manifest.GetProperty("directories").GetProperty("data").GetString());
+    }
+
+    [Fact]
+    public async Task ProductionSet_WithZip_CreatesArchive()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.ProductionZip = true;
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.NotNull(result.ZipFilePath);
+        Assert.True(File.Exists(result.ZipFilePath));
+        Assert.True(new FileInfo(result.ZipFilePath).Length > 0);
+    }
+
+    [Fact]
+    public async Task ProductionSet_WithoutZip_NoArchive()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.ProductionZip = false;
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.Null(result.ZipFilePath);
+    }
+
+    [Fact]
+    public async Task ProductionSet_WithSeed_IsReproducible()
+    {
+        var request1 = this.CreateTestRequest(count: 5, seed: 42);
+        var result1 = await ProductionSetGenerator.GenerateAsync(request1);
+        var dat1 = await File.ReadAllTextAsync(result1.DatFilePath);
+
+        var request2 = this.CreateTestRequest(count: 5, seed: 42);
+        var result2 = await ProductionSetGenerator.GenerateAsync(request2);
+        var dat2 = await File.ReadAllTextAsync(result2.DatFilePath);
+
+        Assert.Equal(dat1, dat2);
+    }
+
+    // === Integration Test via CLI ===
+    [Fact]
+    public async Task ProductionSet_FullCLI_EndToEnd()
+    {
+        var args = new[]
+        {
+            "--production-set", "--count", "5", "--output-path", this.testOutputPath,
+            "--bates-prefix", "E2E", "--type", "pdf", "--seed", "99",
+        };
+
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        int exitCode;
+        try
+        {
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+            exitCode = await Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        Assert.Equal(0, exitCode);
+
+        // Find the production directory
+        var prodDirs = Directory.GetDirectories(this.testOutputPath, "PRODUCTION_*");
+        Assert.Single(prodDirs);
+
+        // Verify structure
+        Assert.True(Directory.Exists(Path.Combine(prodDirs[0], "DATA")));
+        Assert.True(Directory.Exists(Path.Combine(prodDirs[0], "NATIVES")));
+        Assert.True(File.Exists(Path.Combine(prodDirs[0], "DATA", "loadfile.dat")));
+        Assert.True(File.Exists(Path.Combine(prodDirs[0], "DATA", "loadfile.opt")));
+        Assert.True(File.Exists(Path.Combine(prodDirs[0], "_manifest.json")));
+    }
+
+    private FileGenerationRequest CreateTestRequest(
+        int count = 10,
+        string batesPrefix = "TEST",
+        long batesStart = 1,
+        int batesDigits = 8,
+        int volumeSize = 5000,
+        int? seed = null)
+    {
+        return new FileGenerationRequest
+        {
+            OutputPath = this.testOutputPath,
+            FileCount = count,
+            FileType = "pdf",
+            ProductionSet = true,
+            VolumeSize = volumeSize,
+            Seed = seed,
+            BatesConfig = new BatesNumberConfig
+            {
+                Prefix = batesPrefix,
+                Start = batesStart,
+                Digits = batesDigits,
+            },
+        };
+    }
+}

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.24, )",
-        "resolved": "8.0.24",
-        "contentHash": "1gnadp//+DoGJvV4AFdzPqYPxkypaWYjYMCr7KAacV0iadsHz1nU+rrkoxBCna4FCmeKH49CisEwa7g94/MbEg=="
+        "requested": "[8.0.21, )",
+        "resolved": "8.0.21",
+        "contentHash": "s8H5PZQs50OcNkaB6Si54+v3GWM7vzs6vxFRMlD3aXsbM+aPCtod62gmK0BYWou9diGzmo56j8cIf/PziijDqQ=="
       },
       "SixLabors.ImageSharp": {
         "type": "Direct",

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -234,9 +234,21 @@ call .\tests\test-eml-comprehensive.bat
 call :print_success "EML comprehensive tests passed."
 
 REM Test 2: Bates numbering tests
-call :print_info "Running Bates numbering tests..."
+echo [ INFO ] Running Bates Numbering Tests...
 call .\tests\test-bates-numbering.bat
-call :print_success "Bates numbering tests passed."
+
+if errorlevel 1 (
+  echo [ ERROR ] Bates Numbering Tests failed.
+  exit /b 1
+)
+
+echo [ INFO ] Running Production Sets Tests...
+call .\tests\test-production-sets.bat
+
+if errorlevel 1 (
+  echo [ ERROR ] Production Sets Tests failed.
+  exit /b 1
+)
 
 REM Test 3: Multipage TIFF tests
 call :print_info "Running multipage TIFF tests..."

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -425,9 +425,19 @@ bash ./tests/test-eml-comprehensive.sh
 print_success "EML comprehensive tests passed."
 
 # Test 2: Bates numbering tests
-print_info "Running Bates numbering tests..."
+echo "[ INFO ] Running Bates Numbering Tests..."
 bash ./tests/test-bates-numbering.sh
-print_success "Bates numbering tests passed."
+
+if [ $? -ne 0 ]; then
+  print_error "Bates Numbering Tests failed."
+fi
+
+echo "[ INFO ] Running Production Sets Tests..."
+bash ./tests/test-production-sets.sh
+
+if [ $? -ne 0 ]; then
+  print_error "Production Sets Tests failed."
+fi
 
 # Test 3: Multipage TIFF tests
 print_info "Running multipage TIFF tests..."

--- a/tests/test-production-sets.bat
+++ b/tests/test-production-sets.bat
@@ -1,0 +1,96 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: --- Test Configuration ---
+
+set TEST_OUTPUT_DIR=.\results\production-sets
+set PROJECT=src\Zipper.csproj
+
+:: --- Test Setup ---
+
+echo [ INFO ] Running Production Sets E2E Test
+
+:: Clean up previous test results
+if exist "%TEST_OUTPUT_DIR%" rmdir /s /q "%TEST_OUTPUT_DIR%"
+mkdir "%TEST_OUTPUT_DIR%"
+
+:: --- Test Case 1: Basic Production Set ---
+
+echo [ INFO ] Test Case 1: Basic production set generation
+
+dotnet run --project "%PROJECT%" -- ^
+  --production-set ^
+  --count 10 ^
+  --output-path "%TEST_OUTPUT_DIR%\test1" ^
+  --bates-prefix "PROD" ^
+  --volume-size 3
+
+if errorlevel 1 (
+  echo [ ERROR ] Test 1 failed during execution
+  exit /b 1
+)
+
+:: Find production dir
+for /d %%d in ("%TEST_OUTPUT_DIR%\test1\PRODUCTION_*") do set PROD_DIR=%%d
+if not defined PROD_DIR (
+  echo [ ERROR ] Test 1: No production directory found.
+  exit /b 1
+)
+
+:: Verify structure
+if not exist "%PROD_DIR%\DATA\" ( echo [ ERROR ] Missing DATA dir & exit /b 1 )
+if not exist "%PROD_DIR%\NATIVES\" ( echo [ ERROR ] Missing NATIVES dir & exit /b 1 )
+if not exist "%PROD_DIR%\IMAGES\" ( echo [ ERROR ] Missing IMAGES dir & exit /b 1 )
+if not exist "%PROD_DIR%\TEXT\" ( echo [ ERROR ] Missing TEXT dir & exit /b 1 )
+
+:: Verify load files exist
+if not exist "%PROD_DIR%\DATA\loadfile.dat" ( echo [ ERROR ] Missing DAT load file & exit /b 1 )
+if not exist "%PROD_DIR%\DATA\loadfile.opt" ( echo [ ERROR ] Missing OPT load file & exit /b 1 )
+if not exist "%PROD_DIR%\_manifest.json" ( echo [ ERROR ] Missing manifest JSON & exit /b 1 )
+
+:: Verify volumes (10 docs / 3 = 4 volumes)
+if not exist "%PROD_DIR%\NATIVES\VOL001\" ( echo [ ERROR ] Missing VOL001 & exit /b 1 )
+if not exist "%PROD_DIR%\NATIVES\VOL004\" ( echo [ ERROR ] Missing VOL004 & exit /b 1 )
+
+:: Verify DAT contents
+findstr /C:"PROD00000001" "%PROD_DIR%\DATA\loadfile.dat" >nul
+if errorlevel 1 (
+  echo [ ERROR ] Test 1: Bates start not found in DAT
+  exit /b 1
+)
+
+echo [ SUCCESS ] Test Case 1: Basic production set passed
+
+:: --- Test Case 2: Production ZIP ---
+
+echo [ INFO ] Test Case 2: Production set with --production-zip
+
+dotnet run --project "%PROJECT%" -- ^
+  --production-set ^
+  --production-zip ^
+  --count 5 ^
+  --output-path "%TEST_OUTPUT_DIR%\test2" ^
+  --bates-prefix "ZIP"
+
+if errorlevel 1 (
+  echo [ ERROR ] Test 2 failed during execution
+  exit /b 1
+)
+
+:: Verify output
+dir /b /s "%TEST_OUTPUT_DIR%\test2\*.zip" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 2: No ZIP archive generated.
+  exit /b 1
+)
+
+:: Make sure manifest exists and matches
+set PROD_DIR2=
+for /d %%d in ("%TEST_OUTPUT_DIR%\test2\PRODUCTION_*") do set PROD_DIR2=%%d
+if not exist "%PROD_DIR2%\_manifest.json" ( echo [ ERROR ] Missing manifest JSON & exit /b 1 )
+
+echo [ SUCCESS ] Test Case 2: Production ZIP passed
+
+:: --- All Tests Passed ---
+
+echo [ SUCCESS ] All Production Sets E2E tests passed!

--- a/tests/test-production-sets.sh
+++ b/tests/test-production-sets.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Test Configuration ---
+
+TEST_OUTPUT_DIR="./results/production-sets"
+PROJECT="src/Zipper.csproj"
+
+# --- Helper Functions ---
+
+function print_success() {
+  echo -e "\e[42m[ SUCCESS ]\e[0m $1"
+}
+
+function print_info() {
+  echo -e "\e[44m[ INFO ]\e[0m $1"
+}
+
+function print_error() {
+  echo -e "\e[41m[ ERROR ]\e[0m $1"
+  exit 1
+}
+
+# --- Test Setup ---
+
+print_info "Running Production Sets E2E Test"
+
+# Clean up previous test results
+rm -rf "$TEST_OUTPUT_DIR"
+mkdir -p "$TEST_OUTPUT_DIR"
+
+# --- Test Case 1: Basic Production Set ---
+
+print_info "Test Case 1: Basic production set generation"
+
+dotnet run --project "$PROJECT" -- \
+  --production-set \
+  --count 10 \
+  --output-path "$TEST_OUTPUT_DIR/test1" \
+  --bates-prefix "PROD" \
+  --volume-size 3
+
+# Find production dir
+prod_dir=$(find "$TEST_OUTPUT_DIR/test1" -type d -name "PRODUCTION_*" | head -n 1)
+
+if [ -z "$prod_dir" ]; then
+  print_error "Test 1: No production directory found."
+fi
+
+# Verify structure
+if [ ! -d "$prod_dir/DATA" ]; then print_error "Missing DATA dir"; fi
+if [ ! -d "$prod_dir/NATIVES" ]; then print_error "Missing NATIVES dir"; fi
+if [ ! -d "$prod_dir/IMAGES" ]; then print_error "Missing IMAGES dir"; fi
+if [ ! -d "$prod_dir/TEXT" ]; then print_error "Missing TEXT dir"; fi
+
+# Verify load files exist
+if [ ! -f "$prod_dir/DATA/loadfile.dat" ]; then print_error "Missing DAT load file"; fi
+if [ ! -f "$prod_dir/DATA/loadfile.opt" ]; then print_error "Missing OPT load file"; fi
+if [ ! -f "$prod_dir/_manifest.json" ]; then print_error "Missing manifest JSON"; fi
+
+# Verify volumes (10 docs / 3 = 4 volumes)
+vol1=$(find "$prod_dir/NATIVES" -name "VOL001")
+vol4=$(find "$prod_dir/NATIVES" -name "VOL004")
+if [ -z "$vol1" ]; then print_error "Missing VOL001"; fi
+if [ -z "$vol4" ]; then print_error "Missing VOL004"; fi
+
+# Verify DAT contents
+if ! grep -q "PROD00000001" "$prod_dir/DATA/loadfile.dat"; then
+  print_error "Bates start not found in DAT"
+fi
+
+print_success "Test Case 1: Basic production set passed"
+
+
+# --- Test Case 2: Production ZIP ---
+
+print_info "Test Case 2: Production set with --production-zip"
+
+dotnet run --project "$PROJECT" -- \
+  --production-set \
+  --production-zip \
+  --count 5 \
+  --output-path "$TEST_OUTPUT_DIR/test2" \
+  --bates-prefix "ZIP"
+
+zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" | head -n 1)
+
+if [ -z "$zip_file" ]; then
+  print_error "Test 2: No ZIP archive generated."
+fi
+
+# Make sure manifest exists and matches
+prod_dir=$(find "$TEST_OUTPUT_DIR/test2" -type d -name "PRODUCTION_*" | head -n 1)
+if [ ! -f "$prod_dir/_manifest.json" ]; then print_error "Missing manifest JSON"; fi
+
+print_success "Test Case 2: Production ZIP passed"
+
+# --- All Tests Passed ---
+
+print_success "All Production Sets E2E tests passed!"


### PR DESCRIPTION
Adds the ability to generate structured production sets with DAT/OPT load files and NATIVES/TEXT/IMAGES/DATA directories. Resolves Feature 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Production-set generator: timestamped PRODUCTION_* folders with DATA/IMAGES/NATIVES/TEXT, per-volume VOL### subfolders, DAT and OPT load files, optional ZIP, and a root _manifest.json summarizing volumes, counts, and Bates ranges
  * CLI flags: --production-set, --production-zip, --volume-size (default 5000)

* **Documentation**
  * CLI docs updated with new options and argument validation/interaction rules (e.g., --production-set requires --bates-prefix and conflicts with --loadfile-only)

* **Tests**
  * End-to-end and unit tests covering parsing, generation, ZIP output, and reproducibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->