### PR TITLE
fix: CI/CD audit — pre-push hardening, test sync, coverage gaps, reasoning bump

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -72,7 +72,9 @@ case "$(uname -s)" in
             fi
             E2E_RAN=true
         else
-            echo "⚠ tests/run-e2e-basic.sh not found, skipping E2E"
+            echo "❌ tests/run-e2e-basic.sh not found. Push aborted."
+            echo "   The E2E smoke script is required for pre-push checks."
+            exit 1
         fi
         ;;
     MINGW*|MSYS*|CYGWIN*)
@@ -90,7 +92,9 @@ case "$(uname -s)" in
             fi
             E2E_RAN=true
         else
-            echo "⚠ tests/run-e2e-basic.bat not found, skipping E2E"
+            echo "❌ tests/run-e2e-basic.bat not found. Push aborted."
+            echo "   The E2E smoke script is required for pre-push checks."
+            exit 1
         fi
         ;;
 esac
@@ -98,7 +102,8 @@ esac
 echo ""
 if [[ "$E2E_RAN" == "true" ]]; then
     echo "✓ All pre-push checks passed"
+    exit 0
 else
-    echo "⚠ Unit tests passed, but E2E smoke tests were skipped"
+    echo "❌ E2E smoke tests were skipped. Push aborted."
+    exit 1
 fi
-exit 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -42,4 +42,4 @@ jobs:
           review_depth: shallow
           # Faster, cheaper model than kimi-k2.6 (~5-8 min vs 11-19 min).
           review_model: claude-haiku-4-5-20251001
-          reasoning_effort: low
+          reasoning_effort: medium

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,11 +150,11 @@ jobs:
         if: matrix.coverage != true
         run: dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
 
-      - name: Run basic E2E smoke suite
+      - name: Run full E2E suite (same as main CI)
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            ./tests/run-e2e-basic.bat
+            ./tests/run-tests.bat
           else
-            bash ./tests/run-e2e-basic.sh
+            bash ./tests/run-tests.sh
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
     needs: [docs-only, lint]
     if: needs.docs-only.outputs.only_docs != 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -120,10 +120,16 @@ REM %2: Target size in MB
     set "check_text=%~5"
     set "encoding=%~6"
 
-    call :verify_output "%test_dir%" "%expected_count%" "%expected_header_str%" "%file_type%" "%check_text%"
+    call :verify_output "%test_dir%" "%expected_count%" "%expected_header_str%" "%file_type%" "%check_text%" "%encoding%"
 
     for %%F in ("%test_dir%\*.zip") do set "zip_file=%%F"
     for %%F in ("%test_dir%\*.dat") do set "dat_file=%%F"
+    if not defined zip_file (
+        call :print_error "No .zip file found in %test_dir%"
+    )
+    if not defined dat_file (
+        call :print_error "No .dat file found in %test_dir%"
+    )
 
     REM Count attachment files in zip (attachment*.pdf, .jpg, .tiff)
     powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match 'attachment.*\.(pdf|jpg|tiff)$' }).Count; $z.Dispose(); Write-Host $c } catch { Write-Host 0 }" > "%temp%\att_count.txt"

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -112,6 +112,121 @@ REM %2: Target size in MB
     call :print_info "Zip file size is within the expected range."
     goto :eof
 
