### PR TITLE
fix: prevent path traversal, pipeline deadlock, padding corruption, and encoding crash

### DIFF
--- a/src/BatesNumberGenerator.cs
+++ b/src/BatesNumberGenerator.cs
@@ -55,7 +55,8 @@ public static class BatesNumberGenerator
     {
         var number = CalculateValue(config, currentIndex);
         var formattedNumber = number.ToString($"D{config.Digits}");
-        return $"{config.Prefix}{formattedNumber}";
+        var safePrefix = Path.GetFileName(config.Prefix);
+        return $"{safePrefix}{formattedNumber}";
     }
 
     /// <summary>

--- a/src/CommandLineValidator.cs
+++ b/src/CommandLineValidator.cs
@@ -628,6 +628,28 @@ namespace Zipper
                 return false;
             }
 
+            // B2: Validate bates prefix — path traversal prevention (CWE-22)
+            if (!string.IsNullOrEmpty(parsed.BatesPrefix))
+            {
+                if (parsed.BatesPrefix.Contains('/') || parsed.BatesPrefix.Contains('\\'))
+                {
+                    Console.Error.WriteLine("Error: --bates-prefix must not contain path separators.");
+                    return false;
+                }
+
+                if (parsed.BatesPrefix == ".." || parsed.BatesPrefix.Contains("../") || parsed.BatesPrefix.Contains("..\\"))
+                {
+                    Console.Error.WriteLine("Error: --bates-prefix must not contain directory traversal sequences.");
+                    return false;
+                }
+
+                if (!parsed.BatesPrefix.All(c => char.IsLetterOrDigit(c) || c == '_' || c == '-'))
+                {
+                    Console.Error.WriteLine("Error: --bates-prefix must only contain letters, digits, underscores, and hyphens.");
+                    return false;
+                }
+            }
+
             // Validate TIFF pages range
             if (!string.IsNullOrEmpty(parsed.TiffPagesRange))
             {

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -123,26 +123,33 @@ namespace Zipper
             var channel = Channel.CreateUnbounded<FileWorkItem>();
             var writer = channel.Writer;
 
-            Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
-                for (long i = 1; i <= fileCount; i++)
+                try
                 {
-                    var folderNumber = FileDistributionHelper.GetFolderNumber(i, fileCount, folders, distribution);
-                    var folderName = $"folder_{folderNumber:D3}";
-                    var fileName = $"{i:D8}.{fileType}";
-                    var filePathInZip = $"{folderName}/{fileName}";
-
-                    await writer.WriteAsync(new FileWorkItem
+                    for (long i = 1; i <= fileCount; i++)
                     {
-                        Index = i,
-                        FolderNumber = folderNumber,
-                        FolderName = folderName,
-                        FileName = fileName,
-                        FilePathInZip = filePathInZip,
-                    });
-                }
+                        var folderNumber = FileDistributionHelper.GetFolderNumber(i, fileCount, folders, distribution);
+                        var folderName = $"folder_{folderNumber:D3}";
+                        var fileName = $"{i:D8}.{fileType}";
+                        var filePathInZip = $"{folderName}/{fileName}";
 
-                writer.Complete();
+                        await writer.WriteAsync(new FileWorkItem
+                        {
+                            Index = i,
+                            FolderNumber = folderNumber,
+                            FolderName = folderName,
+                            FileName = fileName,
+                            FilePathInZip = filePathInZip,
+                        });
+                    }
+
+                    writer.Complete();
+                }
+                catch (Exception ex)
+                {
+                    writer.Complete(ex);
+                }
             });
 
             return channel.Reader;
@@ -214,15 +221,16 @@ namespace Zipper
                 fileContent = placeholderContent;
             }
 
-            var totalSize = fileContent.Length + paddingPerFile;
+            var effectivePadding = paddingPerFile;
 
             // Cap the total size to the maximum allowed byte array size (2GB - 56 bytes) to prevent OutOfMemoryException
             const int maxByteArraySize = 2147483591;
-            if (totalSize > maxByteArraySize)
+            if (fileContent.Length + effectivePadding > maxByteArraySize)
             {
-                totalSize = maxByteArraySize;
-                paddingPerFile = totalSize - fileContent.Length;
+                effectivePadding = maxByteArraySize - fileContent.Length;
             }
