### PR TITLE
docs: Align README/Requirements with ubiquitous language and remove vendor-specific names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Zipper: A Test Data Generation Tool
 
-Zipper is a .NET command-line tool for generating large zip files containing placeholder documents (`.pdf`, `.jpg`, `.tiff`, `.eml`, `.docx`, `.xlsx`) and a corresponding load file. It's designed for performance testing and can generate archives with up to 100 million files.
+Zipper is a .NET command-line tool for generating large Archives containing Native Files (`.pdf`, `.jpg`, `.tiff`, `.eml`, `.docx`, `.xlsx`) and a corresponding Load File. It's designed for performance testing and can generate Archives with up to 100 million Native Files.
 
 ## Features
 
-- Generates a single `.zip` archive with a specified number of files
+- Generates a single Archive with a specified number of Native Files
 - Supports multiple file types: PDF, JPG, TIFF, EML, DOCX, XLSX
-- Supports multiple load file formats: DAT, OPT, CSV, EDRM-XML
+- Supports multiple Load File formats: DAT, OPT, CSV, EDRM-XML
 - Supports multiple file distribution patterns: proportional, gaussian, and exponential
 - Supports Bates numbering for legal document identification
 - Supports multipage TIFF files with configurable page count ranges
-- Creates a corresponding load file compatible with standard import tools
-- Uses minimal, valid placeholder files for maximum compression
+- Creates a corresponding Load File compatible with standard import tools
+- Uses minimal, valid placeholder Native Files for maximum compression
 - Streams data directly to the archive to handle very large datasets efficiently
 - Provides progress indication during generation with real-time performance metrics
-- Can target a specific zip file size by padding files with non-compressible data
+- Can target a specific Archive size by padding Native Files with non-compressible data
 - Optimized for high-performance parallel processing with memory pooling and buffered I/O
 - Real-time performance monitoring with progress tracking, throughput metrics, and ETA calculations
-- **Loadfile-Only mode**: Generate standalone load files (DAT/OPT) without ZIP archives or native files
-- **Chaos Engine**: Inject deliberate structural anomalies into load files for ingestion resilience testing
+- **Loadfile-Only mode**: Generate standalone Load Files (DAT/OPT) without Archives or Native Files
+- **Chaos Engine**: Inject deliberate structural anomalies into Load Files for ingestion resilience testing
 
 ## Requirements
 
@@ -59,22 +59,22 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 
 **Optional Arguments:**
 - `--folders <number>`: The number of folders to distribute files into. Defaults to 1. Must be between 1 and 100
-- `--encoding <UTF-8|UTF-16|ANSI>`: The text encoding for the load file. Defaults to `UTF-8`. `ANSI` uses the Windows-1252 code page
+- `--encoding <UTF-8|UTF-16|ANSI>`: The text encoding for the Load File. Defaults to `UTF-8`. `ANSI` uses the Windows-1252 code page
 - `--distribution <proportional|gaussian|exponential>`: The distribution pattern for files across folders. Defaults to `proportional`
   - `proportional`: Even distribution across all folders (round-robin)
   - `gaussian`: Bell curve distribution with most files in middle folders
   - `exponential`: Exponential decay with most files in first folders
-- `--with-metadata`: Generates a load file with additional metadata columns (Custodian, Date Sent, Author, File Size). Supported for all file types including `eml`
-- `--with-text`: Generates a corresponding extracted text file for each document and adds the path to the load file. Supported for all file types including `eml`
-- `--attachment-rate <number>`: When type is `eml`, specifies the percentage of emails (0-100) that will receive a random document as an attachment. Defaults to 0
-- `--target-zip-size <size>`: Specifies a target size for the final zip file (e.g., 500MB, 10GB). This feature works by padding each of the `--count` files with uncompressible data to meet the target size. This significantly reduces the overall compression ratio and is intended for specific network or storage performance testing scenarios. Requires `--count`
-- `--include-load-file`: Includes the generated load file in the root of the output `.zip` archive instead of as a separate file
-- `--load-file-format <dat|opt|csv|edrm-xml>`: The format of the load file. Defaults to `dat`. Also accepts `xml` (alias for `edrm-xml`) and `concordance` (alias for `dat`). Available formats:
+- `--with-metadata`: Generates a Load File with additional metadata columns (Custodian, Date Sent, Author, File Size). Supported for all file types including `eml`
+- `--with-text`: Generates a corresponding extracted text file for each document and adds the path to the Load File. Supported for all file types including `eml`
+- `--attachment-rate <number>`: When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0
+- `--target-zip-size <size>`: Specifies a target size for the final Archive (e.g., 500MB, 10GB). This feature works by padding each of the `--count` Native Files with uncompressible data to meet the target size. This significantly reduces the overall Compression Ratio and is intended for specific network or storage performance testing scenarios. Requires `--count`
+- `--include-load-file`: Includes the generated Load File in the root of the output Archive instead of as a separate file
+- `--load-file-format <dat|opt|csv|edrm-xml>`: The format of the Load File. Defaults to `dat`. Also accepts `xml` (alias for `edrm-xml`) and `concordance` (alias for `dat`). Available formats:
   - `dat`: Standard Concordance DAT format with ASCII 20/254/174 delimiters
   - `opt`: Opticon format - comma-separated, page-level image references
   - `csv`: Comma-separated values format with RFC 4180 escaping
   - `edrm-xml`: EDRM XML format - Electronic Discovery Reference Model schema v1.2
-- `--load-file-formats <format1,format2,...>`: Generate multiple load file formats simultaneously (e.g., `dat,opt,csv`)
+- `--load-file-formats <format1,format2,...>`: Generate multiple Load File formats simultaneously (e.g., `dat,opt,csv`)
 - `--dat-delimiters <standard|csv>`: DAT delimiter style. `standard` uses ASCII 20/254/174, `csv` uses comma/quote. Defaults to `standard`
 - `--bates-prefix <prefix>`: Prefix for Bates numbering (e.g., "CLIENT001")
 - `--bates-start <number>`: Starting number for Bates numbering. Defaults to 1