+:verify_eml_output
+    set "test_dir=%~1"
+    set "expected_count=%~2"
+    set "expected_header_str=%~3"
+    set "file_type=%~4"
+    set "check_text=%~5"
+    set "encoding=%~6"
+
+    call :verify_output "%test_dir%" "%expected_count%" "%expected_header_str%" "%file_type%" "%check_text%"
+
+    for %%F in ("%test_dir%\*.zip") do set "zip_file=%%F"
+    for %%F in ("%test_dir%\*.dat") do set "dat_file=%%F"
+
+    REM Count attachment files in zip (attachment*.pdf, .jpg, .tiff)
+    powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match 'attachment.*\.(pdf|jpg|tiff)$' }).Count; $z.Dispose(); Write-Host $c } catch { Write-Host 0 }" > "%temp%\att_count.txt"
+    set /p attachment_files=<"%temp%\att_count.txt"
+
+    REM Count EML files for expected attachment baseline
+    powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match '\.eml$' }).Count; $z.Dispose(); Write-Host $c } catch { Write-Host 0 }" > "%temp%\eml_count.txt"
+    set /p eml_files=<"%temp%\eml_count.txt"
+
+    set /a min_expected_attachments=eml_files / 10
+    if %attachment_files% lss %min_expected_attachments% (
+        call :print_error "Expected at least %min_expected_attachments% attachment files in ZIP, but found %attachment_files%."
+    )
+    call :print_info "Found %attachment_files% attachment files in ZIP archive (expected at least %min_expected_attachments%)."
+
+    REM Check attachments in .dat file
+    findstr /c:"attachment" "%dat_file%" >nul
+    if errorlevel 1 (
+        call :print_error "No attachments found in .dat file, but they were expected."
+    )
+    call :print_info "Found attachments in .dat file."
+
+    REM Verify attachment text files if text extraction enabled
+    if "%check_text%" == "true" (
+        powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match 'attachment.*\.txt$' }).Count; $z.Dispose(); Write-Host $c } catch { Write-Host 0 }" > "%temp%\att_txt_count.txt"
+        set /p attachment_text_files=<"%temp%\att_txt_count.txt"
+        if %attachment_text_files% lss %min_expected_attachments% (
+            call :print_error "Expected at least %min_expected_attachments% attachment text files, but found %attachment_text_files%."
+        )
+        call :print_info "Found %attachment_text_files% attachment text files in ZIP archive."
+    )
+    goto :eof
+
+:verify_load_file_included
+    set "test_dir=%~1"
+    set "expected_count=%~2"
+    set "expected_header_str=%~3"
+    set "file_type=%~4"
+    set "encoding=%~5"
+
+    call :print_info "Verifying load file included in zip archive (Encoding: %encoding%)"
+
+    for %%F in ("%test_dir%\*.zip") do set "zip_file=%%F"
+    if not defined zip_file (
+        call :print_error "No .zip file found in %test_dir%"
+    )
+
+    REM Verify no separate .dat file in output directory
+    for %%F in ("%test_dir%\*.dat") do set "dat_file=%%F"
+    if defined dat_file (
+        call :print_error "Found separate .dat file in output directory, but --include-load-file was specified"
+    )
+
+    REM Verify .dat file exists in zip
+    powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match '\.dat$' }).Count; $z.Dispose(); exit ($c -eq 1 ? 0 : 1) } catch { exit 1 }"
+    if errorlevel 1 (
+        call :print_error "Expected 1 .dat file in zip archive"
+    )
+    call :print_info ".dat file correctly included in zip archive."
+
+    REM Extract .dat file temporarily to verify content
+    set "temp_extract=%test_dir%\_verify_temp"
+    if exist "%temp_extract%" rmdir /s /q "%temp_extract%"
+    mkdir "%temp_extract%"
+    powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $e = $z.Entries | Where { $_.Name -match '\.dat$' } | Select -First 1; [System.IO.Compression.ZipFileExtensions]::ExtractToFile($e, '%temp_extract%\%e.Name%', $true); $z.Dispose() } catch { exit 1 }"
+
+    for %%F in ("%temp_extract%\*.dat") do set "extracted_dat=%%F"
+    if not defined extracted_dat (
+        call :print_error "Failed to extract .dat file from zip archive"
+    )
+
+    REM Verify line count (+1 for header)
+    powershell -Command "(Get-Content -Path '%extracted_dat%').Count" > "%temp%\line_count2.txt"
+    set /p line_count=<"%temp%\line_count2.txt"
+    set /a expected_line_count=%expected_count% + 1
+    if "%line_count%" neq "%expected_line_count%" (
+        call :print_error "Incorrect line count in .dat file. Expected %expected_line_count%, found %line_count%."
+    )
+    call :print_info ".dat file line count is correct (%line_count%)."
+
+    REM Verify header
+    powershell -Command "(Get-Content -Path '%extracted_dat%' -TotalCount 1)" > "%temp%\header2.txt"
+    set /p header=<"%temp%\header2.txt"
+    for %%H in (%expected_header_str%) do (
+        echo "%header%" | findstr /c:"%%H" >nul
+        if errorlevel 1 (
+            call :print_error "Header validation failed. Expected to find '%%H' in '%header%'."
+        )
+    )
+    call :print_info ".dat file header is correct."
+
+    REM Verify file count in zip (excluding .dat file)
+    powershell -Command "try { $z = [System.IO.Compression.ZipFile]::OpenRead('%zip_file%'); $c = ($z.Entries | Where { $_.Name -match '\.%file_type%$' }).Count; $z.Dispose(); Write-Host $c } catch { Write-Host 0 }" > "%temp%\zip_count2.txt"
+    set /p zip_file_count=<"%temp%\zip_count2.txt"
+    if "%zip_file_count%" neq "%expected_count%" (
+        call :print_error "Incorrect file count in .zip file. Expected %expected_count%, found %zip_file_count%."
+    )
+    call :print_info ".zip file count for .%file_type% is correct (%zip_file_count%)."
+
+    REM Cleanup
+    rmdir /s /q "%temp_extract%"
+    goto :eof
+
 REM --- Test Cases ---
 
 call :print_info "Starting test suite..."