+
+            var totalSize = fileContent.Length + effectivePadding;
 
             var memoryOwner = this.memoryPoolManager.Rent((int)Math.Min(totalSize, PerformanceConstants.MaxPoolSize));
             if (memoryOwner == null)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,6 +6,8 @@ namespace Zipper
     {
         public static async Task<int> Main(string[] args)
         {
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
             var version = System.Reflection.Assembly.GetEntryAssembly()?.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
             Console.WriteLine($"Zipper v{version} https://github.com/dwojtaszek/zipper/");
             Console.WriteLine();

--- a/src/Zipper.Tests/CommandLineValidatorTests.cs
+++ b/src/Zipper.Tests/CommandLineValidatorTests.cs
@@ -792,5 +792,88 @@ namespace Zipper
             Assert.Equal("5%", result.ChaosAmount);
             Assert.Equal("quotes,columns", result.ChaosTypes);
         }
+
+        // === B2: Bates prefix path traversal prevention ===
+        [Theory]
+        [InlineData("../../../")]
+        [InlineData("..\\..\\")]
+        [InlineData("foo/bar")]
+        [InlineData("foo\\bar")]
+        [InlineData("evil/path")]
+        public void ValidateAndParseArguments_WithBatesPrefixContainingPathSeparator_ReturnsNull(string maliciousPrefix)
+        {
+            var args = new[]
+            {
+                "--production-set", "--bates-prefix", maliciousPrefix,
+                "--count", "10", "--output-path", this.tempDir,
+            };
+
+            var result = CommandLineValidator.ValidateAndParseArguments(args);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ValidateAndParseArguments_WithBatesPrefixContainingDotDot_ReturnsNull()
+        {
+            var args = new[]
+            {
+                "--production-set", "--bates-prefix", "..",
+                "--count", "10", "--output-path", this.tempDir,
+            };
+
+            var result = CommandLineValidator.ValidateAndParseArguments(args);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ValidateAndParseArguments_WithBatesPrefixContainingSpecialChars_ReturnsNull()
+        {
+            var args = new[]
+            {
+                "--production-set", "--bates-prefix", "hello world!@#",
+                "--count", "10", "--output-path", this.tempDir,
+            };
+
+            var result = CommandLineValidator.ValidateAndParseArguments(args);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ValidateAndParseArguments_WithValidBatesPrefix_ReturnsValidRequest()
+        {
+            var args = new[]
+            {
+                "--production-set", "--bates-prefix", "CLIENT001",
+                "--count", "10", "--output-path", this.tempDir,
+            };
+
+            var result = CommandLineValidator.ValidateAndParseArguments(args);
+
+            Assert.NotNull(result);
+            Assert.Equal("CLIENT001", result!.BatesConfig?.Prefix);
+        }
+
+        [Theory]
+        [InlineData("CLIENT_001")]
+        [InlineData("PREFIX-ABC")]
+        [InlineData("Doc_v1")]
+        [InlineData("ABC")]
+        [InlineData("123")]
+        public void ValidateAndParseArguments_WithValidBatesPrefixVariations_ReturnsValidRequest(string validPrefix)
+        {
+            var args = new[]
+            {
+                "--production-set", "--bates-prefix", validPrefix,
+                "--count", "10", "--output-path", this.tempDir,
+            };
+
+            var result = CommandLineValidator.ValidateAndParseArguments(args);
+
+            Assert.NotNull(result);
+            Assert.Equal(validPrefix, result!.BatesConfig?.Prefix);
+        }
     }
 }

--- a/src/Zipper.Tests/EncodingHelperTests.cs
+++ b/src/Zipper.Tests/EncodingHelperTests.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using Xunit;
+
+namespace Zipper
+{
+    public class EncodingHelperTests
+    {
+        public EncodingHelperTests()
+        {
+            // Required for ANSI/Windows-1252 encoding lookups.
+            // In production, this is called in Program.Main.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
+        [Fact]
+        public void GetEncoding_WithUtf8_ReturnsUtf8Encoding()
+        {
+            var encoding = EncodingHelper.GetEncoding("UTF-8");
+            Assert.NotNull(encoding);
+            Assert.Equal("utf-8", encoding!.BodyName);
+        }
+
+        [Fact]
+        public void GetEncoding_WithAnsi_ReturnsWindows1252Encoding()
+        {
+            var encoding = EncodingHelper.GetEncoding("ANSI");
+            Assert.NotNull(encoding);
+            Assert.Equal(1252, encoding!.CodePage);
+        }
+
+        [Fact]
+        public void GetEncoding_WithWindows1252_ReturnsWindows1252Encoding()
+        {
+            var encoding = EncodingHelper.GetEncoding("Windows-1252");
+            Assert.NotNull(encoding);
+            Assert.Equal(1252, encoding!.CodePage);
+        }
+
+        [Fact]
+        public void GetEncoding_WithUtf16_ReturnsUnicodeEncoding()
+        {
+            var encoding = EncodingHelper.GetEncoding("UTF-16");
+            Assert.NotNull(encoding);
+            Assert.Equal("Unicode", encoding!.EncodingName);
+        }
+
+        [Fact]
+        public void GetEncoding_WithNull_ReturnsNull()
+        {
+            var encoding = EncodingHelper.GetEncoding(null);
+            Assert.Null(encoding);
+        }
+
+        [Fact]
+        public void GetEncoding_WithEmptyString_ReturnsNull()
+        {
+            var encoding = EncodingHelper.GetEncoding(string.Empty);
+            Assert.Null(encoding);
+        }
+
+        [Fact]
+        public void GetEncoding_WithUnknownName_ReturnsNull()
+        {
+            var encoding = EncodingHelper.GetEncoding("NONEXISTENT");
+            Assert.Null(encoding);
+        }
+
+        [Fact]
+        public void GetEncodingOrDefault_WithValidName_ReturnsEncoding()
+        {
+            var encoding = EncodingHelper.GetEncodingOrDefault("ANSI");
+            Assert.NotNull(encoding);
+            Assert.Equal(1252, encoding!.CodePage);
+        }
+
+        [Fact]
+        public void GetEncodingOrDefault_WithUnknownName_ReturnsUtf8Fallback()
+        {
+            var encoding = EncodingHelper.GetEncodingOrDefault("UNKNOWN");
+            Assert.NotNull(encoding);
+            Assert.Equal("utf-8", encoding!.BodyName);
+        }
+
+        [Fact]
+        public void GetEncoding_WithAscii_ReturnsAsciiEncoding()
+        {
+            var encoding = EncodingHelper.GetEncoding("ASCII");
+            Assert.NotNull(encoding);
+            Assert.Equal("us-ascii", encoding!.BodyName);
+        }
+    }
+}

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -126,5 +126,80 @@ namespace Zipper
                 }
             }
         }
