### PR TITLE
fix(security): suppress all SonarCloud security hotspots

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Create Release
         if: steps.tag_step.outputs.tag != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/ChaosEngine.cs
+++ b/src/ChaosEngine.cs
@@ -43,7 +43,9 @@ internal class ChaosEngine
         this.format = format;
         this.columnDelimiter = columnDelimiter;
         this.quoteDelimiter = quoteDelimiter;
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         this.random = seed.HasValue ? new Random(seed.Value) : new Random();
+#pragma warning restore S2245
 
         // Determine enabled types
         var validTypes = format == LoadFileFormat.Opt ? OptChaosTypes : DatChaosTypes;

--- a/src/LoadFileGenerator.cs
+++ b/src/LoadFileGenerator.cs
@@ -57,7 +57,9 @@ namespace Zipper
 
             await writer.WriteLineAsync(headerBuilder.ToString());
 
+            #pragma warning disable S2245
             var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+#pragma warning restore S2245
             var now = DateTime.UtcNow;
 
             var buffer = new StringBuilder();

--- a/src/LoadFiles/ConcordanceWriter.cs
+++ b/src/LoadFiles/ConcordanceWriter.cs
@@ -23,7 +23,9 @@ internal class ConcordanceWriter : LoadFileWriterBase
         const char fieldDelim = ',';
         const char quote = '"';
 
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        #pragma warning disable S2245
+            var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+#pragma warning restore S2245
         var now = DateTime.UtcNow;
 
         await WriteHeaderAsync(writer, request, fieldDelim, quote);

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -19,7 +19,9 @@ internal class CsvWriter : LoadFileWriterBase
         // Use leaveOpen: true to avoid disposing the caller's stream
         await using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);
 
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        #pragma warning disable S2245
+            var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+#pragma warning restore S2245
         var now = DateTime.UtcNow;
 
         await WriteHeaderAsync(writer, request);

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -20,7 +20,9 @@ internal class OptWriter : LoadFileWriterBase
         await using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);
         const char tab = '\t';
 
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        #pragma warning disable S2245
+            var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+#pragma warning restore S2245
         var now = DateTime.UtcNow;
 
         await WriteHeaderAsync(writer, request, tab);

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -34,7 +34,9 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
             await writer.WriteStartDocumentAsync(standalone: true);
             await writer.WriteStartElementAsync(null, "documents", null);
 
+            #pragma warning disable S2245
             var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+#pragma warning restore S2245
             var now = DateTime.UtcNow;
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -70,7 +70,9 @@ internal static class LoadfileOnlyGenerator
                 request.Seed);
         }
 
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
+#pragma warning restore S2245
 
         // Write the load file
         await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -27,7 +27,9 @@ namespace Zipper
             Console.WriteLine("===================");
 
             const int fileCount = 1000;
+#pragma warning disable S5443 // Using temp path is safe for local benchmark execution
             var tempDir = Path.GetTempPath();
+#pragma warning restore S5443
             var outputPath = Path.Combine(tempDir, $"bench_alloc_{Guid.NewGuid()}");
             Directory.CreateDirectory(outputPath);
 
@@ -75,7 +77,9 @@ namespace Zipper
             Console.WriteLine("=====================================");
 
             const int fileCount = 500;
+#pragma warning disable S5443 // Using temp path is safe for local benchmark execution
             var tempDir = Path.GetTempPath();
+#pragma warning restore S5443
             var outputPath1 = Path.Combine(tempDir, $"bench_seq_{Guid.NewGuid()}");
             var outputPath2 = Path.Combine(tempDir, $"bench_par_{Guid.NewGuid()}");
             Directory.CreateDirectory(outputPath1);
@@ -189,7 +193,9 @@ namespace Zipper
             Console.WriteLine("===================");
 
             var fileCounts = new[] { 100, 500, 1000, 2000 };
+#pragma warning disable S5443 // Using temp path is safe for local benchmark execution
             var tempDir = Path.GetTempPath();
+#pragma warning restore S5443
 
             foreach (var fileCount in fileCounts)
             {

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -21,7 +21,9 @@ internal class DataGenerator
     public DataGenerator(ColumnProfile profile, int? seed = null)
     {
         this.profile = profile;
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         this.random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
+#pragma warning restore S2245
         this.generatedDataSources = new Dictionary<string, List<string>>();
         this.distributionIndices = new Dictionary<string, int[]>();
 

--- a/src/TiffMultiPageGenerator.cs
+++ b/src/TiffMultiPageGenerator.cs
@@ -56,7 +56,9 @@ internal static class TiffMultiPageGenerator
         // Use a Random instance seeded by fileIndex (and optional seed)
         // to ensure deterministic page counts for testing, while avoiding
         // shared state contention.
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = new Random((seed ?? 0) + (int)fileIndex);
+#pragma warning restore S2245
         return random.Next(clampedMin, clampedMax + 1);
     }
 


### PR DESCRIPTION
Suppresses various S2245 (Random), S5443 (GetTempPath), and S7637 (GH Actions SHA) hotspots reported by SonarCloud across the codebase to ensure clean builds.