@@ -147,18 +262,18 @@ call :verify_output "%TEST_OUTPUT_DIR%\jpg_encoding" 10 "Control Number,File Pat
 call :print_success "Test Case 2 passed."
 
 REM Test Case 3: TIFF generation with multiple folders and proportional distribution
-call :run_test_case "Test Case 3: TIFF generation" --type tiff --count 100 --output-path "%TEST_OUTPUT_DIR%\tiff_folders" --folders 5 --distribution proportional
-call :verify_output "%TEST_OUTPUT_DIR%\tiff_folders" 100 "Control Number,File Path" "tiff" "false"
+call :run_test_case "Test Case 3: TIFF generation" --type tiff --count 20 --output-path "%TEST_OUTPUT_DIR%\tiff_folders" --folders 5 --distribution proportional
+call :verify_output "%TEST_OUTPUT_DIR%\tiff_folders" 20 "Control Number,File Path" "tiff" "false"
 call :print_success "Test Case 3 passed."
 
 REM Test Case 4: PDF generation with Gaussian distribution
-call :run_test_case "Test Case 4: PDF generation with Gaussian distribution" --type pdf --count 100 --output-path "%TEST_OUTPUT_DIR%\pdf_gaussian" --folders 10 --distribution gaussian
-call :verify_output "%TEST_OUTPUT_DIR%\pdf_gaussian" 100 "Control Number,File Path" "pdf" "false"
+call :run_test_case "Test Case 4: PDF generation with Gaussian distribution" --type pdf --count 20 --output-path "%TEST_OUTPUT_DIR%\pdf_gaussian" --folders 5 --distribution gaussian
+call :verify_output "%TEST_OUTPUT_DIR%\pdf_gaussian" 20 "Control Number,File Path" "pdf" "false"
 call :print_success "Test Case 4 passed."
 
 REM Test Case 5: JPG generation with Exponential distribution
-call :run_test_case "Test Case 5: JPG generation with Exponential distribution" --type jpg --count 100 --output-path "%TEST_OUTPUT_DIR%\jpg_exponential" --folders 10 --distribution exponential
-call :verify_output "%TEST_OUTPUT_DIR%\jpg_exponential" 100 "Control Number,File Path" "jpg" "false"
+call :run_test_case "Test Case 5: JPG generation with Exponential distribution" --type jpg --count 20 --output-path "%TEST_OUTPUT_DIR%\jpg_exponential" --folders 5 --distribution exponential
+call :verify_output "%TEST_OUTPUT_DIR%\jpg_exponential" 20 "Control Number,File Path" "jpg" "false"
 call :print_success "Test Case 5 passed."
 
 REM Test Case 6: PDF generation with metadata
@@ -167,8 +282,8 @@ call :verify_output "%TEST_OUTPUT_DIR%\pdf_metadata" 10 "Control Number,File Pat
 call :print_success "Test Case 6 passed."
 
 REM Test Case 7: All options combined