+
+        // === B3: Padding truncation must not corrupt subsequent files ===
+        [Fact]
+        public async Task GenerateFilesAsync_MultipleFilesWithPadding_AllFilesGenerated()
+        {
+            // B3 regression: padding per file must apply independently.
+            // Previous code mutated shared paddingPerFile var on cap.
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                var generator = new ParallelFileGenerator();
+                var result = await generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = outputPath,
+                    FileCount = 25,
+                    FileType = "pdf",
+                    Folders = 2,
+                    Concurrency = 4,
+                    TargetZipSize = 2_000_000,
+                });
+
+                Assert.Equal(25, result.FilesGenerated);
+                Assert.True(File.Exists(result.ZipFilePath));
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(result.ZipFilePath);
+                Assert.Equal(25, archive.Entries.Count);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        // === B1: Pipeline must not deadlock on errors ===
+        [Fact]
+        public async Task GenerateFilesAsync_CompletesWithinTimeout()
+        {
+            // B1 regression: fire-and-forget Task.Run in CreateWorkChannel could deadlock
+            // if an exception prevented writer.Complete(). Verify pipeline always completes.
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                var generator = new ParallelFileGenerator();
+                var task = generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = outputPath,
+                    FileCount = 5,
+                    FileType = "pdf",
+                    Folders = 1,
+                    Concurrency = 2,
+                });
+
+                var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(30))) == task;
+                Assert.True(completed, "GenerateFilesAsync did not complete within 30s timeout (possible deadlock)");
+
+                var result = await task;
+                Assert.Equal(5, result.FilesGenerated);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **B1**: Fix pipeline deadlock when channel population throws — wrap in try/catch, complete channel with exception
- **B2**: Fix path traversal via `--bates-prefix` (CWE-22) — validate prefix chars, restrict to `[A-Za-z0-9_-]`, add `Path.GetFileName` defense-in-depth
- **B3**: Fix padding truncation that mutated shared loop variable, corrupting subsequent files — use local `effectivePadding`
- **B4**: Fix `--encoding ANSI` crash — register `CodePagesEncodingProvider` in `Program.Main`

## Test plan
- [x] 488 unit tests pass (7 new tests: 10x EncodingHelper, 6x bates-prefix validation, 1x padding, 1x pipeline timeout)
- [x] 5/5 E2E smoke tests pass (pre-push hook)
- [x] Build succeeds with 0 warnings (TreatWarningsAsErrors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Bates prefix arguments—now rejects invalid characters and path separators.
  * Added support for legacy/non-UTF-8 encodings.

* **Bug Fixes**
  * Bates prefix sanitization now safely handles path-like inputs.
  * Improved error handling in file generation pipeline.

* **Tests**
  * Added comprehensive test coverage for encoding support and file generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->