@@ -90,9 +90,9 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--with-families`: Generate parent-child document relationships (BEGATTACH, ENDATTACH, PARENTDOCID columns)
 
 **Loadfile-Only Options:**
-- `--loadfile-only`: Generate standalone load files (DAT or OPT) directly to disk without creating ZIP archives or native files. Produces a companion `_properties.json` audit file. `--type` becomes optional (defaults to `pdf` for schema). Conflicts with `--target-zip-size` and `--include-load-file`
+- `--loadfile-only`: Generate standalone Load Files directly to disk without creating Archives or Native Files. Produces a companion `_properties.json` audit file. `--type` becomes optional (defaults to `pdf` for schema). Conflicts with `--target-zip-size` and `--include-load-file`
 - `--loadfile-format <dat|opt>`: Alias for `--load-file-format` in loadfile-only mode. Accepts `dat` or `opt`. Defaults to `dat`
-- `--eol <CRLF|LF|CR>`: Line ending format for the generated load file. Defaults to `CRLF`
+- `--eol <CRLF|LF|CR>`: Line ending format for the generated Load File. Defaults to `CRLF`
 - `--col-delim <ascii:N|char:C>`: Column delimiter using strict prefix format. Requires `--loadfile-only`. Example: `ascii:20` or `char:|`
 - `--quote-delim <ascii:N|char:C|none>`: Quote delimiter using strict prefix format, or `none` to omit quotes. Requires `--loadfile-only`. Example: `ascii:254` or `none`
 - `--newline-delim <ascii:N|char:C>`: In-field newline replacement using strict prefix format. Requires `--loadfile-only`. Example: `ascii:174`
@@ -100,7 +100,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--nested-delim <ascii:N|char:C>`: Nested value separator for hierarchical fields. Requires `--loadfile-only`. Example: `char:\`
 
 **Chaos Engine Options:**
-- `--chaos-mode`: Enable the Chaos Engine to inject deliberate structural anomalies into load files. Requires `--loadfile-only`. Only supported for dat and opt load file formats.
+- `--chaos-mode`: Enable the Chaos Engine to inject deliberate structural anomalies into Load Files. Requires `--loadfile-only`. Only supported for dat and opt Load File formats.
 - `--chaos-amount <N|N%>`: Number or percentage of records to corrupt. Requires `--chaos-mode`. Example: `5` (exact count) or `10%` (percentage)
 - `--chaos-types <type1,type2,...>`: Comma-separated filter for specific anomaly types. Requires `--chaos-mode`. DAT types: `mixed-delimiters`, `quotes`, `columns`, `eol`, `encoding`. OPT types: `opt-boundary`, `opt-columns`, `opt-pagecount`, `opt-path`, `opt-batesid`
 - `--chaos-scenario <name>`: Use a predefined chaos scenario instead of manual `--chaos-types`. Requires `--chaos-mode`. Conflicts with `--chaos-types`. Use `--chaos-list` to see available scenarios
@@ -176,18 +176,18 @@ Compatibility checklist:
 
 | Argument | Default | Range/Values | Description |
 |----------|---------|--------------|-------------|
-| `--type` | **required** | pdf, jpg, tiff, eml, docx, xlsx | File type to generate |
+| `--type` | **required** | pdf, jpg, tiff, eml, docx, xlsx | File type to generate (optional with `--loadfile-only` or `--production-set`) |
 | `--count` | **required** | positive integer | Number of files |
 | `--output-path` | **required** | directory path | Output directory |
 | `--folders` | 1 | 1-100 | Number of folders |
-| `--encoding` | UTF-8 | UTF-8, UTF-16, ANSI | Load file encoding |
+| `--encoding` | UTF-8 | UTF-8, UTF-16, ANSI | Load File encoding |
 | `--distribution` | proportional | proportional, gaussian, exponential | File distribution |
 | `--with-metadata` | false | flag | Include metadata columns |
 | `--with-text` | false | flag | Generate text files |
-| `--attachment-rate` | 0 | 0-100 | EML attachment % |
+| `--attachment-rate` | 0 | 0-100 | Email Attachment % |
 | `--target-zip-size` | none | KB/MB/GB (e.g., 500MB) | Target ZIP size |
-| `--include-load-file` | false | flag | Load file in ZIP |
-| `--load-file-format` | dat | dat, opt, csv, edrm-xml, xml, concordance | Load file format |
+| `--include-load-file` | false | flag | Load File in Archive |
+| `--load-file-format` | dat | dat, opt, csv, edrm-xml, xml, concordance | Load File format |
 | `--load-file-formats` | none | comma-separated | Multiple formats |
 | `--dat-delimiters` | standard | standard, csv | DAT delimiter style |
 | `--delimiter-column` | ASCII 20 | char or ASCII code | Custom column delimiter |
@@ -203,9 +203,9 @@ Compatibility checklist:
 | `--empty-percentage` | 15 | 0-100 | Empty value % override |
 | `--custodian-count` | none | 1-1000 | Custodian count override |
 | `--with-families` | false | flag | Family relationships |
-| `--loadfile-only` | false | flag | Standalone load file (no ZIP) |
+| `--loadfile-only` | false | flag | Standalone Load File (no Archive) |
 | `--loadfile-format` | dat | dat, opt | Alias for `--load-file-format` in loadfile-only mode |
-| `--eol` | CRLF | CRLF, LF, CR | Load file line endings |
+| `--eol` | CRLF | CRLF, LF, CR | Load File line endings |
 | `--col-delim` | ASCII 20 | `ascii:N` or `char:C` | Column delimiter (strict) |
 | `--quote-delim` | ASCII 254 | `ascii:N`, `char:C`, or `none` | Quote delimiter (strict) |
 | `--newline-delim` | ASCII 174 | `ascii:N` or `char:C` | Newline replacement (strict) |
@@ -217,7 +217,7 @@ Compatibility checklist:
 | `--chaos-scenario` | none | scenario name | Predefined chaos scenario |
 | `--chaos-list` | false | flag | List scenarios and exit |
 | `--production-set` | false | flag | Generate structured production with DATA/IMAGES/NATIVES/TEXT |
-| `--production-zip` | false | flag | Wrap production set output in a ZIP archive |
+| `--production-zip` | false | flag | Wrap production set output in an Archive |
 | `--volume-size` | 5000 | number | Max files per volume subfolder |
 | `--benchmark` | false | flag | Run benchmark suite and exit |
 
@@ -230,7 +230,7 @@ Compatibility checklist:
 |-------------|----------|
 | `--column-profile` + `--with-metadata` | Column profile takes precedence; `--with-metadata` is ignored with a warning |
 | `--target-zip-size` | Requires `--count` to be specified |
-| `--attachment-rate` | Only meaningful when `--type eml` |
+| `--attachment-rate` | Only meaningful when `--type eml` (Email File Type) |
 | `--tiff-pages` | Only meaningful when `--type tiff` |
 | `--bates-start`, `--bates-digits` | Only meaningful when `--bates-prefix` is specified |
 | `--date-format`, `--empty-percentage`, `--custodian-count` | Only meaningful when `--column-profile` is specified |
@@ -256,7 +256,7 @@ Column profiles allow you to generate rich, configurable metadata with up to 200
 | `minimal` | 5 | Basic fields: DOCID, FILEPATH, CUSTODIAN, DATECREATED, FILESIZE |
 | `standard` | 25 | Common e-discovery fields including dates, people, classification |
 | `litigation` | 50 | Full litigation support with privilege, responsiveness, hashes |
-| `full` | 127 | Maximum coverage with custom tags, issues, and notes |
+| `full` | 150 | Maximum coverage with custom tags, issues, and notes |
 
 Column types supported:
 - `identifier`: Sequential document IDs (DOC00000001)
@@ -282,15 +282,15 @@ The following chart illustrates how files are distributed across folders using d
 
 ### Examples
 
-To generate a zip file containing 50,000 PDF files distributed across 10 folders using a gaussian distribution pattern:
+To generate an Archive containing 50,000 PDF Native Files distributed across 10 folders using a gaussian distribution pattern:
 
 ```bash
 zipper --type pdf --count 50000 --output-path ./test_data --folders 10 --distribution gaussian
 ```
 
 This command will produce two files in the `test_data` directory, with filenames based on the current date and time (e.g., `archive_YYYYMMDD_HHMMSS.zip` and `archive_YYYYMMDD_HHMMSS.dat`):
-- A zip file containing 50,000 PDFs distributed across 10 folders
-- The load file pointing to the documents within the archive
+- An Archive containing 50,000 PDFs distributed across 10 folders
+- The Load File pointing to the documents within the archive
 
 #### Additional Use Cases
 
@@ -304,16 +304,16 @@ zipper --type jpg --count 25000 --output-path ./test --folders 20 --distribution
 # Generate 5,000 TIFFs with an exponential decay distribution
 zipper --type tiff --count 5000 --output-path ./test --folders 10 --distribution exponential
 
-# Generate a load file with additional metadata columns
+# Generate a Load File with additional metadata columns
 zipper --type pdf --count 1000 --output-path ./test --with-metadata
 
-# Generate a load file with extracted text placeholders
+# Generate a Load File with extracted text placeholders
 zipper --type tiff --count 25000 --output-path ./test_data --with-text
 
 # Combine all options: 100k TIFFs with metadata and text, distributed across 50 folders
 zipper --type tiff --count 100000 --output-path ./test_data --folders 50 --distribution gaussian --with-metadata --with-text
 
-# Generate 5,000 emails with a 20% chance of having an attachment
+# Generate 5,000 Emails with a 20% chance of having an Attachment
 zipper --type eml --count 5000 --output-path ./email_test --attachment-rate 20
 
 # Generate emails with metadata (Custodian, Author, Date Sent, File Size)
@@ -325,58 +325,58 @@ zipper --type eml --count 2500 --output-path ./email_text --with-text
 # Generate emails with both metadata and extracted text
 zipper --type eml --count 3000 --output-path ./email_full --with-metadata --with-text
 
-# Generate emails with attachments, metadata, and text
+# Generate Emails with Attachments, metadata, and text
 zipper --type eml --count 2000 --output-path ./email_complete --with-metadata --with-text --attachment-rate 30
 
 # Generates exactly 100,000 PDF files and pads each one with uncompressible
-# data so that the final compressed zip archive is approximately 1GB in size
+# data so that the final compressed Archive is approximately 1GB in size
 zipper --type pdf --count 100000 --target-zip-size 1GB --output-path ./test_padded_files
 
-# Generate 1,000 PDFs and include the load file inside the zip archive
+# Generate 1,000 PDFs and include the Load File inside the Archive
 zipper --type pdf --count 1000 --output-path ./test_inclusive --include-load-file
 
 # Generate DOCX files with Bates numbering
 zipper --type docx --count 500 --output-path ./test_docx --bates-prefix "CLIENT001" --bates-start 1 --bates-digits 8
 
-# Generate XLSX files with custom load file format
+# Generate XLSX files with custom Load File format
 zipper --type xlsx --count 1000 --output-path ./test_xlsx --load-file-format csv
 
 # Generate TIFF files with variable page counts (1-20 pages per file)
 zipper --type tiff --count 5000 --output-path ./test_tiff --tiff-pages "1-20"
 
-# Combine new features: DOCX with Bates numbering, CSV load file, and metadata
+# Combine new features: DOCX with Bates numbering, CSV Load File, and metadata
 zipper --type docx --count 1000 --output-path ./test_combined --bates-prefix "CASE001" --bates-start 5000 --bates-digits 10 --load-file-format csv --with-metadata
 
 # Generate TIFF files with page count tracking and Bates numbering
 zipper --type tiff --count 2500 --output-path ./test_tiff_bates --tiff-pages "5-50" --bates-prefix "IMG" --bates-digits 8 --with-metadata
 
-# Generate emails with XML load file format
+# Generate emails with XML Load File format
 zipper --type eml --count 5000 --output-path ./test_eml_xml --load-file-format edrm-xml --with-metadata --with-text
 
-# Generate PDFs with the standard column profile (24 metadata columns)
+# Generate PDFs with the standard column profile (25 metadata columns)
 zipper --type pdf --count 1000 --output-path ./test_profiles --column-profile standard
 
-# Generate with litigation profile (48 columns) for complex e-discovery workflows
+# Generate with litigation profile (50 columns) for complex e-discovery workflows
 zipper --type pdf --count 5000 --output-path ./litigation_data --column-profile litigation
 
 # Generate reproducible output using a seed
 zipper --type pdf --count 1000 --output-path ./reproducible --column-profile standard --seed 12345
 
-# Generate multiple load file formats simultaneously
+# Generate multiple Load File formats simultaneously
 zipper --type pdf --count 1000 --output-path ./multi_format --load-file-formats dat,opt,csv
 
 # Generate with custom date format and empty percentage
 zipper --type pdf --count 1000 --output-path ./custom --column-profile standard --date-format "MM/dd/yyyy" --empty-percentage 25
 
-# Generate family relationships for email attachments
+# Generate family relationships for Email Attachments
 zipper --type eml --count 2000 --output-path ./families --attachment-rate 30 --with-families
 
 # ── Loadfile-Only Mode ──────────────────────────
 
-# Generate a standalone DAT load file (no ZIP, no native files)
+# Generate a standalone DAT Load File (no Archive, no Native Files)
 zipper --loadfile-only --count 100000 --output-path ./dat_only
 
-# Generate a standalone OPT load file in Opticon 7-column format
+# Generate a standalone OPT Load File in Opticon 7-column format
 zipper --loadfile-only --loadfile-format opt --count 50000 --output-path ./opt_only
 
 # Custom delimiters with strict prefix format and LF line endings
@@ -406,13 +406,13 @@ zipper --loadfile-only --loadfile-format opt --count 10000 --output-path ./opt_c
 # List all available chaos scenarios
 zipper --chaos-list
 
-# Simulate common Relativity ingestion failures
-zipper --loadfile-only --count 100000 --output-path ./relativity_test \
-    --chaos-mode --chaos-scenario relativity-import --seed 42
+# Simulate common platform ingestion failures
+zipper --loadfile-only --count 100000 --output-path ./platform_import_test \
+    --chaos-mode --chaos-scenario structured-import-failures --seed 42
 
-# Simulate NUIX export errors with custom anomaly amount
-zipper --loadfile-only --count 50000 --output-path ./nuix_test \
-    --chaos-mode --chaos-scenario nuix-export --chaos-amount "15%"
+# Simulate cross-platform transfer errors with custom anomaly amount
+zipper --loadfile-only --count 50000 --output-path ./transfer_test \
+    --chaos-mode --chaos-scenario transfer-encoding-failures --chaos-amount "15%"
 
 # Full chaos: all anomaly types at 10% density
 zipper --loadfile-only --count 100000 --output-path ./full_chaos \
@@ -522,7 +522,7 @@ zipper --benchmark
 For extreme performance testing and edge case validation, see the [stress test suite](tests/stress/README.md). These tests are designed for manual execution only and test system limits under extreme conditions:
 
 - **10GB File Count Challenge**: Tests maximum file handling (5M files)
-- **30GB Attachment-Heavy EML**: Tests attachment processing and large archives
+- **30GB Attachment-Heavy Email**: Tests Attachment processing and large Archives
 - **Large Load File Performance**: Tests metadata and text extraction performance
 
 **Warning**: Stress tests consume significant system resources and require manual confirmation before execution.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 ### Arguments
 
 **Required Arguments:**
-- `--type <pdf|jpg|tiff|eml|docx|xlsx>`: **(Required unless `--loadfile-only`)** The type of file to generate. Defaults to `pdf` when `--loadfile-only` is used
+- `--type <pdf|jpg|tiff|eml|docx|xlsx>`: **(Required unless `--loadfile-only` or `--production-set`)** The type of Native File to generate. Defaults to `pdf` when optional
 - `--count <number>`: **(Required)** The total number of files/records to generate
 - `--output-path <directory>`: **(Required)** The directory where the output files will be saved. The directory will be created if it doesn't exist
 
@@ -254,9 +254,9 @@ Column profiles allow you to generate rich, configurable metadata with up to 200
 | Profile | Columns | Description |
 |---------|---------|-------------|
 | `minimal` | 5 | Basic fields: DOCID, FILEPATH, CUSTODIAN, DATECREATED, FILESIZE |
-| `standard` | 25 | Common e-discovery fields including dates, people, classification |
-| `litigation` | 50 | Full litigation support with privilege, responsiveness, hashes |
-| `full` | 150 | Maximum coverage with custom tags, issues, and notes |
+| `standard` | 24 | Common e-discovery fields including dates, people, classification |
+| `litigation` | 48 | Full litigation support with privilege, responsiveness, hashes |
+| `full` | 138 | Maximum coverage with custom tags, issues, and notes |
 
 Column types supported:
 - `identifier`: Sequential document IDs (DOC00000001)
@@ -353,10 +353,10 @@ zipper --type tiff --count 2500 --output-path ./test_tiff_bates --tiff-pages "5-
 # Generate emails with XML Load File format
 zipper --type eml --count 5000 --output-path ./test_eml_xml --load-file-format edrm-xml --with-metadata --with-text
 
-# Generate PDFs with the standard column profile (25 metadata columns)
+# Generate PDFs with the standard column profile (24 metadata columns)
 zipper --type pdf --count 1000 --output-path ./test_profiles --column-profile standard
 
-# Generate with litigation profile (50 columns) for complex e-discovery workflows
+# Generate with litigation profile (48 columns) for complex e-discovery workflows
 zipper --type pdf --count 5000 --output-path ./litigation_data --column-profile litigation
 
 # Generate reproducible output using a seed

--- a/Requirements.md
+++ b/Requirements.md
@@ -8,73 +8,73 @@
 
 ## 1. Core Purpose
 
-The `zipper` application is a .NET Core command-line tool designed to generate large, highly compressed `.zip` files containing a specified number of placeholder files. It also generates a corresponding load file compatible with import specifications.
+The `zipper` application is a .NET Core command-line tool designed to generate large, highly compressed Archives containing a specified number of Native Files. It also generates a corresponding Load File compatible with import specifications.
 
 ## 2. Features
 
 ### FR_E-002: Core File Generation
-- **REQ_E-008**: The application must generate a user-specified number of files.
-- **REQ_E-009**: The application must support generating up to 100 million files.
-- **REQ_E-010**: The application must support generating files of type `pdf`, `jpg`, `tiff`, `eml`, `docx`, or `xlsx`.
-- **REQ_E-011**: The content for the generated files must be a minimal, valid, and identical placeholder to ensure maximum compression.
+- **REQ_E-008**: The application must generate a user-specified number of Native Files.
+- **REQ_E-009**: The application must support generating up to 100 million Native Files.
+- **REQ_E-010**: The application must support generating Native Files of type `pdf`, `jpg`, `tiff`, `eml`, `docx`, or `xlsx`.
+- **REQ_E-011**: The content for the generated Native Files must be a minimal, valid, and identical placeholder to ensure maximum compression.
 - **REQ_E-012**: The application will provide placeholder content internally, without requiring user-supplied template files.
 
 ### FR_E-003: Archive Creation
-- **REQ_E-013**: The application must output a single `.zip` archive.
+- **REQ_E-013**: The application must output a single Archive.
 - **REQ_E-014**: The compression level must be equivalent to the standard "best compression" (DEFLATE).
-- **REQ_E-015**: The system must support archives exceeding 4GB and 65,535 files (Zip64).
+- **REQ_E-015**: The system must support Archives exceeding 4GB and 65,535 Native Files (Zip64).
 
 ### FR_E-004: Load File Generation
-- **REQ_E-016**: The application must generate a single `.dat` load file corresponding to the zip archive.
-- **REQ_E-017**: The load file must use ASCII character 20 as the column delimiter.
-- **REQ_E-018**: The load file must use ASCII character 254 as the quote/text qualifier.
-- **REQ_E-019**: The load file must be saved with a user-specifiable encoding (`UTF-8`, `UTF-16`, `ANSI`), defaulting to `UTF-8`.
-- **REQ_E-020**: The load file must contain a unique `Control Number` column for each document.
-- **REQ_E-021**: The load file must contain a `File Path` column pointing to the file's relative location within the zip archive.
+- **REQ_E-016**: The application must generate a single `.dat` Load File corresponding to the Archive.
+- **REQ_E-017**: The Load File must use ASCII character 20 as the column delimiter.
+- **REQ_E-018**: The Load File must use ASCII character 254 as the quote/text qualifier.
+- **REQ_E-019**: The Load File must be saved with a user-specifiable encoding (`UTF-8`, `UTF-16`, `ANSI`), defaulting to `UTF-8`.
+- **REQ_E-020**: The Load File must contain a unique `Control Number` column for each Native File.
+- **REQ_E-021**: The Load File must contain a `File Path` column pointing to the Native File's relative location within the Archive.
 
 ### FR-000: Automatic Metadata Generation
 - **REQ-000**: A new optional command-line argument `--with-metadata` shall be introduced.
-- **REQ-001**: When `--with-metadata` is specified, the output `.dat` file must include the additional columns: `Custodian`, `Date Sent`, `Author`, and `File Size`. Note: For EML file types, email-specific metadata columns are always included regardless of this flag, as these are intrinsic to email files.
-- **REQ-002**: The `Custodian` field shall be linked to the folder structure. The tool will generate a unique custodian name for each folder (e.g., "Custodian 1"). All files within a given folder will be assigned that folder's custodian. If no folders are specified, a single default custodian name will be assigned to all files.
+- **REQ-001**: When `--with-metadata` is specified, the output `.dat` file must include the additional columns: `Custodian`, `Date Sent`, `Author`, and `File Size`. Note: For the Email File Type, email-specific metadata columns are always included regardless of this flag, as these are intrinsic to Emails.
+- **REQ-002**: The `Custodian` field shall be linked to the Folder structure. The tool will generate a unique custodian name for each Folder (e.g., "Custodian 1"). All Native Files within a given Folder will be assigned that Folder's custodian. If no Folders are specified, a single default custodian name will be assigned to all Native Files.
 - **REQ-003**: The `Author`, `Date Sent`, and `File Size` fields will be auto-generated with plausible random data without requiring user input.
 
 ### FR-001: Integrated Extracted Text
 - **REQ-004**: A new optional command-line argument `--with-text` shall be introduced.
-- **REQ-005**: When specified, the tool will generate a matching `.txt` file for every document within the zip archive.
+- **REQ-005**: When specified, the tool will generate a matching `.txt` file for every document within the Archive.
 - **REQ-006**: The content for each `.txt` file will be a fixed, non-configurable, standard block of internal placeholder text to ensure maximum compressibility.
-- **REQ-007**: The `.dat` load file must be updated to include a column `Extracted Text` pointing to the relative path of the corresponding `.txt` file.
+- **REQ-007**: The `.dat` Load File must be updated to include a column `Extracted Text` pointing to the relative path of the corresponding `.txt` file.
 
 ### FR-002: Basic Email Generation
 - **REQ-008**: The `--type` argument shall be expanded to accept `eml` as a valid file type.
-- **REQ-009**: When `--type eml` is specified, the tool will generate `.eml` files with basic, valid headers (To, From, Subject, Sent-Date) and a simple, repetitive text body.
-- **REQ-010**: The associated `.dat` load file will contain columns corresponding to the email headers, populated with auto-generated data. For EML files, metadata columns (To, From, Subject, Sent Date, Attachment) are always included regardless of the `--with-metadata` flag, as these are intrinsic to email files.
-- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated emails have one of the placeholder documents included as a random attachment. Defaults to 0.
+- **REQ-009**: When `--type eml` is specified, the tool will generate Email Native Files with basic, valid headers (To, From, Subject, Sent-Date) and a simple, repetitive text body.
+- **REQ-010**: The associated `.dat` Load File will contain columns corresponding to the email headers, populated with auto-generated data. For Emails, metadata columns (To, From, Subject, Sent Date, Attachment) are always included regardless of the `--with-metadata` flag, as these are intrinsic to Emails.
+- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated Emails have one of the Native Files included as a random Attachment. Defaults to 0.
 
 ### FR_E-005: File Distribution Patterns
 - **REQ_E-022**: A new optional command-line argument `--distribution` shall be introduced.
 - **REQ_E-023**: The tool shall support three distribution patterns: `proportional`, `gaussian`, and `exponential`.
 - **REQ_E-024**: `proportional` shall be the default distribution pattern.
-- **REQ_E-025**: `proportional` distribution shall assign files to folders in a round-robin fashion.
-- **REQ_E-026**: `gaussian` distribution shall assign files in a bell-curve pattern, with most files concentrated in the middle folders.
-- **REQ_E-027**: `exponential` distribution shall assign files in an exponential decay pattern, with most files concentrated in the first few folders.
-- **REQ_E-028**: The application must support distributing files into a user-specified number of folders (from 1 to 100), defaulting to 1.
+- **REQ_E-025**: `proportional` distribution shall assign Native Files to Folders in a round-robin fashion.
+- **REQ_E-026**: `gaussian` distribution shall assign Native Files in a bell-curve pattern, with most Native Files concentrated in the middle Folders.
+- **REQ_E-027**: `exponential` distribution shall assign Native Files in an exponential decay pattern, with most Native Files concentrated in the first few Folders.
+- **REQ_E-028**: The application must support distributing Native Files into a user-specified number of Folders (from 1 to 100), defaulting to 1.
 
 ### FR-005: Target Zip Size via In-File Padding
 - **REQ-021**: A new optional command-line argument `--target-zip-size <size>` shall be introduced.
 - **REQ-022**: The application must exit with a validation error if `--target-zip-size` is specified without the `--count` argument.
-- **REQ-023**: When both `--target-zip-size` and `--count` are used, the tool must calculate the amount of uncompressible padding needed for each file to meet the final compressed --target-zip-size.
-- **REQ-024**: The tool must append the calculated amount of random (non-compressible) data to each of the count placeholder files' content before they are added to the archive for compression.
-- **REQ-025**: The final generated zip file size must fall within a +/- 10% tolerance of the --target-zip-size. This is the final success criterion for the operation.
+- **REQ-023**: When both `--target-zip-size` and `--count` are used, the tool must calculate the amount of uncompressible padding needed for each Native File to meet the final compressed --target-zip-size.
+- **REQ-024**: The tool must append the calculated amount of random (non-compressible) data to each of the count Native Files' content before they are added to the Archive for compression.
+- **REQ-025**: The final generated Archive size must fall within a +/- 10% tolerance of the --target-zip-size. This is the final success criterion for the operation.
 - **REQ-026**: The application must perform a pre-check to estimate the minimum possible compressed size of the requested files. If this estimated minimum size already exceeds the --target-zip-size, the tool must exit immediately with a clear error message to prevent an impossible task from running.
 
 ### FR-006: Inclusive Load File
 - **REQ-027**: A new optional command-line argument `--include-load-file` shall be introduced.
-- **REQ-028**: When this flag is specified, the generated `.dat` load file must be included in the root of the output `.zip` archive.
-- **REQ-029**: When this flag is specified, the `.dat` load file must not be created as a separate file in the output directory.
+- **REQ-028**: When this flag is specified, the generated Load File must be included in the root of the output Archive.
+- **REQ-029**: When this flag is specified, the Load File must not be created as a separate file in the output directory.
 
 ### FR-007: Multiple Load File Formats
 - **REQ-036**: A new optional command-line argument `--load-file-format <format>` shall be introduced.
-- **REQ-037**: The tool shall support multiple load file formats as specified in Section 8: `dat` (default), `opt`, `csv`, and `edrm-xml`.
+- **REQ-037**: The tool shall support multiple Load File formats as specified in Section 8: `dat` (default), `opt`, `csv`, and `edrm-xml`.
 - **REQ-038**: Each format shall conform to industry-standard specifications defined in Section 8 (Load File Format Standards).
 
 ### FR-008: Bates Numbering System
@@ -82,15 +82,15 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
   - `--bates-prefix <prefix>`: Prefix for Bates numbering (e.g., "CLIENT001")
   - `--bates-start <number>`: Starting number for Bates numbering. Defaults to 1
   - `--bates-digits <number>`: Number of digits for Bates numbering. Defaults to 8
-- **REQ-040**: When Bates numbering is enabled, the load file must include a `Bates Number` column.
+- **REQ-040**: When Bates numbering is enabled, the Load File must include a `Bates Number` column.
 - **REQ-041**: Bates numbers shall be formatted as `{PREFIX}{PADDED_NUMBER}` where the number is zero-padded to the specified digit count.
-- **REQ-042**: Bates numbers must increment sequentially for each file generated.
+- **REQ-042**: Bates numbers must increment sequentially for each Native File generated.
 
 ### FR-009: Multipage TIFF Support
 - **REQ-043**: A new optional command-line argument `--tiff-pages <min-max>` shall be introduced.
 - **REQ-044**: The argument accepts a range specification (e.g., "1-20") to define the minimum and maximum page count.
-- **REQ-045**: When `--type tiff` is specified with `--tiff-pages`, each TIFF file shall have a random page count within the specified range.
-- **REQ-046**: The load file must include a `Page Count` column indicating the number of pages in each TIFF file.
+- **REQ-045**: When `--type tiff` is specified with `--tiff-pages`, each TIFF Native File shall have a random page count within the specified range.
+- **REQ-046**: The Load File must include a `Page Count` column indicating the number of pages in each TIFF file.
 - **REQ-047**: The default page range shall be "1-1" (single page) for backward compatibility.
 
 ## 3. Technical Requirements
@@ -103,7 +103,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
   - `ClosedXML` - For XLSX spreadsheet generation
   - `DocumentFormat.OpenXml` - For DOCX document generation
   - `System.Drawing.Common` - For image processing
-- **Performance**: The application must be designed to stream data directly to the archive without storing intermediate files on disk, minimizing memory and disk space usage.
+- **Performance**: The application must be designed to stream data directly to the Archive without storing intermediate files on disk, minimizing memory and disk space usage.
 - **Parallel Processing**: The application must support parallel file generation with configurable worker pools to optimize performance on multi-core systems.
 - **Memory Management**: The application must implement object pooling and buffered I/O to reduce garbage collection pressure and improve throughput.
 - **Performance Monitoring**: The application must provide real-time progress tracking, performance metrics, and ETA calculations during file generation.
@@ -111,20 +111,20 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 ## 4. Command-Line Arguments
 
 > [!NOTE]
-> Additional arguments for load file formats and column profiles are defined in Section 9.
+> Additional arguments for Load File formats, column profiles, Loadfile-Only Mode, Chaos Engine, benchmarking, and production sets are defined in Sections 9 through 16.
 
-- `--type <pdf|jpg|tiff|eml|docx|xlsx>`: (Required) The type of file to generate.
-- `--count <number>`: (Required) The total number of files to generate.
-- `--output-path <directory>`: (Required) The directory where the output `.zip` and load file will be saved.
-- `--folders <number>`: (Optional) The number of folders to distribute files into. Defaults to 1. Must be between 1 and 100.
-- `--encoding <UTF-8|UTF-16|ANSI>`: (Optional) The text encoding for the load file. Defaults to UTF-8. `ANSI` corresponds to the Windows-1252 code page.
-- `--distribution <proportional|gaussian|exponential>`: (Optional) The distribution pattern for files across folders. Defaults to `proportional`.
-- `--with-metadata`: (Optional) Generates a load file with additional metadata columns (Custodian, Date Sent, Author, File Size).
-- `--with-text`: (Optional) Generates a corresponding extracted text file for each document and adds the path to the load file.
-- `--attachment-rate <number>`: (Optional) When type is `eml`, specifies the percentage of emails (0-100) that will receive a random document as an attachment. Defaults to 0.
-- `--target-zip-size <size>`: (Optional, Requires --count) Specifies a target size for the final zip file (e.g., 500MB, 10GB).
-- `--include-load-file`: (Optional) Includes the generated load file in the root of the output `.zip` archive.
-- `--load-file-format <dat|opt|csv|edrm-xml>`: (Optional) The format of the load file. Defaults to `dat`. See Section 8 for format specifications.
+- `--type <pdf|jpg|tiff|eml|docx|xlsx>`: (Required unless `--loadfile-only` or `--production-set`) The type of Native File to generate. Defaults to `pdf` when optional.
+- `--count <number>`: (Required) The total number of Native Files to generate.
+- `--output-path <directory>`: (Required) The directory where the output Archive and Load File will be saved.
+- `--folders <number>`: (Optional) The number of Folders to distribute Native Files into. Defaults to 1. Must be between 1 and 100.
+- `--encoding <UTF-8|UTF-16|ANSI>`: (Optional) The text encoding for the Load File. Defaults to UTF-8. `ANSI` corresponds to the Windows-1252 code page.
+- `--distribution <proportional|gaussian|exponential>`: (Optional) The distribution pattern for Native Files across Folders. Defaults to `proportional`.
+- `--with-metadata`: (Optional) Generates a Load File with additional metadata columns (Custodian, Date Sent, Author, File Size).
+- `--with-text`: (Optional) Generates a corresponding extracted text file for each document and adds the path to the Load File.
+- `--attachment-rate <number>`: (Optional) When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0.
+- `--target-zip-size <size>`: (Optional, Requires --count) Specifies a target size for the final Archive (e.g., 500MB, 10GB).
+- `--include-load-file`: (Optional) Includes the generated Load File in the root of the output Archive.
+- `--load-file-format <dat|opt|csv|edrm-xml>`: (Optional) The format of the Load File. Defaults to `dat`. See Section 8 for format specifications.
 - `--bates-prefix <prefix>`: (Optional) Prefix for Bates numbering.
 - `--bates-start <number>`: (Optional) Starting number for Bates numbering. Defaults to 1.
 - `--bates-digits <number>`: (Optional) Number of digits for Bates numbering. Defaults to 8.
@@ -161,7 +161,7 @@ To enforce the pre-commit testing requirement, the repository will include a scr
 
 ## 8. Load File Format Standards (E-Discovery Industry Specifications)
 
-This section documents industry-standard load file formats used by major e-discovery platforms. These specifications inform the implementation of the `--load-file-format` feature and ensure broad platform compatibility.
+This section documents industry-standard Load File formats used by major e-discovery platforms. These specifications inform the implementation of the `--load-file-format` feature and ensure broad platform compatibility.
 
 ### 8.1 Overview of Load File Types
 
@@ -173,7 +173,7 @@ This section documents industry-standard load file formats used by major e-disco
 
 ### 8.2 Concordance DAT Format Specification
 
-The Concordance DAT format is the most widely used load file format in e-discovery. It is a delimited text file containing metadata and document information.
+The Concordance DAT format is the most widely used Load File format in e-discovery. It is a delimited text file containing metadata and document information.
 
 #### Structure
 - **Encoding**: UTF-8 (preferred), UTF-8 without BOM, ASCII (Windows-1252), or UTF-16
@@ -195,8 +195,8 @@ The Concordance DAT format is the most widely used load file format in e-discove
 > While these are the standard defaults, some platforms allow custom delimiters. When generating DAT files, use the standard delimiters for maximum compatibility.
 
 #### Required Fields
-- **Unique Identifier**: Every load file must have a unique document identifier (e.g., `Control Number`, `DOCID`, `Bates Number`)
-- **File Path**: Relative path to the file within the archive/production
+- **Unique Identifier**: Every Load File must have a unique document identifier (e.g., `Control Number`, `DOCID`, `Bates Number`)
+- **File Path**: Relative path to the Native File within the Archive/production
 
 #### Common Metadata Fields
 
@@ -223,10 +223,10 @@ The Concordance DAT format is the most widely used load file format in e-discove
 
 - Header rows strongly recommended but not always mandatory
 - Field order is generally flexible
-- An identifier field is required for each load
+- An identifier field is required for each Load
 - Column headers in ALL CAPITAL LETTERS recommended for maximum compatibility
 - `DOCID` column required with unique values
-- Native file path column should be named `ITEMPATH`
+- Native File path column should be named `ITEMPATH`
 - `PARENT_DOCID` required for family relationships
 - Date formats may need configuration during import
 - Prefer ASCII or UTF-8 encoding
@@ -234,7 +234,7 @@ The Concordance DAT format is the most widely used load file format in e-discove
 
 ### 8.3 Opticon (OPT) Format Specification
 
-The Opticon format is a page-level load file that links Bates numbers to image file locations, defining document boundaries.
+The Opticon format is a page-level Load File that links Bates numbers to image file locations, defining document boundaries.
 
 #### Structure
 - **Encoding**: ANSI/Western European (Windows-1252) — Unicode NOT supported in most platforms
@@ -337,7 +337,7 @@ The EDRM (Electronic Discovery Reference Model) XML format is a vendor-neutral s
 
 ### 8.6 Implementation Requirements for Zipper
 
-Based on the above research, the following requirements apply to the Zipper load file generation feature:
+Based on the above research, the following requirements apply to the Zipper Load File generation feature:
 
 #### FR-010: Extended Load File Format Support
 
@@ -350,27 +350,27 @@ Based on the above research, the following requirements apply to the Zipper load
 
 #### FR-011: Multi-Format Output
 
-- **REQ-055**: A new argument `--load-file-formats <format1,format2,...>` (plural) shall allow generating multiple load file formats simultaneously.
+- **REQ-055**: A new argument `--load-file-formats <format1,format2,...>` (plural) shall allow generating multiple Load File formats simultaneously.
 - **REQ-056**: When `--load-file-formats` is specified, all requested formats shall be generated to the output directory.
 
 #### FR-012: OPT File Generation
 
-- **REQ-057**: When `--type tiff` or `--type jpg` is used, an OPT file shall be generated automatically alongside the DAT file. Note: PDF files do NOT trigger automatic OPT generation as they are treated as native files, not page-level images.
+- **REQ-057**: When `--type tiff` or `--type jpg` is used, an OPT file shall be generated automatically alongside the DAT file. Note: PDF Native Files do NOT trigger automatic OPT generation as they are treated as Native Files, not page-level images.
 - **REQ-058**: The OPT file shall correctly mark document breaks for multi-page documents (when `--tiff-pages` is used). For multi-page TIFFs, page-level Bates numbers shall use suffixes (e.g., `ABC001_00001_001`, `ABC001_00001_002`).
 - **REQ-059**: OPT files shall use ANSI encoding for maximum platform compatibility.
 
 #### FR-013: Family Relationship Support
 
 - **REQ-060**: A new argument `--with-families` shall generate parent-child document relationships.
-- **REQ-061**: When `--with-families` is specified, the load file shall include `BEGATTACH`, `ENDATTACH`, and `PARENT_DOCID` columns.
-- **REQ-062**: Email attachments (when using `--attachment-rate`) shall be properly linked as children of their parent email documents.
+- **REQ-061**: When `--with-families` is specified, the Load File shall include `BEGATTACH`, `ENDATTACH`, and `PARENT_DOCID` columns.
+- **REQ-062**: Email Attachments (when using `--attachment-rate`) shall be properly linked as children of their parent Email documents.
 
 #### FR-014: Column Profile System
 
 - **REQ-063**: A new argument `--column-profile <name|path>` shall be introduced to specify metadata columns.
 - **REQ-064**: The argument shall accept either a built-in profile name or a path to a custom JSON profile file.
 - **REQ-065**: Column profiles shall be embedded in the application binary as resources.
-- **REQ-066**: If `--column-profile` is not specified, only base columns (Control Number, File Path) shall be included in the load file. The `--with-metadata` flag adds its columns independently.
+- **REQ-066**: If `--column-profile` is not specified, only base columns (Control Number, File Path) shall be included in the Load File. The `--with-metadata` flag adds its columns independently.
 - **REQ-076**: When both `--column-profile` and `--with-metadata` are specified, the profile columns take precedence, and `--with-metadata` is ignored with a warning.
 - **REQ-077**: When `--type eml` is specified, email-intrinsic columns (From, To, CC, Subject, Sent Date) are always included regardless of the column profile or `--with-metadata` flag.
 - **REQ-078**: Custom profiles shall have a maximum of 200 columns. Profiles exceeding this limit shall produce a validation error.
@@ -382,7 +382,7 @@ Based on the above research, the following requirements apply to the Zipper load
 | `minimal` | 5 | Basic fields: DOCID, FILEPATH, CUSTODIAN, DATECREATED, FILESIZE |
 | `standard` | 25 | Common e-discovery fields |
 | `litigation` | 50 | Full litigation support |
-| `full` | 127 | Maximum field coverage |
+| `full` | 150 | Maximum field coverage |
 
 - **REQ-067**: Custom profile files shall follow a JSON schema with the following structure:
 
@@ -465,25 +465,25 @@ Based on the above research, the following requirements apply to the Zipper load
   - Column delimiter: ASCII 20 (Concordance standard)
   - Quote delimiter: ASCII 254 (Concordance standard)
   - Newline delimiter: ASCII 174 (Concordance standard)
-- **REQ-086**: The application shall replace any newline characters (`\n`, `\r`, `\r\n`) within field values with the configured newline delimiter character to prevent load file corruption.
+- **REQ-086**: The application shall replace any newline characters (`\n`, `\r`, `\r\n`) within field values with the configured newline delimiter character to prevent Load File corruption.
 
 ---
 
 ## 9. Updated Command-Line Arguments
 
-The following arguments are added or modified by the load file and column profile features:
+The following arguments are added or modified by the Load File and column profile features:
 
 ### Load File Arguments
 
-- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the load file. Defaults to `dat`. Accepts `xml` and `concordance` as aliases.
-- `--load-file-formats <format1,format2,...>`: (Optional) Generate multiple load file formats simultaneously.
+- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the Load File. Defaults to `dat`. Accepts `xml` and `concordance` as aliases.
+- `--load-file-formats <format1,format2,...>`: (Optional) Generate multiple Load File formats simultaneously.
 - `--dat-delimiters <standard|csv>`: (Optional) Delimiter style for DAT files. Defaults to `standard` (ASCII 20/254/174).
 - `--delimiter-column <char|code>`: (Optional) Custom column delimiter for DAT files. Overrides `--dat-delimiters` preset.
 - `--delimiter-quote <char|code>`: (Optional) Custom quote delimiter for DAT files. Overrides `--dat-delimiters` preset.
 - `--delimiter-newline <char|code>`: (Optional) Custom newline replacement for DAT files. Overrides `--dat-delimiters` preset.
 
 > [!NOTE]
-> When `--load-file-formats` is used with `--include-load-file`, all specified formats are included in the archive.
+> When `--load-file-formats` is used with `--include-load-file`, all specified formats are included in the Archive.
 
 ### Column Profile Arguments
 
@@ -507,17 +507,23 @@ This section clarifies behavior when multiple arguments interact:
 |-------------|----------|
 | `--with-metadata` + `--column-profile` | Profile takes precedence; `--with-metadata` ignored with warning |
 | `--type eml` + any profile | Email columns (From, To, CC, Subject, Sent Date) always added |
-| `--load-file-formats` + `--include-load-file` | All specified formats are included in the archive |
-| `--distribution` (folder) + profile distribution | These are independent: `--distribution` controls folders, profile controls data values |
+| `--load-file-formats` + `--include-load-file` | All specified formats are included in the Archive |
+| `--distribution` (folder) + profile distribution | These are independent: `--distribution` controls Folders, profile controls data values |
 | `--encoding` + profile `dateFormat` | Independent: `--encoding` is file encoding, `dateFormat` is value formatting |
 | `--delimiter-*` + `--dat-delimiters` | Specific delimiter flags override the preset for that delimiter only |
 | `--loadfile-only` + `--target-zip-size` | **Conflict**: cannot use both |
 | `--loadfile-only` + `--include-load-file` | **Conflict**: cannot use both |
+| `--loadfile-only` + `--production-set` | **Conflict**: cannot use both |
+| `--production-set` + `--bates-prefix` | **Required**: `--bates-prefix` is mandatory when `--production-set` is used |
+| `--production-zip` + `--production-set` | **Requires**: `--production-zip` cannot be used without `--production-set` |
+| `--volume-size` + `--production-set` | **Requires**: `--volume-size` cannot be used without `--production-set` |
 | `--col-delim`, `--quote-delim`, etc. | Require `--loadfile-only`; use `ascii:N` or `char:C` prefix |
 | `--chaos-mode` | Requires `--loadfile-only` |
 | `--chaos-amount`, `--chaos-types` | Require `--chaos-mode` |
 | `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` |
+| `--benchmark` | **Early exit**: bypasses all file generation and argument validation; runs benchmarks and exits |
+| `--chaos-list` | **Early exit**: bypasses all file generation and argument validation; prints scenarios and exits |
 
 ---
 
@@ -526,8 +532,8 @@ This section clarifies behavior when multiple arguments interact:
 ### FR-018: Standalone Load File Generation
 
 - **REQ-087**: A new optional command-line argument `--loadfile-only` shall be introduced.
-- **REQ-088**: When `--loadfile-only` is specified, the application shall generate load files (DAT or OPT) directly to disk without creating ZIP archives or native files.
-- **REQ-089**: When `--loadfile-only` is specified, the `--type` argument becomes optional and defaults to `pdf` for schema purposes.
+- **REQ-088**: When `--loadfile-only` is specified, the application shall generate Load Files (DAT or OPT) directly to disk without creating Archives or Native Files.
+- **REQ-089**: When `--loadfile-only` or `--production-set` is specified, the `--type` argument becomes optional and defaults to `pdf` for schema purposes.
 - **REQ-090**: The `--loadfile-only` mode shall generate a companion `_properties.json` audit file containing format details, encoding, delimiter configuration, and chaos anomaly manifest.
 - **REQ-091**: The `--loadfile-only` flag shall conflict with `--target-zip-size` and `--include-load-file`. The application must reject these combinations with a clear error message.
 - **REQ-092**: A new optional argument `--eol <CRLF|LF|CR>` shall control the line ending format. Defaults to `CRLF`.
@@ -547,7 +553,7 @@ This section clarifies behavior when multiple arguments interact:
 
 ### FR-019: Deliberate Anomaly Injection
 
-- **REQ-094**: A new optional command-line argument `--chaos-mode` shall be introduced. Requires `--loadfile-only`. Only supported for `dat` and `opt` load file formats.
+- **REQ-094**: A new optional command-line argument `--chaos-mode` shall be introduced. Requires `--loadfile-only`. Only supported for `dat` and `opt` Load File formats.
 - **REQ-095**: A new optional argument `--chaos-amount <N|N%>` shall specify the number or percentage of records to corrupt. Requires `--chaos-mode`. Defaults to 1%.
 - **REQ-096**: A new optional argument `--chaos-types <type1,type2,...>` shall filter specific anomaly types. Requires `--chaos-mode`. When not specified, all types are enabled.
 - **REQ-097**: The following DAT chaos anomaly types shall be supported:
@@ -600,12 +606,12 @@ This section clarifies behavior when multiple arguments interact:
 
 | Scenario Name | Description | Chaos Types | Default Amount | Required Format |
 |---|---|---|---|---|
-| `relativity-import` | Common Relativity ingestion failures | `mixed-delimiters`, `quotes`, `columns` | 3% | DAT |
+| `structured-import-failures` | Common platform ingestion failures | `mixed-delimiters`, `quotes`, `columns` | 3% | DAT |
 | `encoding-nightmare` | Multi-encoding source data | `encoding`, `mixed-delimiters` | 5% | DAT |
 | `broken-boundaries` | OPT document boundary corruption | `opt-boundary`, `opt-pagecount`, `opt-path` | 8% | OPT |
 | `field-overflow` | Unescaped newlines and extra columns | `eol`, `columns` | 2% | DAT |
 | `full-chaos` | All anomaly types at high density | all types enabled | 10% | Any |
-| `nuix-export` | NUIX-to-platform transfer errors | `mixed-delimiters`, `encoding`, `quotes` | 4% | DAT |
+| `transfer-encoding-failures` | Cross-platform transfer errors | `mixed-delimiters`, `encoding`, `quotes` | 4% | DAT |
 
 ---
 
@@ -614,9 +620,9 @@ This section clarifies behavior when multiple arguments interact:
 ### FR-023: Production Set Generator
 
 - **REQ-114**: A new command-line argument `--production-set` shall be introduced to generate structured production deliveries instead of flat mock files.
-- **REQ-115**: When `--production-set` is specified, the application shall create a root production directory (e.g., `PRODUCTION_YYYYMMDD_HHMMSS`) and distribute generated files into `DATA`, `IMAGES`, `NATIVES`, and `TEXT` subdirectories.
-- **REQ-116**: A new command-line argument `--volume-size <number>` shall control the maximum number of files per volume (e.g., `VOL001`, `VOL002`) within the output directories. Defaults to 5,000.
-- **REQ-117**: The generator shall create both a standard DAT load file (metadata) and an OPT load file (image cross-reference) within the `DATA` directory.
+- **REQ-115**: When `--production-set` is specified, the application shall create a root production directory (e.g., `PRODUCTION_YYYYMMDD_HHMMSS`) and distribute generated Native Files into `DATA`, `IMAGES`, `NATIVES`, and `TEXT` subdirectories.
+- **REQ-116**: A new command-line argument `--volume-size <number>` shall control the maximum number of Native Files per Volume (e.g., `VOL001`, `VOL002`) within the output directories. Defaults to 5,000.
+- **REQ-117**: The generator shall create both a standard DAT Load File (metadata) and an OPT Load File (image cross-reference) within the `DATA` directory.
 - **REQ-118**: A `_manifest.json` file shall be generated at the root of the production folder containing top-level properties like volume structure, document counts, and the Bates numbering range.
-- **REQ-119**: A new command-line argument `--production-zip` shall be introduced. When specified alongside `--production-set`, the application shall compress the entire production set folder structure into a single ZIP archive named after the production root directory.
+- **REQ-119**: A new command-line argument `--production-zip` shall be introduced. When specified alongside `--production-set`, the application shall compress the entire production set directory structure into a single Archive named after the production root directory.
 - **REQ-120**: `--production-set` requires `--bates-prefix` to be specified and conflicts with `--loadfile-only`.

--- a/Requirements.md
+++ b/Requirements.md
@@ -380,9 +380,9 @@ Based on the above research, the following requirements apply to the Zipper Load
 | Profile Name | Column Count | Description |
 |-------------|--------------|-------------|
 | `minimal` | 5 | Basic fields: DOCID, FILEPATH, CUSTODIAN, DATECREATED, FILESIZE |
-| `standard` | 25 | Common e-discovery fields |
-| `litigation` | 50 | Full litigation support |
-| `full` | 150 | Maximum field coverage |
+| `standard` | 24 | Common e-discovery fields |
+| `litigation` | 48 | Full litigation support |
+| `full` | 138 | Maximum field coverage |
 
 - **REQ-067**: Custom profile files shall follow a JSON schema with the following structure:
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -99,7 +99,7 @@
 | **Anomaly** | A deliberately injected error in a **Load File** record. Types: delimiter corruption, quote issues, column misalignment, unescaped newlines, encoding errors. Tracked in `_properties.json`. | Error, corruption, defect |
 | **Anomaly Type** | The classification of an **Anomaly**. DAT types: `mixed-delimiters`, `quotes`, `columns`, `eol`, `encoding`. OPT types: `opt-boundary`, `opt-columns`, `opt-pagecount`. | Error type, corruption type |
 | **Chaos Amount** | The number or percentage of **Load File** records to corrupt with **Anomalies**. Specified as a count or percentage (e.g., `5` or `10%`). | Anomaly count, corruption amount |
-| **Chaos Scenario** | A predefined set of **Anomaly Types** and **Chaos Amount** for common ingestion failure patterns (e.g., `relativity-import`, `encoding-nightmare`). | Scenario, preset configuration |
+| **Chaos Scenario** | A predefined set of **Anomaly Types** and **Chaos Amount** for common ingestion failure patterns (e.g., `structured-import-failures`, `encoding-nightmare`). | Scenario, preset configuration |
 | **Audit File** | The `_properties.json` file generated in **Loadfile-Only Mode**, documenting format details, delimiters, and all injected **Anomalies** with line numbers and descriptions. | Metadata file, manifest |
 
 ---

--- a/src/ChaosScenario.cs
+++ b/src/ChaosScenario.cs
@@ -19,8 +19,8 @@ internal static class ChaosScenarios
     private static readonly ChaosScenarioDefinition[] ScenariosArray =
     {
         new(
-            Name: "relativity-import",
-            Description: "Common Relativity ingestion failures: delimiter mismatches, unclosed quotes, column count errors",
+            Name: "structured-import-failures",
+            Description: "Common platform ingestion failures: delimiter mismatches, unclosed quotes, column count errors",
             ChaosTypes: "mixed-delimiters,quotes,columns",
             DefaultAmount: "3%",
             RequiredFormat: LoadFileFormat.Dat),
@@ -49,8 +49,8 @@ internal static class ChaosScenarios
             DefaultAmount: "10%",
             RequiredFormat: null),
         new(
-            Name: "nuix-export",
-            Description: "NUIX-to-platform transfer errors: mixed delimiters, encoding issues, unclosed quotes",
+            Name: "transfer-encoding-failures",
+            Description: "Cross-platform transfer errors: mixed delimiters, encoding issues, unclosed quotes",
             ChaosTypes: "mixed-delimiters,encoding,quotes",
             DefaultAmount: "4%",
             RequiredFormat: LoadFileFormat.Dat),

--- a/src/ChaosScenario.cs
+++ b/src/ChaosScenario.cs
@@ -86,13 +86,13 @@ internal static class ChaosScenarios
     {
         Console.WriteLine("Available Chaos Scenarios:");
         Console.WriteLine();
-        Console.WriteLine($"  {"Name",-25} {"Format",-8} {"Default",-10} Description");
-        Console.WriteLine($"  {new string('-', 25)} {new string('-', 8)} {new string('-', 10)} {new string('-', 50)}");
+        Console.WriteLine($"  {"Name",-28} {"Format",-8} {"Default",-10} Description");
+        Console.WriteLine($"  {new string('-', 28)} {new string('-', 8)} {new string('-', 10)} {new string('-', 50)}");
 
         foreach (var scenario in ScenariosArray)
         {
             var format = scenario.RequiredFormat?.ToString() ?? "Any";
-            Console.WriteLine($"  {scenario.Name,-25} {format,-8} {scenario.DefaultAmount,-10} {scenario.Description}");
+            Console.WriteLine($"  {scenario.Name,-28} {format,-8} {scenario.DefaultAmount,-10} {scenario.Description}");
         }
 
         Console.WriteLine();

--- a/src/FileGenerationRequest.cs
+++ b/src/FileGenerationRequest.cs
@@ -169,7 +169,7 @@ namespace Zipper
         public string? ChaosTypes { get; set; }
 
         /// <summary>
-        /// Gets or sets the named chaos scenario (e.g., "relativity-import", "encoding-nightmare").
+        /// Gets or sets the named chaos scenario (e.g., "structured-import-failures", "encoding-nightmare").
         /// When set, resolves to predefined ChaosTypes and default ChaosAmount.
         /// </summary>
         public string? ChaosScenario { get; set; }

--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -39,7 +39,7 @@ public static class BuiltInProfiles
     };
 
     /// <summary>
-    /// Gets the standard profile (25 columns).
+    /// Gets the standard profile (24 columns).
     /// </summary>
     public static ColumnProfile Standard { get; } = new()
     {
@@ -99,7 +99,7 @@ public static class BuiltInProfiles
     };
 
     /// <summary>
-    /// Gets the litigation profile (50 columns).
+    /// Gets the litigation profile (48 columns).
     /// </summary>
     public static ColumnProfile Litigation { get; } = new()
     {
@@ -128,7 +128,7 @@ public static class BuiltInProfiles
     };
 
     /// <summary>
-    /// Gets the full profile (150 columns).
+    /// Gets the full profile (138 columns).
     /// </summary>
     public static ColumnProfile Full { get; } = new()
     {

--- a/src/Zipper.Tests/ChaosScenarioTests.cs
+++ b/src/Zipper.Tests/ChaosScenarioTests.cs
@@ -229,8 +229,8 @@ public class ChaosScenarioTests
 
             // Should only contain types from the structured-import-failures scenario
             Assert.Subset(
-                new HashSet<string> { "mixed-delimiters", "quotes", "columns" },
-                errorTypes);
+                errorTypes,
+                new HashSet<string> { "mixed-delimiters", "quotes", "columns" });
         }
         finally
         {

--- a/src/Zipper.Tests/ChaosScenarioTests.cs
+++ b/src/Zipper.Tests/ChaosScenarioTests.cs
@@ -30,18 +30,18 @@ public class ChaosScenarioTests
     [Fact]
     public void GetByName_ValidName_ReturnsScenario()
     {
-        var scenario = ChaosScenarios.GetByName("relativity-import");
+        var scenario = ChaosScenarios.GetByName("structured-import-failures");
         Assert.NotNull(scenario);
-        Assert.Equal("relativity-import", scenario.Name);
+        Assert.Equal("structured-import-failures", scenario.Name);
         Assert.Contains("mixed-delimiters", scenario.ChaosTypes);
     }
 
     [Fact]
     public void GetByName_CaseInsensitive_ReturnsScenario()
     {
-        var scenario = ChaosScenarios.GetByName("RELATIVITY-IMPORT");
+        var scenario = ChaosScenarios.GetByName("STRUCTURED-IMPORT-FAILURES");
         Assert.NotNull(scenario);
-        Assert.Equal("relativity-import", scenario.Name);
+        Assert.Equal("structured-import-failures", scenario.Name);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class ChaosScenarioTests
         var (exitCode, stdout, _) = await RunWithCapture(new[] { "--chaos-list" });
         Assert.Equal(0, exitCode);
         Assert.Contains("Available Chaos Scenarios", stdout);
-        Assert.Contains("relativity-import", stdout);
+        Assert.Contains("structured-import-failures", stdout);
         Assert.Contains("full-chaos", stdout);
     }
 
@@ -106,7 +106,7 @@ public class ChaosScenarioTests
             var (exitCode, _, stderr) = await RunWithCapture(new[]
             {
                 "--loadfile-only", "--count", "100", "--output-path", tempPath,
-                "--chaos-scenario", "relativity-import",
+                "--chaos-scenario", "structured-import-failures",
             });
             Assert.Equal(1, exitCode);
             Assert.Contains("--chaos-scenario requires --chaos-mode", stderr);
@@ -129,7 +129,7 @@ public class ChaosScenarioTests
             var (exitCode, _, stderr) = await RunWithCapture(new[]
             {
                 "--loadfile-only", "--count", "100", "--output-path", tempPath,
-                "--chaos-mode", "--chaos-scenario", "relativity-import",
+                "--chaos-mode", "--chaos-scenario", "structured-import-failures",
                 "--chaos-types", "quotes",
             });
             Assert.Equal(1, exitCode);
@@ -200,10 +200,10 @@ public class ChaosScenarioTests
             var (exitCode, stdout, _) = await RunWithCapture(new[]
             {
                 "--loadfile-only", "--count", "1000", "--output-path", tempPath,
-                "--chaos-mode", "--chaos-scenario", "relativity-import", "--seed", "42",
+                "--chaos-mode", "--chaos-scenario", "structured-import-failures", "--seed", "42",
             });
             Assert.Equal(0, exitCode);
-            Assert.Contains("Chaos Scenario: relativity-import", stdout);
+            Assert.Contains("Chaos Scenario: structured-import-failures", stdout);
 
             // Verify load file was created
             var datFiles = Directory.GetFiles(tempPath, "*.dat");
@@ -227,7 +227,7 @@ public class ChaosScenarioTests
                 errorTypes.Add(anomaly.GetProperty("errorType").GetString()!);
             }
 
-            // Should only contain types from the relativity-import scenario
+            // Should only contain types from the structured-import-failures scenario
             Assert.Subset(
                 new HashSet<string> { "mixed-delimiters", "quotes", "columns" },
                 errorTypes);
@@ -250,7 +250,7 @@ public class ChaosScenarioTests
             var (exitCode, _, _) = await RunWithCapture(new[]
             {
                 "--loadfile-only", "--count", "1000", "--output-path", tempPath,
-                "--chaos-mode", "--chaos-scenario", "relativity-import",
+                "--chaos-mode", "--chaos-scenario", "structured-import-failures",
                 "--chaos-amount", "20%", "--seed", "42",
             });
             Assert.Equal(0, exitCode);


### PR DESCRIPTION
This PR aligns documentation and code with the project's ubiquitous language and removes vendor-specific trademarked names.

### Changes

**Ubiquitous Language Alignment (README.md + Requirements.md)**
- Replaced non-canonical terms with domain language: Archive, Native File, Load File, Email, Attachment, Folder, Volume
- Fixed factual inaccuracies:
  - `full` column profile: 127 -> **150** columns
  - `standard` profile example: 24 -> **25** metadata columns
  - `litigation` profile example: 48 -> **50** columns
- `--type` now correctly documented as optional with both `--loadfile-only` and `--production-set`
- `--loadfile-format` in loadfile-only mode reverted to "accepts dat or opt" to match current implementation

**Missing Argument Interactions Added (Requirements.md)**
- `--production-set` + `--loadfile-only` = conflict
- `--production-set` requires `--bates-prefix`
- `--production-zip` / `--volume-size` require `--production-set`
- `--benchmark` and `--chaos-list` early-exit behavior

**Vendor-Neutral Renames (docs + code + tests)**
- `relativity-import` -> `structured-import-failures`
- `nuix-export` -> `transfer-encoding-failures`
- Scenario descriptions updated to generic platform language

### Verification
- All 456 unit tests pass
- All 5 pre-push E2E smoke tests pass
- No breaking changes to public CLI behavior (only scenario names changed)

### Files Changed
- `README.md`
- `Requirements.md`
- `UBIQUITOUS_LANGUAGE.md`
- `src/ChaosScenario.cs`
- `src/FileGenerationRequest.cs`
- `src/Zipper.Tests/ChaosScenarioTests.cs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology across all documentation from "ZIP files" to "Archive" and "Native Files" for consistency and clarity.
  * Clarified CLI flag requirements and interactions, including optional `--type` flag behavior with specific options.
  * Renamed chaos scenarios to better describe their functionality ("structured-import-failures" and "transfer-encoding-failures").
  * Updated feature examples and captions to reflect new terminology.
  * Adjusted column-profile "full" count from 127 to 150.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->