-call :run_test_case "Test Case 7: All options combined" --type tiff --count 100 --output-path "%TEST_OUTPUT_DIR%\all_options" --folders 20 --encoding ANSI --distribution gaussian --with-metadata
-call :verify_output "%TEST_OUTPUT_DIR%\all_options" 100 "Control Number,File Path,Custodian,Date Sent,Author,File Size" "tiff" "false"
+call :run_test_case "Test Case 7: All options combined" --type tiff --count 15 --output-path "%TEST_OUTPUT_DIR%\all_options" --folders 5 --encoding ANSI --distribution gaussian --with-metadata
+call :verify_output "%TEST_OUTPUT_DIR%\all_options" 15 "Control Number,File Path,Custodian,Date Sent,Author,File Size" "tiff" "false"
 call :print_success "Test Case 7 passed."
 
 REM Test Case 8: With text
@@ -183,7 +298,7 @@ call :print_success "Test Case 9 passed."
 
 REM Test Case 10: EML generation with attachments
 call :run_test_case "Test Case 10: EML generation with attachments" --type eml --count 20 --output-path "%TEST_OUTPUT_DIR%\eml_attachments" --attachment-rate 50
-call :verify_output "%TEST_OUTPUT_DIR%\eml_attachments" 20 "Control Number,File Path,To,From,Subject,Sent Date,Attachment" "eml" "false"
+call :verify_eml_output "%TEST_OUTPUT_DIR%\eml_attachments" 20 "Control Number,File Path,To,From,Subject,Sent Date,Attachment" "eml" "false" "UTF-8"
 call :print_success "Test Case 10 passed."
 
 REM Test Case 11: EML generation with metadata
@@ -220,6 +335,46 @@ REM Test Case 17: Maximum folders edge case (100 folders)
 call :run_test_case "Test Case 17: Maximum folders edge case (100 folders)" --type pdf --count 25 --output-path "%TEST_OUTPUT_DIR%\pdf_max_folders" --folders 10
 call :verify_output "%TEST_OUTPUT_DIR%\pdf_max_folders" 25 "Control Number,File Path" "pdf" "false" "UTF-8"
 call :print_success "Test Case 17 passed."
+
+REM Test Case 18: CSV load file format (non-DAT format inline validation)
+call :run_test_case "Test Case 18: CSV load file format" --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\pdf_csv" --load-file-format csv
+set "csv_dir=%TEST_OUTPUT_DIR%\pdf_csv"
+for %%F in ("%csv_dir%\*.zip") do set "csv_zip=%%F"
+for %%F in ("%csv_dir%\*.csv") do set "csv_file=%%F"
+if not defined csv_zip (
+    call :print_error "Test 18: No .zip file found"
+)
+if not defined csv_file (
+    call :print_error "Test 18: No .csv file found"
+)
+powershell -Command "(Get-Content -Path '%csv_file%' -TotalCount 1)" | findstr /c:"Control Number" >nul
+if errorlevel 1 (
+    call :print_error "Test 18: 'Control Number' column not found in .csv header"
+)
+call :print_success "Test Case 18 passed."
+
+REM Test Case 19: OPT load file format (non-DAT format inline validation)
+call :run_test_case "Test Case 19: OPT load file format" --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\pdf_opt" --load-file-format opt
+set "opt_dir=%TEST_OUTPUT_DIR%\pdf_opt"
+for %%F in ("%opt_dir%\*.zip") do set "opt_zip=%%F"
+for %%F in ("%opt_dir%\*.opt") do set "opt_file=%%F"
+if not defined opt_zip (
+    call :print_error "Test 19: No .zip file found"
+)
+if not defined opt_file (
+    call :print_error "Test 19: No .opt file found"
+)
+REM OPT uses comma delimiter (Opticon 7-column standard)
+findstr "," "%opt_file%" >nul
+if errorlevel 1 (
+    call :print_error "Test 19: No comma delimiter found in .opt file"
+)
+REM OPT has no header row
+powershell -Command "(Get-Content -Path '%opt_file%' -TotalCount 1)" | findstr /c:"Control Number" >nul
+if not errorlevel 1 (
+    call :print_error "Test 19: OPT should not contain header row, found 'Control Number'"
+)
+call :print_success "Test Case 19 passed."
 
 REM --- Cleanup ---
 
@@ -273,10 +428,7 @@ call :print_info "Running artifact handling tests..."
 call .\tests\test-artifact-handling.bat
 call :print_success "Artifact handling tests passed."
 
-REM Test 7-8: Skip workflow validation tests (obsolete - checking old build.yml structure)
-call :print_info "Skipping obsolete workflow validation tests..."
-
-REM Test 9: Cross-platform tests
+REM Test 7: Cross-platform tests
 call :print_info "Running cross-platform tests..."
 call .\tests\test-cross-platform.bat
 call :print_success "Cross-platform tests passed."

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -413,6 +413,43 @@ run_test_case "Test Case 17: Maximum folders edge case (100 folders)" --type pdf
 verify_output "$TEST_OUTPUT_DIR/pdf_max_folders" 25 "Control Number,File Path" "pdf" "false" "UTF-8"
 print_success "Test Case 17 passed."
 
+# Test Case 18: CSV load file format (non-DAT format inline validation)
+run_test_case "Test Case 18: CSV load file format" --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/pdf_csv" --load-file-format csv
+csv_dir="$TEST_OUTPUT_DIR/pdf_csv"
+csv_zip=$(find "$csv_dir" -name "*.zip")
+csv_file=$(find "$csv_dir" -name "*.csv")
+if [[ -z "$csv_zip" ]]; then
+  print_error "Test 18: No .zip file found"
+fi
+if [[ -z "$csv_file" ]]; then
+  print_error "Test 18: No .csv file found"
+fi
+if ! head -n 1 "$csv_file" | grep -q "Control Number"; then
+  print_error "Test 18: 'Control Number' column not found in .csv header"
+fi
+print_success "Test Case 18 passed."
+
+# Test Case 19: OPT load file format (non-DAT format inline validation)
+run_test_case "Test Case 19: OPT load file format" --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/pdf_opt" --load-file-format opt
+opt_dir="$TEST_OUTPUT_DIR/pdf_opt"
+opt_zip=$(find "$opt_dir" -name "*.zip")
+opt_file=$(find "$opt_dir" -name "*.opt")
+if [[ -z "$opt_zip" ]]; then
+  print_error "Test 19: No .zip file found"
+fi
+if [[ -z "$opt_file" ]]; then
+  print_error "Test 19: No .opt file found"
+fi
+# OPT uses comma delimiter (Opticon 7-column standard)
+if ! grep ',' "$opt_file" > /dev/null; then
+  print_error "Test 19: No comma delimiter found in .opt file"
+fi
+# OPT has no header row
+if head -n 1 "$opt_file" | grep -q "Control Number"; then
+  print_error "Test 19: OPT should not contain header row, found 'Control Number'"
+fi
+print_success "Test Case 19 passed."
+
 # --- Cleanup ---
 
 print_info "Cleaning up test output..."
@@ -463,10 +500,7 @@ print_info "Running artifact handling tests..."
 bash ./tests/test-artifact-handling.sh
 print_success "Artifact handling tests passed."
 
-# Test 7-8: Skip workflow validation tests (obsolete - checking old build.yml structure)
-print_info "Skipping obsolete workflow validation tests..."
-
-# Test 9: Cross-platform tests
+# Test 7: Cross-platform tests
 print_info "Running cross-platform tests..."
 bash ./tests/test-cross-platform.sh
 print_success "Cross-platform tests passed."


### PR DESCRIPTION
## Summary
- **pre-push**: missing E2E script now exits 1 instead of silent warn + exit 0
- **build-and-test.yml**: `cancel-in-progress: true` to prevent main queue pileup on rapid merges
- **droid-review.yml**: `reasoning_effort: medium` (was `low`)
- **run-tests.bat synced with run-tests.sh**: test counts aligned (100→20), added missing `:verify_eml_output` and `:verify_load_file_included` functions that were undefined on Windows
- **Inline non-DAT format coverage**: added TC18 (CSV) and TC19 (OPT) to both scripts so basic smoke catches load-file-format regressions without needing standalone suites
- **Dead comments removed**: "obsolete workflow validation tests" from both scripts

## Test plan
- [x] Unit tests pass (463/463)
- [x] Pre-push hook fires and exits correctly (E2E smoke passes)
- [ ] PR CI passes all platforms (full E2E suite)
- [ ] Windows CI specifically validates the new `verify_eml_output` and `verify_load_file_included` functions