### PR TITLE
fix: add test coverage for T3-T14 and improve analyzer reliability checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -130,6 +130,21 @@ dotnet_diagnostic.CS1591.severity = none
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
 
+# IDE0051: Remove unused private members (dead code prevention)
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0052: Remove unread private members (dead code prevention)
+dotnet_diagnostic.IDE0052.severity = warning
+
+# CA1062: Validate arguments of public methods (null ref prevention)
+dotnet_diagnostic.CA1062.severity = warning
+
+# CA1854: Prefer Dictionary.TryGetValue over ContainsKey + indexer (correctness)
+dotnet_diagnostic.CA1854.severity = warning
+
+# CA1861: Avoid constant arrays as arguments (performance)
+dotnet_diagnostic.CA1861.severity = suggestion
+
 # SA1200: Using directives should be placed correctly
 dotnet_diagnostic.SA1200.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -189,6 +189,9 @@ dotnet_diagnostic.SA1648.severity = none
 dotnet_diagnostic.SA1649.severity = none
 dotnet_diagnostic.SA1650.severity = none
 
+# RCS1139: Add summary element to documentation comment (disabled - codebase uses /// <remarks> without <summary>)
+dotnet_diagnostic.RCS1139.severity = none
+
 # SA1402: File may only contain single type (disabled - multiple types per file is OK)
 dotnet_diagnostic.SA1402.severity = none
 

--- a/.factory/skills/caveman
+++ b/.factory/skills/caveman
@@ -1,0 +1,1 @@
+../../.agents/skills/caveman

--- a/.factory/skills/diagnose
+++ b/.factory/skills/diagnose
@@ -1,0 +1,1 @@
+../../.agents/skills/diagnose

--- a/.factory/skills/grill-me
+++ b/.factory/skills/grill-me
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-me

--- a/.factory/skills/grill-with-docs
+++ b/.factory/skills/grill-with-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-with-docs

--- a/.factory/skills/improve-codebase-architecture
+++ b/.factory/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/.factory/skills/setup-matt-pocock-skills
+++ b/.factory/skills/setup-matt-pocock-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/setup-matt-pocock-skills

--- a/.factory/skills/tdd
+++ b/.factory/skills/tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/tdd

--- a/.factory/skills/to-issues
+++ b/.factory/skills/to-issues
@@ -1,0 +1,1 @@
+../../.agents/skills/to-issues

--- a/.factory/skills/to-prd
+++ b/.factory/skills/to-prd
@@ -1,0 +1,1 @@
+../../.agents/skills/to-prd

--- a/.factory/skills/triage
+++ b/.factory/skills/triage
@@ -1,0 +1,1 @@
+../../.agents/skills/triage

--- a/.factory/skills/write-a-skill
+++ b/.factory/skills/write-a-skill
@@ -1,0 +1,1 @@
+../../.agents/skills/write-a-skill

--- a/.factory/skills/zoom-out
+++ b/.factory/skills/zoom-out
@@ -1,0 +1,1 @@
+../../.agents/skills/zoom-out

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ in-memoria.db
 # gemini-cli settings
 .gemini/
 
+# AI agent directories
+.factory/
+.qwen/
+
 # GitHub App credentials
 gha-creds-*.jsonspec-kit/
 

--- a/.qwen/skills/caveman
+++ b/.qwen/skills/caveman
@@ -1,0 +1,1 @@
+../../.agents/skills/caveman

--- a/.qwen/skills/diagnose
+++ b/.qwen/skills/diagnose
@@ -1,0 +1,1 @@
+../../.agents/skills/diagnose

--- a/.qwen/skills/grill-me
+++ b/.qwen/skills/grill-me
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-me

--- a/.qwen/skills/grill-with-docs
+++ b/.qwen/skills/grill-with-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-with-docs

--- a/.qwen/skills/improve-codebase-architecture
+++ b/.qwen/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/.qwen/skills/setup-matt-pocock-skills
+++ b/.qwen/skills/setup-matt-pocock-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/setup-matt-pocock-skills

--- a/.qwen/skills/tdd
+++ b/.qwen/skills/tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/tdd

--- a/.qwen/skills/to-issues
+++ b/.qwen/skills/to-issues
@@ -1,0 +1,1 @@
+../../.agents/skills/to-issues

--- a/.qwen/skills/to-prd
+++ b/.qwen/skills/to-prd
@@ -1,0 +1,1 @@
+../../.agents/skills/to-prd

--- a/.qwen/skills/triage
+++ b/.qwen/skills/triage
@@ -1,0 +1,1 @@
+../../.agents/skills/triage

--- a/.qwen/skills/write-a-skill
+++ b/.qwen/skills/write-a-skill
@@ -1,0 +1,1 @@
+../../.agents/skills/write-a-skill

--- a/.qwen/skills/zoom-out
+++ b/.qwen/skills/zoom-out
@@ -1,0 +1,1 @@
+../../.agents/skills/zoom-out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,11 @@ dotnet test src/Zipper.Tests/Zipper.Tests.csproj
 # Single test class
 dotnet test src/Zipper.Tests/Zipper.Tests.csproj --filter "FullyQualifiedName~ClassName"
 
-# Lint (CI runs this - fix with: dotnet format)
+# Lint (runs automatically before every commit via pre-commit hook)
 dotnet format --verify-no-changes
+
+# Quick lint (run after every code change before staging)
+dotnet format --verify-no-changes src/
 
 # E2E Tests (must pass before push - enforced by git hooks)
 ./tests/run-tests.sh   # Linux/macOS
@@ -66,8 +69,12 @@ Tackle in this order: **Blockers** → **Critical** → **High** → **Test Cove
 2. `git checkout -b fix/ISSUE-NNN-short-desc`
 3. Read the issue body for file paths, line numbers, and fix guidance
 4. Write a failing test first (TDD), then implement the fix
-5. Run unit tests, E2E tests, lint
+5. **Run lint + tests after EVERY code change:**
+   - `dotnet format --verify-no-changes src/` — quick lint check
+   - `dotnet test src/Zipper.Tests/Zipper.Tests.csproj --no-build` — quick test (if build hasn't changed)
+   - `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` — full test + build (after structural changes)
 6. Commit and create PR
+7. **Monitor CI after PR:** After creating or updating a PR, monitor GitHub CI status until all checks pass. If CI fails, diagnose and fix before requesting review.
 
 ## Requirement-Driven Changes
 
@@ -90,6 +97,8 @@ Tackle in this order: **Blockers** → **Critical** → **High** → **Test Cove
 > - [ ] Argument interactions updated in both README.md and Requirements.md Section 10
 
 **Test Location:** All unit tests go in `src/Zipper.Tests/` (NOT the root `Zipper.Tests/` which is obsolete).
+
+**Pre-commit Hook:** The `.git/hooks/pre-commit` hook runs `dotnet format --verify-no-changes`, auto-formats staged C# files, then runs unit tests on every `git commit`. To bypass: `git commit --no-verify`.
 
 **E2E Tests:** Must verify actual output (file counts, headers, content). All new E2E tests need both `.sh` and `.bat` implementations.
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "skills": {
+    "caveman": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/caveman/SKILL.md",
+      "computedHash": "934433479903febc585bf6deb5f0cebc63137e3f86b7babe0aab1ecb94d6d7a4"
+    },
+    "diagnose": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/diagnose/SKILL.md",
+      "computedHash": "15939a26f86edec2d4862042b8564e5a062cb81d04e047a0cea6305c8830b5f5"
+    },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "31a5b1ae116558bf7d3f633f442835f54bd7645923d4f45c7823e52a97317666"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+    },
+    "setup-matt-pocock-skills": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
+      "computedHash": "3a32f8f1ed8160c9d286a2aabe88ee9b884c6f3f88a7a6c47b7d5d552c959587"
+    },
+    "tdd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/tdd/SKILL.md",
+      "computedHash": "15a7b5e36383ebadb2dec5e586679e55e9663d292da418926b8da6fc0ef27d84"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-issues/SKILL.md",
+      "computedHash": "73a91f30784523aa59ec9b02769576ebfc738e2cd5ad8f6441076031f0a5d5ac"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-prd/SKILL.md",
+      "computedHash": "fd8c259f9c44eff08e29a1a2fc71a806a3568d279a55387a361f78620b10f2aa"
+    },
+    "triage": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/triage/SKILL.md",
+      "computedHash": "2b6efb6da12d92551772fcc04acf331f4e0e6f7bd9d4cb23ce0b301e0b128feb"
+    },
+    "write-a-skill": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/write-a-skill/SKILL.md",
+      "computedHash": "b44d8aab2ead83c716e01af4c9a24ccc4575ce70ad58ec4f1749fb88c9cc82ba"
+    },
+    "zoom-out": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/zoom-out/SKILL.md",
+      "computedHash": "8357aeaece3b709c442eab67e64b86844e05e2f1ea95b109565eba50b6def36e"
+    }
+  }
+}

--- a/src/BatesNumberGenerator.cs
+++ b/src/BatesNumberGenerator.cs
@@ -53,6 +53,7 @@ public static class BatesNumberGenerator
     /// <returns>Formatted Bates number (e.g., "CLIENT00100000001").</returns>
     public static string Generate(BatesNumberConfig config, long currentIndex)
     {
+        ArgumentNullException.ThrowIfNull(config);
         var number = CalculateValue(config, currentIndex);
         var formattedNumber = number.ToString($"D{config.Digits}");
         var safePrefix = Path.GetFileName(config.Prefix);
@@ -67,6 +68,7 @@ public static class BatesNumberGenerator
     /// <returns>Formatted number only (e.g., "00000001").</returns>
     public static string GenerateWithoutPrefix(BatesNumberConfig config, long currentIndex)
     {
+        ArgumentNullException.ThrowIfNull(config);
         return CalculateValue(config, currentIndex).ToString($"D{config.Digits}");
     }
 }

--- a/src/EmailBuilder.cs
+++ b/src/EmailBuilder.cs
@@ -71,6 +71,7 @@ namespace Zipper
         /// </summary>
         public static void BuildEmailToWriter(TextWriter writer, EmailTemplate template, AttachmentInfo? attachment = null)
         {
+            ArgumentNullException.ThrowIfNull(writer);
             if (template == null)
             {
                 throw new ArgumentNullException(nameof(template));

--- a/src/EmailTemplateSystem.cs
+++ b/src/EmailTemplateSystem.cs
@@ -58,6 +58,7 @@ namespace Zipper
         /// <returns>EmailTemplate tailored to the context.</returns>
         public static EmailTemplate GetContextualTemplate(EmailContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
             var baseTemplate = GetContextualBaseTemplate(context);
 
             return new EmailTemplate
@@ -85,6 +86,7 @@ namespace Zipper
 
         public static string GenerateEmailAddress(int index, string type)
         {
+            ArgumentNullException.ThrowIfNull(type);
             var domain = EmailDomains[index % EmailDomains.Length];
             var userType = type.ToLowerInvariant();
 

--- a/src/EmlGenerationService.cs
+++ b/src/EmlGenerationService.cs
@@ -55,6 +55,8 @@ namespace Zipper
         /// <returns>EML generation result with content and optional attachment.</returns>
         public static EmlGenerationResult GenerateEmlContent(EmlGenerationConfig config)
         {
+            ArgumentNullException.ThrowIfNull(config);
+
             // Get a realistic email template
             var emailTemplate = EmailTemplateSystem.GetRandomTemplate(
                 config.FileIndex,

--- a/src/LoadFileGenerator.cs
+++ b/src/LoadFileGenerator.cs
@@ -28,12 +28,12 @@ namespace Zipper
             var headerBuilder = new StringBuilder();
             headerBuilder.Append($"{quote}Control Number{quote}{colDelim}{quote}File Path{quote}");
 
-            if (request.WithMetadata || request.FileType.ToLowerInvariant() == "eml")
+            if (request.WithMetadata || string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 headerBuilder.Append($"{colDelim}{quote}Custodian{quote}{colDelim}{quote}Date Sent{quote}{colDelim}{quote}Author{quote}{colDelim}{quote}File Size{quote}");
             }
 
-            if (request.FileType.ToLowerInvariant() == "eml")
+            if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 headerBuilder.Append($"{colDelim}{quote}To{quote}{colDelim}{quote}From{quote}{colDelim}{quote}Subject{quote}{colDelim}{quote}Sent Date{quote}{colDelim}{quote}Attachment{quote}");
             }
@@ -45,7 +45,7 @@ namespace Zipper
             }
 
             // Add Page Count column for TIFF with page range
-            if (request.FileType.ToLowerInvariant() == "tiff" && request.TiffPageRange.HasValue)
+            if (string.Equals(request.FileType, "tiff", StringComparison.OrdinalIgnoreCase) && request.TiffPageRange.HasValue)
             {
                 headerBuilder.Append($"{colDelim}{quote}Page Count{quote}");
             }
@@ -104,14 +104,14 @@ namespace Zipper
             lineBuilder.Append($"{quote}{docId}{quote}{colDelim}{quote}{SanitizeField(workItem.FilePathInZip, request.NewlineDelimiter)}{quote}");
 
             // Add metadata columns if requested
-            if (request.WithMetadata || request.FileType.ToLowerInvariant() == "eml")
+            if (request.WithMetadata || string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 var metadataColumns = GetMetadataColumns(workItem, fileData, request, colDelim, quote, random, now);
                 lineBuilder.Append(metadataColumns);
             }
 
             // Add EML-specific columns if needed
-            if (request.FileType.ToLowerInvariant() == "eml")
+            if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 var emlColumns = GetEmlColumns(workItem, fileData, request, colDelim, quote, random, now);
                 lineBuilder.Append(emlColumns);
@@ -125,7 +125,7 @@ namespace Zipper
             }
 
             // Add Page Count column for TIFF with page range
-            if (request.FileType.ToLowerInvariant() == "tiff" && request.TiffPageRange.HasValue)
+            if (string.Equals(request.FileType, "tiff", StringComparison.OrdinalIgnoreCase) && request.TiffPageRange.HasValue)
             {
                 lineBuilder.Append($"{colDelim}{quote}{fileData.PageCount}{quote}");
             }

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Threading.Channels;
 
@@ -19,6 +20,8 @@ namespace Zipper
 
         public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request)
         {
+            ArgumentNullException.ThrowIfNull(request);
+
             // Clone to avoid mutating the caller's request object
             request = request.Clone();
 
@@ -39,7 +42,7 @@ namespace Zipper
 
                 // For EML files, use sequential processing to avoid ZIP entry creation conflicts
                 // when attachments and text extraction are enabled
-                if (request.FileType.ToLowerInvariant() == "eml" && (request.WithText || request.AttachmentRate > 0))
+                if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase) && (request.WithText || request.AttachmentRate > 0))
                 {
                     request.Concurrency = 1; // Force sequential processing
                 }
@@ -55,7 +58,7 @@ namespace Zipper
 
                 // Allow Office formats and EML to have empty placeholder content (generated dynamically)
                 if (placeholderContent.Length == 0 &&
-                    request.FileType.ToLowerInvariant() != "eml" &&
+                    !string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase) &&
                     !OfficeFileGenerator.IsOfficeFormat(request.FileType))
                 {
                     throw new InvalidOperationException($"Unknown file type: {request.FileType}");
@@ -205,7 +208,7 @@ namespace Zipper
             int pageCount = 1;
             EmailTemplate? emailTemplate = null;
 
-            if (request.FileType.ToLowerInvariant() == "eml")
+            if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 // Use the new EmlGenerationService for clean separation of concerns
                 var emlResult = EmlGenerationService.GenerateEmlContent(
@@ -221,7 +224,7 @@ namespace Zipper
                 // Generate Office format documents
                 fileContent = OfficeFileGenerator.GenerateContent(request.FileType, workItem);
             }
-            else if (request.FileType.ToLowerInvariant() == "tiff" && request.TiffPageRange.HasValue)
+            else if (string.Equals(request.FileType, "tiff", StringComparison.OrdinalIgnoreCase) && request.TiffPageRange.HasValue)
             {
                 // Generate multipage TIFF
                 pageCount = TiffMultiPageGenerator.GetPageCount(request.TiffPageRange, request.Seed, workItem.Index);
@@ -243,7 +246,39 @@ namespace Zipper
 
             var totalSize = fileContent.Length + effectivePadding;
 
-            var memoryOwner = this.memoryPoolManager.Rent((int)Math.Min(totalSize, PerformanceConstants.MaxPoolSize))!;
+            var memoryOwner = this.memoryPoolManager.Rent((int)Math.Min(totalSize, PerformanceConstants.MaxPoolSize));
+
+            if (memoryOwner == null)
+            {
+                var data = new byte[(int)totalSize];
+                Buffer.BlockCopy(fileContent, 0, data, 0, fileContent.Length);
+
+                if (paddingPerFile > 0)
+                {
+                    var padding = new byte[Math.Min(paddingPerFile, 1024 * 1024)];
+                    RandomNumberGenerator.Fill(padding);
+
+                    int offset = fileContent.Length;
+                    long remaining = paddingPerFile;
+                    while (remaining > 0)
+                    {
+                        int toCopy = (int)Math.Min(remaining, padding.Length);
+                        Buffer.BlockCopy(padding, 0, data, offset, toCopy);
+                        offset += toCopy;
+                        remaining -= toCopy;
+                    }
+                }
+
+                return new FileData
+                {
+                    WorkItem = workItem,
+                    Data = data,
+                    DataLength = (int)totalSize,
+                    Attachment = attachment,
+                    PageCount = pageCount,
+                    EmailTemplate = emailTemplate,
+                };
+            }
 
             fileContent.CopyTo(memoryOwner.Memory.Span);
 
@@ -307,7 +342,7 @@ namespace Zipper
         {
             if (ex is not null)
             {
-                throw ex;
+                ExceptionDispatchInfo.Capture(ex).Throw();
             }
         }
     }

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -8,23 +8,25 @@ namespace Zipper
     /// </summary>
     public static class PerformanceBenchmarkRunner
     {
-        public static async Task RunBenchmarks()
+        public static async Task RunBenchmarks(TextWriter? writer = null)
         {
-            Console.WriteLine("=== Performance Benchmark Suite ===");
-            Console.WriteLine();
+            writer ??= Console.Out;
 
-            await BenchmarkParallelVsSequential();
-            await BenchmarkMemoryPooling();
-            await BenchmarkScalability();
-            await BenchmarkAllocation();
+            await writer.WriteLineAsync("=== Performance Benchmark Suite ===");
+            await writer.WriteLineAsync();
 
-            Console.WriteLine("=== Benchmark Suite Complete ===");
+            await BenchmarkParallelVsSequential(writer);
+            await BenchmarkMemoryPooling(writer);
+            await BenchmarkScalability(writer);
+            await BenchmarkAllocation(writer);
+
+            await writer.WriteLineAsync("=== Benchmark Suite Complete ===");
         }
 
-        private static async Task BenchmarkAllocation()
+        private static async Task BenchmarkAllocation(TextWriter writer)
         {
-            Console.WriteLine("4. Allocation Impact");
-            Console.WriteLine("===================");
+            await writer.WriteLineAsync("4. Allocation Impact");
+            await writer.WriteLineAsync("===================");
 
             const int fileCount = 1000;
 #pragma warning disable S5443 // Using temp path is safe for local benchmark execution
@@ -59,22 +61,22 @@ namespace Zipper
                 var totalAllocated = allocatedAfter - allocatedBefore;
                 var bytesPerFile = totalAllocated / fileCount;
 
-                Console.WriteLine($"  Files Generated: {fileCount}");
-                Console.WriteLine($"  Total Allocated: {totalAllocated:N0} bytes");
-                Console.WriteLine($"  Bytes Per File:  {bytesPerFile:N0} bytes/file");
+                await writer.WriteLineAsync($"  Files Generated: {fileCount}");
+                await writer.WriteLineAsync($"  Total Allocated: {totalAllocated:N0} bytes");
+                await writer.WriteLineAsync($"  Bytes Per File:  {bytesPerFile:N0} bytes/file");
             }
             finally
             {
                 CleanupDirectory(outputPath);
             }
 
-            Console.WriteLine();
+            await writer.WriteLineAsync();
         }
 
-        private static async Task BenchmarkParallelVsSequential()
+        private static async Task BenchmarkParallelVsSequential(TextWriter writer)
         {
-            Console.WriteLine("1. Parallel vs Sequential Generation");
-            Console.WriteLine("=====================================");
+            await writer.WriteLineAsync("1. Parallel vs Sequential Generation");
+            await writer.WriteLineAsync("=====================================");
 
             const int fileCount = 500;
 #pragma warning disable S5443 // Using temp path is safe for local benchmark execution
@@ -111,10 +113,10 @@ namespace Zipper
 
                 var speedup = (double)sequentialTime / parallelTime;
 
-                Console.WriteLine($"  Sequential: {sequentialTime}ms");
-                Console.WriteLine($"  Parallel:   {parallelTime}ms");
-                Console.WriteLine($"  Speedup:    {speedup:F2}x");
-                Console.WriteLine($"  Status:     {(speedup >= 1.0 ? "✓ PASS" : "✗ FAIL")}");
+                await writer.WriteLineAsync($"  Sequential: {sequentialTime}ms");
+                await writer.WriteLineAsync($"  Parallel:   {parallelTime}ms");
+                await writer.WriteLineAsync($"  Speedup:    {speedup:F2}x");
+                await writer.WriteLineAsync($"  Status:     {(speedup >= 1.0 ? "✓ PASS" : "✗ FAIL")}");
             }
             finally
             {
@@ -122,13 +124,13 @@ namespace Zipper
                 CleanupDirectory(outputPath2);
             }
 
-            Console.WriteLine();
+            await writer.WriteLineAsync();
         }
 
-        private static Task BenchmarkMemoryPooling()
+        private static async Task BenchmarkMemoryPooling(TextWriter writer)
         {
-            Console.WriteLine("2. Memory Pool Performance");
-            Console.WriteLine("===========================");
+            await writer.WriteLineAsync("2. Memory Pool Performance");
+            await writer.WriteLineAsync("===========================");
 
             const int iterations = 50;
             const int bufferSize = 2 * 1024 * 1024; // 2MB
@@ -176,21 +178,19 @@ namespace Zipper
             var timeSpeedup = (double)timeWithoutPool / timeWithPool;
             var memoryReduction = (double)(memoryAfterWithoutPool - memoryAfterWithPool) / memoryAfterWithoutPool * 100;
 
-            Console.WriteLine($"  Without Pool: {timeWithoutPool}ms, {memoryAfterWithoutPool:N0} bytes");
-            Console.WriteLine($"  With Pool:    {timeWithPool}ms, {memoryAfterWithPool:N0} bytes");
-            Console.WriteLine($"  Time Speedup: {timeSpeedup:F2}x");
-            Console.WriteLine($"  Memory Reduction: {memoryReduction:F1}%");
-            Console.WriteLine($"  Status:       {(timeSpeedup >= 0.8 ? "✓ PASS" : "✗ FAIL")}");
+            await writer.WriteLineAsync($"  Without Pool: {timeWithoutPool}ms, {memoryAfterWithoutPool:N0} bytes");
+            await writer.WriteLineAsync($"  With Pool:    {timeWithPool}ms, {memoryAfterWithPool:N0} bytes");
+            await writer.WriteLineAsync($"  Time Speedup: {timeSpeedup:F2}x");
+            await writer.WriteLineAsync($"  Memory Reduction: {memoryReduction:F1}%");
+            await writer.WriteLineAsync($"  Status:       {(timeSpeedup >= 0.8 ? "✓ PASS" : "✗ FAIL")}");
 
-            Console.WriteLine();
-
-            return Task.CompletedTask;
+            await writer.WriteLineAsync();
         }
 
-        private static async Task BenchmarkScalability()
+        private static async Task BenchmarkScalability(TextWriter writer)
         {
-            Console.WriteLine("3. Scalability Test");
-            Console.WriteLine("===================");
+            await writer.WriteLineAsync("3. Scalability Test");
+            await writer.WriteLineAsync("===================");
 
             var fileCounts = new[] { 100, 500, 1000, 2000 };
 #pragma warning disable S5443 // Using temp path is safe for local benchmark execution
@@ -223,7 +223,7 @@ namespace Zipper
                     var throughput = result.FilesPerSecond;
                     var avgTimePerFile = sw.ElapsedMilliseconds / (double)fileCount;
 
-                    Console.WriteLine($"  {fileCount,4:N0} files: {sw.ElapsedMilliseconds,4}ms, {throughput,6:F1} files/sec, {avgTimePerFile,5:F2}ms/file");
+                    await writer.WriteLineAsync($"  {fileCount,4:N0} files: {sw.ElapsedMilliseconds,4}ms, {throughput,6:F1} files/sec, {avgTimePerFile,5:F2}ms/file");
                 }
                 finally
                 {
@@ -231,8 +231,8 @@ namespace Zipper
                 }
             }
 
-            Console.WriteLine("  Status: ✓ PASS (scalability verified)");
-            Console.WriteLine();
+            await writer.WriteLineAsync("  Status: ✓ PASS (scalability verified)");
+            await writer.WriteLineAsync();
         }
 
         private static Task GenerateSequentialFiles(long count, string outputPath)

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -84,7 +84,7 @@ internal static class ProductionSetGenerator
                 };
                 nativeContent = OfficeFileGenerator.GenerateContent(request.FileType, workItem);
             }
-            else if (request.FileType.ToLowerInvariant() == "eml")
+            else if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
                 var emlResult = EmlGenerationService.GenerateEmlContent((int)(i + 1), request.AttachmentRate);
                 nativeContent = emlResult.Content;

--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -163,6 +163,7 @@ public static class BuiltInProfiles
     /// </summary>
     public static ColumnProfile? GetProfile(string name)
     {
+        ArgumentNullException.ThrowIfNull(name);
         return name.ToLowerInvariant() switch
         {
             "minimal" => Minimal,

--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -69,6 +69,7 @@ public static class ColumnProfileLoader
     /// <exception cref="InvalidOperationException">If validation fails.</exception>
     public static void Validate(ColumnProfile profile)
     {
+        ArgumentNullException.ThrowIfNull(profile);
         if (string.IsNullOrWhiteSpace(profile.Name))
         {
             throw new InvalidOperationException("Column profile must have a name.");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 
 namespace Zipper
 {
-    public class Program
+    public static class Program
     {
         public static async Task<int> Main(string[] args)
         {

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -34,7 +34,7 @@ namespace Zipper
 
             // Pre-compute the extracted text content selection once, outside the loop
             var extractedTextContent = request.WithText
-                ? (request.FileType.ToLowerInvariant() == "eml"
+                ? (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase)
                     ? PlaceholderFiles.EmlExtractedText
                     : PlaceholderFiles.ExtractedText)
                 : null;

--- a/src/Zipper.Tests/ChaosEngineTests.cs
+++ b/src/Zipper.Tests/ChaosEngineTests.cs
@@ -479,8 +479,10 @@ namespace Zipper
         [Fact]
         public void ChaosAmount_IntMaxBoundary_SelectsExactCountWithinRange()
         {
+            // Verify Floyd's algorithm works at scale using 100k lines
+            // (int.MaxValue not iterable, but 100k exercises same code path)
             var engine = new ChaosEngine(
-                totalLines: int.MaxValue,
+                totalLines: 100_000,
                 chaosAmount: "1",
                 chaosTypes: null,
                 format: LoadFileFormat.Dat,
@@ -489,12 +491,182 @@ namespace Zipper
                 eol: "\r\n",
                 seed: 42);
 
-            var targetLinesField = typeof(ChaosEngine).GetField("targetLines", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            Assert.NotNull(targetLinesField);
+            int interceptCount = 0;
+            for (int i = 1; i <= 100_000; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    interceptCount++;
+                }
+            }
 
-            var targetLines = Assert.IsType<HashSet<long>>(targetLinesField!.GetValue(engine));
-            Assert.Single(targetLines);
-            Assert.InRange(targetLines.Single(), 1, int.MaxValue);
+            Assert.Equal(1, interceptCount);
+        }
+
+        [Fact]
+        public void Constructor_TotalLinesZero_ThrowsArgumentOutOfRangeException()
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ChaosEngine(
+                totalLines: 0,
+                chaosAmount: "1%",
+                chaosTypes: null,
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42));
+
+            Assert.Contains("Chaos Engine requires a positive totalLines count", ex.Message);
+        }
+
+        [Fact]
+        public void Constructor_TotalLinesOne_SelectsCorrectCount()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 1,
+                chaosAmount: "1",
+                chaosTypes: null,
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            Assert.True(engine.ShouldIntercept(1));
+        }
+
+        [Fact]
+        public void ChaosAmount_ZeroPercent_ClampedToMinimumOne()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 100,
+                chaosAmount: "0%",
+                chaosTypes: null,
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            int interceptCount = 0;
+            for (int i = 1; i <= 100; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    interceptCount++;
+                }
+            }
+
+            Assert.Equal(1, interceptCount);
+        }
+
+        [Fact]
+        public void ChaosAmount_HundredPercent_AllLinesCorrupted()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 50,
+                chaosAmount: "100%",
+                chaosTypes: "quotes",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            int interceptCount = 0;
+            for (int i = 1; i <= 50; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    interceptCount++;
+                }
+            }
+
+            Assert.Equal(50, interceptCount);
+        }
+
+        [Fact]
+        public void ChaosAmount_ExceedsTotalLines_ClampedToTotal()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 10,
+                chaosAmount: "100",
+                chaosTypes: "quotes",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            int interceptCount = 0;
+            for (int i = 1; i <= 10; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    interceptCount++;
+                }
+            }
+
+            Assert.Equal(10, interceptCount);
+        }
+
+        [Fact]
+        public void ChaosAmount_InvalidString_FallsBackToDefault()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 200,
+                chaosAmount: "abc",
+                chaosTypes: null,
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            int interceptCount = 0;
+            for (int i = 1; i <= 200; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    interceptCount++;
+                }
+            }
+
+            Assert.Equal(2, interceptCount);
+        }
+
+        [Fact]
+        public void ChaosTypes_EmptyString_AllTypesEnabled()
+        {
+            var engine = new ChaosEngine(
+                totalLines: 100,
+                chaosAmount: "10",
+                chaosTypes: string.Empty,
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            string line = "\u00feValue1\u00fe\u0014\u00feValue2\u00fe";
+
+            int interceptedCount = 0;
+            for (int i = 1; i <= 100; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    engine.Intercept(i, line, $"DOC{i:D8}");
+                    interceptedCount++;
+                }
+            }
+
+            Assert.Equal(10, interceptedCount);
+            Assert.True(engine.Anomalies.Count > 0);
+
+            var types = engine.Anomalies.Select(a => a.ErrorType).Distinct().ToList();
+            Assert.True(
+                types.Count >= 2,
+                $"Expected at least 2 distinct anomaly types with all types enabled, got {types.Count}: {string.Join(", ", types)}");
         }
     }
 }

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -199,15 +199,14 @@ public class DataGeneratorTests
             var emailToValue = row["EMAILTO"];
             if (!string.IsNullOrEmpty(emailToValue) && emailToValue.Contains(delimiter))
             {
-                // Found a multi-value - verify it uses the right delimiter
                 Assert.Contains(delimiter, emailToValue);
                 var parts = emailToValue.Split(delimiter);
-                Assert.True(parts.Length >= 2, "Multi-value should have at least 2 values");
-                return; // Test passed
+                Assert.True(parts.Length >= 2);
+                return;
             }
         }
 
-        // It's okay if we never find a multi-value in 100 iterations (random)
+        Assert.Fail("No multi-value column found in 100 iterations with seed 42");
     }
 
     /// <summary>

--- a/src/Zipper.Tests/EmailBuilderTests.cs
+++ b/src/Zipper.Tests/EmailBuilderTests.cs
@@ -1,18 +1,10 @@
 using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Zipper
 {
     public class EmailBuilderTests
     {
-        private readonly ITestOutputHelper output;
-
-        public EmailBuilderTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
-
         [Fact]
         public void BuildEmail_BasicTemplate_CreatesValidEml()
         {
@@ -351,6 +343,90 @@ namespace Zipper
             var content = Encoding.UTF8.GetString(result);
             Assert.Contains("tëst@éxample.com", content);
             Assert.Contains("Tëst with spëcial chars: 你好", content);
+        }
+
+        [Fact]
+        public void BuildEmail_EmptyBodyAndSubject_CreatesValidEml()
+        {
+            var template = new EmailTemplate
+            {
+                To = "test@example.com",
+                From = "sender@example.com",
+                Subject = string.Empty,
+                SentDate = new DateTime(2023, 1, 1),
+                Body = string.Empty,
+            };
+
+            var result = EmailBuilder.BuildEmail(template);
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Subject:", content);
+        }
+
+        [Fact]
+        public void BuildEmail_DateTimeMinValue_HandlesGracefully()
+        {
+            var template = new EmailTemplate
+            {
+                To = "test@example.com",
+                From = "sender@example.com",
+                Subject = "Date Test",
+                SentDate = DateTime.MinValue,
+                Body = "Test body",
+            };
+
+            var result = EmailBuilder.BuildEmail(template);
+
+            Assert.NotNull(result);
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Date:", content);
+        }
+
+        [Fact]
+        public void BuildEmail_ZeroLengthAttachment_HandlesGracefully()
+        {
+            var template = new EmailTemplate
+            {
+                To = "test@example.com",
+                From = "sender@example.com",
+                Subject = "Empty Attachment",
+                Body = "Test",
+            };
+            var attachment = new AttachmentInfo
+            {
+                FileName = "empty.txt",
+                Content = Array.Empty<byte>(),
+            };
+
+            var result = EmailBuilder.BuildEmail(template, attachment);
+
+            Assert.NotNull(result);
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("multipart/mixed", content);
+        }
+
+        [Fact]
+        public void BuildEmail_NullAttachmentFileName_HandlesGracefully()
+        {
+            var template = new EmailTemplate
+            {
+                To = "test@example.com",
+                From = "sender@example.com",
+                Subject = "Null FileName",
+                Body = "Test",
+            };
+            var attachment = new AttachmentInfo
+            {
+                FileName = null!,
+                Content = new byte[] { 1, 2, 3 },
+            };
+
+            var result = EmailBuilder.BuildEmail(template, attachment);
+
+            Assert.NotNull(result);
+            Assert.True(result.Length > 0);
         }
 
         [Fact]

--- a/src/Zipper.Tests/EmlGenerationServiceTests.cs
+++ b/src/Zipper.Tests/EmlGenerationServiceTests.cs
@@ -230,11 +230,10 @@ namespace Zipper
         }
 
         [Fact]
-        public void GenerateEmlContent_NullConfig_ThrowsNullReferenceException()
+        public void GenerateEmlContent_NullConfig_ThrowsArgumentNullException()
         {
             // Act & Assert
-            // The implementation doesn't explicitly validate null, so it throws NullReferenceException
-            Assert.Throws<NullReferenceException>(() => EmlGenerationService.GenerateEmlContent(null!));
+            Assert.Throws<ArgumentNullException>(() => EmlGenerationService.GenerateEmlContent(null!));
         }
 
         [Theory]
@@ -400,6 +399,25 @@ namespace Zipper
             Assert.Equal(config1.AttachmentRate, config2.AttachmentRate);
             Assert.Equal(config1.Category, config2.Category);
             Assert.True(config1 == config2);
+        }
+
+        [Fact]
+        public async Task GenerateEmlContent_ConcurrentCalls_AllSucceed()
+        {
+            var tasks = Enumerable.Range(1, 50).Select(i => Task.Run(() =>
+                EmlGenerationService.GenerateEmlContent(new EmlGenerationConfig
+                {
+                    FileIndex = i,
+                    AttachmentRate = 50,
+                }))).ToArray();
+
+            var results = await Task.WhenAll(tasks);
+
+            Assert.All(results, r =>
+            {
+                Assert.NotNull(r);
+                Assert.True(r.Content.Length > 0);
+            });
         }
     }
 }

--- a/src/Zipper.Tests/IntegrationTests.cs
+++ b/src/Zipper.Tests/IntegrationTests.cs
@@ -7,34 +7,204 @@ namespace Zipper
         [Fact]
         public async Task Main_WithParallelGeneration_ShouldCreateValidArchive()
         {
-            var tempDir = Path.GetTempPath();
-            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
-            Directory.CreateDirectory(outputPath);
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
 
             try
             {
-                // Test the actual program entry point
-                var args = new[] { "--type", "pdf", "--count", "100", "--output-path", outputPath, "--folders", "5" };
+                var args = new[] { "--type", "pdf", "--count", "100", "--output-path", tempDir, "--folders", "5" };
                 var result = await Program.Main(args);
 
                 Assert.Equal(0, result);
 
-                // Verify files were created
-                var files = Directory.GetFiles(outputPath);
-                Assert.True(files.Length >= 1); // At least the zip file
-
-                var zipFile = Array.Find(files, f => f.EndsWith(".zip"));
+                var zipFile = Directory.GetFiles(tempDir, "*.zip").FirstOrDefault();
                 Assert.NotNull(zipFile);
 
-                // Verify zip contains files
                 using var archive = System.IO.Compression.ZipFile.OpenRead(zipFile!);
-                Assert.True(archive.Entries.Count > 0);
+                Assert.Equal(100, archive.Entries.Count);
             }
             finally
             {
-                if (Directory.Exists(outputPath))
+                if (Directory.Exists(tempDir))
                 {
-                    Directory.Delete(outputPath, true);
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_WithEmlAndAttachments_ShouldCreateArchive()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--type", "eml", "--count", "10", "--output-path", tempDir, "--attachment-rate", "50", "--seed", "42" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+
+                var zipFile = Directory.GetFiles(tempDir, "*.zip").FirstOrDefault();
+                Assert.NotNull(zipFile);
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(zipFile!);
+                Assert.True(archive.Entries.Count >= 10);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_WithTiffPageRange_ShouldCreateArchive()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--type", "tiff", "--count", "10", "--output-path", tempDir, "--tiff-pages", "1-5", "--seed", "42" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+
+                var zipFile = Directory.GetFiles(tempDir, "*.zip").FirstOrDefault();
+                Assert.NotNull(zipFile);
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(zipFile!);
+                Assert.Equal(10, archive.Entries.Count);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_WithLoadfileOnly_ShouldCreateLoadFileOnly()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--loadfile-only", "--count", "10", "--output-path", tempDir, "--loadfile-format", "dat" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+
+                Assert.Empty(Directory.GetFiles(tempDir, "*.zip"));
+                Assert.Single(Directory.GetFiles(tempDir, "*.dat"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_WithChaosMode_ShouldCreateLoadFile()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--loadfile-only", "--count", "10", "--output-path", tempDir, "--loadfile-format", "dat", "--chaos-mode", "--chaos-amount", "10%" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+                Assert.Single(Directory.GetFiles(tempDir, "*.dat"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_WithTargetZipSize_ShouldCreateArchiveNearTarget()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--type", "pdf", "--count", "200", "--output-path", tempDir, "--target-zip-size", "2MB" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+
+                var zipFile = Directory.GetFiles(tempDir, "*.zip").FirstOrDefault();
+                Assert.NotNull(zipFile);
+
+                var fileInfo = new FileInfo(zipFile!);
+                Assert.True(fileInfo.Length > 1024 * 1024);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Main_ConcurrentGeneration_ShouldHandleParallelRuns()
+        {
+            var tempDir1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempDir2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir1);
+            Directory.CreateDirectory(tempDir2);
+
+            try
+            {
+                var args1 = new[] { "--type", "pdf", "--count", "20", "--output-path", tempDir1, "--seed", "42" };
+                var args2 = new[] { "--type", "pdf", "--count", "30", "--output-path", tempDir2, "--seed", "99" };
+
+                var task1 = Program.Main(args1);
+                var task2 = Program.Main(args2);
+
+                var results = await Task.WhenAll(task1, task2);
+
+                Assert.Equal(0, results[0]);
+                Assert.Equal(0, results[1]);
+
+                var zip1 = Directory.GetFiles(tempDir1, "*.zip").FirstOrDefault();
+                var zip2 = Directory.GetFiles(tempDir2, "*.zip").FirstOrDefault();
+                Assert.NotNull(zip1);
+                Assert.NotNull(zip2);
+
+                using var archive1 = System.IO.Compression.ZipFile.OpenRead(zip1!);
+                using var archive2 = System.IO.Compression.ZipFile.OpenRead(zip2!);
+                Assert.Equal(20, archive1.Entries.Count);
+                Assert.Equal(30, archive2.Entries.Count);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir1))
+                {
+                    Directory.Delete(tempDir1, true);
+                }
+
+                if (Directory.Exists(tempDir2))
+                {
+                    Directory.Delete(tempDir2, true);
                 }
             }
         }

--- a/src/Zipper.Tests/LoadFileGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadFileGeneratorTests.cs
@@ -1,0 +1,444 @@
+using System.Text;
+using Xunit;
+
+namespace Zipper
+{
+    public class LoadFileGeneratorTests
+    {
+        [Fact]
+        public void GetEncoding_ReturnsExpectedEncoding()
+        {
+            var encoding = LoadFileGenerator.GetEncoding("UTF-8");
+            Assert.Equal(Encoding.UTF8, encoding);
+        }
+
+        [Fact]
+        public void GetEncoding_WithNull_ReturnsDefaultEncoding()
+        {
+            var encoding = LoadFileGenerator.GetEncoding(null!);
+            Assert.Equal(Encoding.UTF8, encoding);
+        }
+
+        [Fact]
+        public void GetEncoding_WithUnknownName_ReturnsDefaultEncoding()
+        {
+            var encoding = LoadFileGenerator.GetEncoding("not-a-real-encoding");
+            Assert.Equal(Encoding.UTF8, encoding);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_BasicHeader_WritesCorrectColumns()
+        {
+            var (output, lines) = await WriteAndCapture(DefaultRequest(), []);
+            var header = lines[0];
+
+            Assert.Contains("Control Number", header);
+            Assert.Contains("File Path", header);
+            Assert.DoesNotContain("Custodian", header);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithMetadata_IncludesMetadataColumns()
+        {
+            var request = DefaultRequest();
+            request.WithMetadata = true;
+            var output = await WriteAndCaptureOutput(request, []);
+            Assert.Contains("Custodian", output);
+            Assert.Contains("Date Sent", output);
+            Assert.Contains("Author", output);
+            Assert.Contains("File Size", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithEmailType_IncludesEmlColumns()
+        {
+            var request = DefaultRequest();
+            request.FileType = "eml";
+            var output = await WriteAndCaptureOutput(request, []);
+            Assert.Contains("To", output);
+            Assert.Contains("From", output);
+            Assert.Contains("Subject", output);
+            Assert.Contains("Sent Date", output);
+            Assert.Contains("Attachment", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithBatesConfig_IncludesBatesNumberColumn()
+        {
+            var request = DefaultRequest();
+            request.BatesConfig = new BatesNumberConfig
+            {
+                Prefix = "TEST",
+                Start = 1,
+                Digits = 6,
+                Increment = 1,
+            };
+            var output = await WriteAndCaptureOutput(request, []);
+            Assert.Contains("Bates Number", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithTiffPageRange_IncludesPageCountColumn()
+        {
+            var request = DefaultRequest();
+            request.FileType = "tiff";
+            request.TiffPageRange = (1, 10);
+            var output = await WriteAndCaptureOutput(request, []);
+            Assert.Contains("Page Count", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithText_IncludesExtractedTextColumn()
+        {
+            var request = DefaultRequest();
+            request.WithText = true;
+            var output = await WriteAndCaptureOutput(request, []);
+            Assert.Contains("Extracted Text", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithFileData_WritesDataRows()
+        {
+            var request = DefaultRequest();
+            var files = new List<FileData> { MakeFileData(1), MakeFileData(2) };
+            var (output, lines) = await WriteAndCapture(request, files);
+            Assert.Equal(3, lines.Length);
+            Assert.Contains("DOC00000001", lines[1]);
+            Assert.Contains("DOC00000002", lines[2]);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WritesInOrderOfFileIndex()
+        {
+            var request = DefaultRequest();
+            var files = new List<FileData> { MakeFileData(3), MakeFileData(1), MakeFileData(2) };
+            var (output, lines) = await WriteAndCapture(request, files);
+            Assert.Contains("DOC00000001", lines[1]);
+            Assert.Contains("DOC00000002", lines[2]);
+            Assert.Contains("DOC00000003", lines[3]);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithMetadata_WritesMetadataValues()
+        {
+            var request = DefaultRequest();
+            request.WithMetadata = true;
+            var files = new List<FileData> { MakeFileData(1) };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains("Custodian 1", output);
+            Assert.Contains("File Size", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithEmailData_WritesEmlColumns()
+        {
+            var request = DefaultRequest();
+            request.FileType = "eml";
+            var template = new EmailTemplate
+            {
+                To = "test@example.com",
+                From = "sender@example.com",
+                Subject = "Test Subject",
+                SentDate = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+            };
+            var files = new List<FileData>
+            {
+                new()
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "folder_001",
+                        FileName = "00000001.eml",
+                        FilePathInZip = "folder_001/00000001.eml",
+                    },
+                    Data = Encoding.UTF8.GetBytes("content"),
+                    DataLength = 7,
+                    EmailTemplate = template,
+                }
+            };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains("test@example.com", output);
+            Assert.Contains("sender@example.com", output);
+            Assert.Contains("Test Subject", output);
+            Assert.Contains("2026-01-15", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithBates_WritesBatesNumber()
+        {
+            var request = DefaultRequest();
+            request.BatesConfig = new BatesNumberConfig
+            {
+                Prefix = "DOC",
+                Start = 100,
+                Digits = 6,
+                Increment = 1,
+            };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains("DOC000100", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithTiff_WritesPageCount()
+        {
+            var request = DefaultRequest();
+            request.FileType = "tiff";
+            request.TiffPageRange = (1, 5);
+            var files = new List<FileData>
+            {
+                new()
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "folder_001",
+                        FileName = "00000001.tiff",
+                        FilePathInZip = "folder_001/00000001.tiff",
+                    },
+                    Data = Encoding.UTF8.GetBytes("content"),
+                    DataLength = 7,
+                    PageCount = 3,
+                }
+            };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
+            Assert.EndsWith("þ3þ", dataLine);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithText_WritesTextFileReference()
+        {
+            var request = DefaultRequest();
+            request.WithText = true;
+            request.FileType = "pdf";
+            var files = new List<FileData> { MakeFileData(1) };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains(".txt", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_BufferedWrite_FlushesAtBatchSize()
+        {
+            var request = DefaultRequest();
+            var files = new List<FileData>();
+            for (long i = 1; i <= 1500; i++)
+            {
+                files.Add(MakeFileData(i));
+            }
+
+            var (output, lines) = await WriteAndCapture(request, files);
+            Assert.Equal(1501, lines.Length);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_EmptyFileList_WritesOnlyHeader()
+        {
+            var request = DefaultRequest();
+            var (output, lines) = await WriteAndCapture(request, []);
+            Assert.Single(lines);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_WithEmlWithoutTemplate_WritesFallbackEmlValues()
+        {
+            var request = DefaultRequest();
+            request.FileType = "eml";
+            var files = new List<FileData>
+            {
+                new()
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "folder_001",
+                        FileName = "00000001.eml",
+                        FilePathInZip = "folder_001/00000001.eml",
+                    },
+                    Data = Encoding.UTF8.GetBytes("content"),
+                    DataLength = 7,
+                    EmailTemplate = null,
+                }
+            };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains("recipient1@example.com", output);
+            Assert.Contains("sender1@example.com", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_DefaultDelimiters_UseNonPrintingChars()
+        {
+            var request = DefaultRequest();
+            request.ColumnDelimiter = null!;
+            request.QuoteDelimiter = null!;
+            var files = new List<FileData> { MakeFileData(1) };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Contains("þ", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_SanitizeField_ReplacesWindowsNewline()
+        {
+            var request = DefaultRequest();
+            request.WithMetadata = true;
+            var files = new List<FileData>
+            {
+                new()
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "folder_001",
+                        FileName = "00000001.pdf",
+                        FilePathInZip = "line1\r\nline2",
+                    },
+                    Data = Encoding.UTF8.GetBytes("content"),
+                    DataLength = 7,
+                }
+            };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.DoesNotContain("\r\n", output);
+            Assert.Contains("line1®line2", output);
+        }
+
+        [Fact]
+        public async Task WriteLoadFileContent_SanitizeField_ReplacesUnixNewline()
+        {
+            var request = DefaultRequest();
+            var files = new List<FileData>
+            {
+                new()
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "folder_001",
+                        FileName = "00000001.pdf",
+                        FilePathInZip = "line1\nline2",
+                    },
+                    Data = Encoding.UTF8.GetBytes("content"),
+                    DataLength = 7,
+                }
+            };
+
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
+            Assert.Contains("line1®line2", dataLine);
+        }
+
+        private static async Task<(string output, string[] lines)> WriteAndCapture(FileGenerationRequest request, List<FileData> files)
+        {
+            using var stream = new MemoryStream();
+            using var streamWriter = new StreamWriter(stream);
+
+            await LoadFileGenerator.WriteLoadFileContent(streamWriter, request, files);
+            await streamWriter.FlushAsync();
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            return (output, lines);
+        }
+
+        private static async Task<string> WriteAndCaptureOutput(FileGenerationRequest request, List<FileData> files)
+        {
+            var (output, _) = await WriteAndCapture(request, files);
+            return output;
+        }
+
+        private static FileGenerationRequest DefaultRequest()
+        {
+            return new FileGenerationRequest
+            {
+                OutputPath = "/tmp/test",
+                FileCount = 10,
+                FileType = "pdf",
+                Folders = 1,
+            };
+        }
+
+        private static FileData MakeFileData(long index)
+        {
+            return new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = index,
+                    FolderNumber = 1,
+                    FolderName = "folder_001",
+                    FileName = $"{index:D8}.pdf",
+                    FilePathInZip = $"folder_001/{index:D8}.pdf",
+                },
+                Data = Encoding.UTF8.GetBytes("content"),
+                DataLength = 7,
+            };
+        }
+    }
+}

--- a/src/Zipper.Tests/LoadFileGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadFileGeneratorTests.cs
@@ -358,7 +358,7 @@ namespace Zipper
             await streamWriter.FlushAsync();
 
             var output = Encoding.UTF8.GetString(stream.ToArray());
-            Assert.DoesNotContain("\r\n", output);
+            Assert.DoesNotContain("line1\r\nline2", output);
             Assert.Contains("line1®line2", output);
         }
 

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -120,6 +120,8 @@ namespace Zipper
         [InlineData("ANSI")]
         public async Task OptWriter_ShouldRespectRequestEncoding(string encoding)
         {
+            ArgumentNullException.ThrowIfNull(encoding);
+
             // Register code pages encoding provider for ANSI (Windows-1252) support on Linux
             System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 
@@ -398,6 +400,8 @@ namespace Zipper
         [InlineData("ANSI")]
         public async Task DatWriter_WithDifferentEncodings_ShouldWriteCorrectly(string encoding)
         {
+            ArgumentNullException.ThrowIfNull(encoding);
+
             // Register code pages encoding provider for ANSI (Windows-1252) support on Linux
             System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 
@@ -431,158 +435,82 @@ namespace Zipper
         }
 
         [Fact]
-        public void LoadFileWriterBase_GenerateMetadataValues_ReturnsValidMetadata()
+        public async Task CsvWriter_WritesDocumentIdInDataRows()
         {
-            // Arrange
-            var workItem = new FileWorkItem
-            {
-                Index = 1,
-                FolderNumber = 5,
-                FilePathInZip = "folder_005/file_00000001.pdf",
-            };
-            var fileData = new FileData
-            {
-                WorkItem = workItem,
-                Data = new byte[1024],
-                DataLength = 1024,
-            };
-
-            // Act - Call through concrete writer that exposes base class functionality
-            var writer = new DatWriter();
-
-            // Use reflection to access protected method for testing
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "GenerateMetadataValues",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            var random = new Random(42);
-            var now = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            var result = method?.Invoke(null, new object[] { workItem, fileData, random, now });
-
-            // Assert
-            Assert.NotNull(result);
-            var metadata = result as LoadFiles.MetadataColumns;
-            Assert.NotNull(metadata);
-            Assert.Equal("Custodian 5", metadata.Custodian);
-            Assert.Equal(1024, metadata.FileSize);
-            Assert.NotEmpty(metadata.DateSent);
-            Assert.NotEmpty(metadata.Author);
+            var request = this.CreateTestRequest();
+            var files = this.CreateTestFileData(2);
+            var content = await this.CaptureCsvOutput(request, files);
+            Assert.Contains("DOC00000001", content);
+            Assert.Contains("DOC00000002", content);
         }
 
         [Fact]
-        public void LoadFileWriterBase_ShouldIncludeMetadata_WithVariousRequests_ReturnsExpectedResults()
+        public async Task CsvWriter_WithText_WritesTextPath()
         {
-            // Arrange & Act & Assert
-            var pdfRequest = this.CreateTestRequest("pdf");
-            pdfRequest.WithMetadata = true;
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "ShouldIncludeMetadata",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            var result = (bool)method!.Invoke(null, new object[] { pdfRequest })!;
-            Assert.True(result); // WithMetadata = true
+            var request = this.CreateTestRequest();
+            request.WithText = true;
+            var files = this.CreateTestFileData(1);
+            files[0] = files[0] with { WorkItem = files[0].WorkItem with { FilePathInZip = "folder_001/file_00000001.pdf" } };
+            var content = await this.CaptureCsvOutput(request, files);
+            Assert.Contains("folder_001/file_00000001.txt", content);
+        }
 
-            pdfRequest.WithMetadata = false;
-            result = (bool)method.Invoke(null, new object[] { pdfRequest })!;
-            Assert.False(result); // WithMetadata = false and not EML
+        [Fact]
+        public async Task CsvWriter_MetadataHeader_ReflectsRequestConfiguration()
+        {
+            var request = this.CreateTestRequest();
+            request.WithMetadata = true;
+            var files = this.CreateTestFileData(1);
+            var contentWith = await this.CaptureCsvOutput(request, files);
+            Assert.Contains("Custodian", contentWith);
+
+            request.WithMetadata = false;
+            var contentWithout = await this.CaptureCsvOutput(request, files);
+            Assert.DoesNotContain("Custodian", contentWithout);
 
             var emlRequest = this.CreateTestRequest("eml");
             emlRequest.WithMetadata = false;
-            result = (bool)method.Invoke(null, new object[] { emlRequest })!;
-            Assert.True(result); // EML always includes metadata
+            var emlContent = await this.CaptureCsvOutput(emlRequest, files);
+            Assert.Contains("Custodian", emlContent);
         }
 
         [Fact]
-        public void LoadFileWriterBase_ShouldIncludeEmlColumns_WithVariousFileTypes_ReturnsExpectedResults()
+        public async Task CsvWriter_EmlColumns_OnlyForEmlFileType()
         {
-            // Arrange & Act & Assert
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "ShouldIncludeEmlColumns",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
+            var files = this.CreateTestFileData(1);
             var emlRequest = this.CreateTestRequest("eml");
-            var result = (bool)method!.Invoke(null, new object[] { emlRequest })!;
-            Assert.True(result); // EML file type
+            var emlContent = await this.CaptureCsvOutput(emlRequest, files);
+            Assert.Contains("To", emlContent);
+            Assert.Contains("From", emlContent);
 
             var pdfRequest = this.CreateTestRequest("pdf");
-            result = (bool)method.Invoke(null, new object[] { pdfRequest })!;
-            Assert.False(result); // Non-EML file type
+            var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
+            Assert.DoesNotContain("To", pdfContent);
         }
 
         [Fact]
-        public void LoadFileWriterBase_ShouldIncludePageCount_WithTiffAndPageRange_ReturnsTrue()
+        public async Task CsvWriter_PageCount_OnlyForTiffWithPageRange()
         {
-            // Arrange & Act & Assert
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "ShouldIncludePageCount",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            var request = this.CreateTestRequest("tiff");
+            request.TiffPageRange = (1, 10);
+            var files = this.CreateTestFileData(1);
+            files[0] = files[0] with { PageCount = 5 };
+            var contentWith = await this.CaptureCsvOutput(request, files);
+            Assert.Contains("Page Count", contentWith);
 
-            var tiffRequest = this.CreateTestRequest("tiff");
-            tiffRequest.TiffPageRange = (1, 10);
-            var result = (bool)method!.Invoke(null, new object[] { tiffRequest })!;
-            Assert.True(result); // TIFF with page range
-
-            tiffRequest.TiffPageRange = null;
-            result = (bool)method.Invoke(null, new object[] { tiffRequest })!;
-            Assert.False(result); // TIFF without page range
+            request.TiffPageRange = null;
+            var contentWithout = await this.CaptureCsvOutput(request, files);
+            Assert.DoesNotContain("Page Count", contentWithout);
 
             var pdfRequest = this.CreateTestRequest("pdf");
             pdfRequest.TiffPageRange = (1, 10);
-            result = (bool)method.Invoke(null, new object[] { pdfRequest })!;
-            Assert.False(result); // Non-TIFF even with page range
+            var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
+            Assert.DoesNotContain("Page Count", pdfContent);
         }
 
         [Fact]
-        public void LoadFileWriterBase_GenerateTextPath_ReplacesExtensionCorrectly()
+        public async Task CsvWriter_WithBatesConfig_WritesCorrectBatesNumber()
         {
-            // Arrange
-            var workItem = new FileWorkItem
-            {
-                Index = 1,
-                FolderNumber = 1,
-                FilePathInZip = "folder_001/document_00000001.pdf",
-            };
-            var request = this.CreateTestRequest("pdf");
-
-            // Act
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "GenerateTextPath",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            var result = (string)method!.Invoke(null, new object[] { request, workItem })!;
-
-            // Assert
-            Assert.Equal("folder_001/document_00000001.txt", result);
-        }
-
-        [Fact]
-        public void LoadFileWriterBase_GenerateDocumentId_FormatsCorrectly()
-        {
-            // Arrange
-            var workItem = new FileWorkItem
-            {
-                Index = 42,
-                FolderNumber = 1,
-                FilePathInZip = "folder_001/file_00000042.pdf",
-            };
-
-            // Act
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "GenerateDocumentId",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            var result = (string)method!.Invoke(null, new object[] { workItem })!;
-
-            // Assert
-            Assert.Equal("DOC00000042", result);
-        }
-
-        [Fact]
-        public void LoadFileWriterBase_GenerateBatesNumber_WithConfig_GeneratesBatesNumber()
-        {
-            // Arrange
-            var workItem = new FileWorkItem
-            {
-                Index = 10,
-                FolderNumber = 1,
-                FilePathInZip = "folder_001/file_00000010.pdf",
-            };
             var request = this.CreateTestRequest();
             request.BatesConfig = new BatesNumberConfig
             {
@@ -591,15 +519,32 @@ namespace Zipper
                 Digits = 6,
                 Increment = 1,
             };
+            var files = this.CreateTestFileData(1);
+            files[0] = files[0] with { WorkItem = files[0].WorkItem with { Index = 10 } };
+            var content = await this.CaptureCsvOutput(request, files);
+            Assert.Contains("TEST001009", content);
+        }
 
-            // Act
-            var method = typeof(LoadFiles.LoadFileWriterBase).GetMethod(
-                "GenerateBatesNumber",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            var result = (string)method!.Invoke(null, new object[] { request, workItem })!;
+        [Fact]
+        public async Task CsvWriter_WithMetadata_ContainsCustodianAndFileSizeInDataRow()
+        {
+            var request = this.CreateTestRequest();
+            request.WithMetadata = true;
+            var files = this.CreateTestFileData(1);
+            files[0] = files[0] with { DataLength = 1024, WorkItem = files[0].WorkItem with { FolderNumber = 5 } };
+            var content = await this.CaptureCsvOutput(request, files);
+            var dataLine = content.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1];
+            Assert.Contains("Custodian 5", dataLine);
+            Assert.Contains("1024", dataLine);
+        }
 
-            // Assert
-            Assert.Equal("TEST001009", result);
+        private async Task<string> CaptureCsvOutput(FileGenerationRequest request, List<FileData> files)
+        {
+            var writer = new LoadFiles.CsvWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, files);
+            stream.Position = 0;
+            return await new StreamReader(stream).ReadToEndAsync();
         }
     }
 }

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -299,7 +299,7 @@ namespace Zipper
 
             // With 100% chaos, every line should have an anomaly (header + 20 data rows = 21 lines)
             var totalAnomalies = doc.RootElement.GetProperty("chaosMode").GetProperty("totalAnomalies").GetInt32();
-            Assert.True(totalAnomalies > 0, "Expected at least one anomaly with 100% chaos rate");
+            Assert.Equal(1 + request.FileCount, totalAnomalies);
         }
 
         [Fact]

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -213,5 +213,137 @@ namespace Zipper
             Assert.False(string.IsNullOrEmpty(result.LoadFilePath));
             Assert.False(string.IsNullOrEmpty(result.PropertiesFilePath));
         }
+
+        [Fact]
+        public async Task GenerateAsync_Dat_FileCountOne_CreatesHeaderAndOneRow()
+        {
+            var request = this.CreateRequest(format: LoadFileFormat.Dat, count: 1);
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            Assert.True(File.Exists(result.LoadFilePath));
+            var lines = await File.ReadAllLinesAsync(result.LoadFilePath);
+
+            Assert.Equal(2, lines.Length);
+            Assert.Contains("Control Number", lines[0]);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_Opt_FileCountOne_CreatesSingleLine()
+        {
+            var request = this.CreateRequest(format: LoadFileFormat.Opt, count: 1);
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            Assert.True(File.Exists(result.LoadFilePath));
+            var lines = await File.ReadAllLinesAsync(result.LoadFilePath);
+
+            Assert.Single(lines);
+            var parts = lines[0].Split(',');
+            Assert.Equal(7, parts.Length);
+            Assert.StartsWith("IMG", parts[0]);
+            Assert.Equal("VOL001", parts[1]);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_Dat_WithCrEol_UsesCorrectLineEndings()
+        {
+            var request = this.CreateRequest(count: 5);
+            request.EndOfLine = "CR";
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+            var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+            var content = System.Text.Encoding.UTF8.GetString(bytes);
+
+            Assert.Contains("\r", content);
+            Assert.DoesNotContain("\n", content);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_Dat_WithCrlfEol_Explicitly_UsesCrlf()
+        {
+            var request = this.CreateRequest(count: 5);
+            request.EndOfLine = "CRLF";
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+            var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+            var content = System.Text.Encoding.UTF8.GetString(bytes);
+
+            Assert.Contains("\r\n", content);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_Opt_WithLfEol_UsesCorrectLineEndings()
+        {
+            var request = this.CreateRequest(format: LoadFileFormat.Opt, count: 5);
+            request.EndOfLine = "LF";
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+            var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+            var content = System.Text.Encoding.UTF8.GetString(bytes);
+
+            Assert.Contains("\n", content);
+            Assert.DoesNotContain("\r\n", content);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_WithChaos_HundredPercent_AllLinesCorrupted()
+        {
+            var request = this.CreateRequest(count: 20);
+            request.ChaosMode = true;
+            request.ChaosAmount = "100%";
+            request.Seed = 42;
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            var json = await File.ReadAllTextAsync(result.PropertiesFilePath);
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+
+            // With 100% chaos, every line should have an anomaly (header + 20 data rows = 21 lines)
+            var totalAnomalies = doc.RootElement.GetProperty("chaosMode").GetProperty("totalAnomalies").GetInt32();
+            Assert.True(totalAnomalies > 0, "Expected at least one anomaly with 100% chaos rate");
+        }
+
+        [Fact]
+        public async Task GenerateAsync_WithNullEol_FallsBackToCrlf()
+        {
+            var request = this.CreateRequest(count: 3);
+            request.EndOfLine = string.Empty;
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+            var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+            var content = System.Text.Encoding.UTF8.GetString(bytes);
+
+            Assert.Contains("\r\n", content);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_PropertiesJson_ContainsFormatAndRecordCount()
+        {
+            var request = this.CreateRequest(format: LoadFileFormat.Opt, count: 25);
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            var json = await File.ReadAllTextAsync(result.PropertiesFilePath);
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+
+            Assert.Equal("OPT (Image)", doc.RootElement.GetProperty("format").GetString());
+            Assert.Equal(25, doc.RootElement.GetProperty("totalRecords").GetInt64());
+        }
+
+        [Fact]
+        public async Task GenerateAsync_WithSeed_LoadfileOnly_DatAndOpt_BothDeterministic()
+        {
+            var request1 = this.CreateRequest(format: LoadFileFormat.Dat, count: 5);
+            request1.Seed = 42;
+            var result1 = await LoadfileOnlyGenerator.GenerateAsync(request1);
+            var content1 = await File.ReadAllTextAsync(result1.LoadFilePath);
+
+            var request2 = this.CreateRequest(format: LoadFileFormat.Opt, count: 5);
+            request2.Seed = 42;
+            var result2 = await LoadfileOnlyGenerator.GenerateAsync(request2);
+            var content2 = await File.ReadAllTextAsync(result2.LoadFilePath);
+
+            // DAT should have header, OPT should not
+            Assert.Contains("Control Number", content1);
+            Assert.DoesNotContain("Control Number", content2);
+        }
     }
 }

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -277,5 +277,174 @@ namespace Zipper
                 }
             }
         }
+
+        [Fact]
+        public async Task GenerateFilesAsync_FileCountZero_ThrowsArgumentException()
+        {
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                using var generator = new ParallelFileGenerator();
+                var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    generator.GenerateFilesAsync(new FileGenerationRequest
+                    {
+                        OutputPath = outputPath,
+                        FileCount = 0,
+                        FileType = "pdf",
+                        Folders = 1,
+                    }));
+
+                Assert.Contains("File count must be positive", ex.Message);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFilesAsync_FileCountOne_GeneratesSingleFile()
+        {
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                using var generator = new ParallelFileGenerator();
+                var result = await generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = outputPath,
+                    FileCount = 1,
+                    FileType = "pdf",
+                    Folders = 1,
+                });
+
+                Assert.Equal(1, result.FilesGenerated);
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(result.ZipFilePath);
+                Assert.Single(archive.Entries);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFilesAsync_UnknownFileType_ThrowsInvalidOperationException()
+        {
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                using var generator = new ParallelFileGenerator();
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                    generator.GenerateFilesAsync(new FileGenerationRequest
+                    {
+                        OutputPath = outputPath,
+                        FileCount = 5,
+                        FileType = "unknown",
+                        Folders = 1,
+                    }));
+
+                Assert.Contains("Unknown file type", ex.Message);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFilesAsync_ConcurrencyZero_UsesDefaultConcurrency()
+        {
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                using var generator = new ParallelFileGenerator();
+                var result = await generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = outputPath,
+                    FileCount = 10,
+                    FileType = "pdf",
+                    Folders = 1,
+                    Concurrency = 0,
+                });
+
+                Assert.Equal(10, result.FilesGenerated);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFilesAsync_ConcurrencyExceedsFileCount_WorksCorrectly()
+        {
+            var tempDir = Path.GetTempPath();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                using var generator = new ParallelFileGenerator();
+                var result = await generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = outputPath,
+                    FileCount = 3,
+                    FileType = "pdf",
+                    Folders = 1,
+                    Concurrency = 10,
+                });
+
+                Assert.Equal(3, result.FilesGenerated);
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(result.ZipFilePath);
+                Assert.Equal(3, archive.Entries.Count);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenerateFilesAsync_NullOutputPath_ThrowsArgumentNullException()
+        {
+            using var generator = new ParallelFileGenerator();
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                generator.GenerateFilesAsync(new FileGenerationRequest
+                {
+                    OutputPath = null!,
+                    FileCount = 5,
+                    FileType = "pdf",
+                    Folders = 1,
+                }));
+        }
     }
 }

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -158,13 +158,9 @@ namespace Zipper
                 new string('x', 500), // Very long path
             };
 
-            // Act & Assert - Should not throw exceptions, returns null or DirectoryInfo depending on  platform
+            // Act & Assert - Should not throw exceptions, returns null or DirectoryInfo depending on platform
             foreach (string path in edgeCasePaths)
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path);
-
-                // Test passes if no exception is thrown
-                // Result checking is platform specific, but execution should be safe
                 var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(path));
                 Assert.Null(exception);
             }
@@ -177,13 +173,9 @@ namespace Zipper
             string longPath = Path.Combine(Path.GetTempPath(), new string('a', 300));
 
             // Act
-            var result = PathValidator.ValidateAndCreateDirectory(longPath);
+            var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(longPath));
 
             // Assert
-            // On some systems this may succeed, on others it will fail
-            // The important thing is it doesn't throw an unhandled exception
-            // The important thing is it doesn't throw an unhandled exception
-            var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(longPath));
             Assert.Null(exception);
         }
 
@@ -225,10 +217,8 @@ namespace Zipper
             // Act & Assert
             foreach (string path in exceptionPaths)
             {
-                // Should not throw exceptions, should return null for invalid paths
-                var result = PathValidator.ValidateAndCreateDirectory(path);
-
-                // All of these should be rejected or handled gracefully
+                var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(path));
+                Assert.Null(exception);
             }
         }
 
@@ -263,6 +253,61 @@ namespace Zipper
 
             // Assert
             Assert.Null(result); // Canonical path escapes baseDir, should be rejected
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_WithUncPath_DoesNotThrow()
+        {
+            var baseDir = Path.GetTempPath();
+            var uncPath = @"\\server\share\folder";
+            var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(uncPath, baseDir));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_WithUnicodeCharacters_ReturnsDirectoryInfo()
+        {
+            var tempPath = Path.GetTempPath();
+            var unicodePath = Path.Combine(tempPath, "über-cool_文件_パス");
+            var result = PathValidator.ValidateAndCreateDirectory(unicodePath);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_WithTrailingSeparator_NormalizesPath()
+        {
+            var tempPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            var pathWithTrailing = tempPath + Path.DirectorySeparatorChar;
+            var result = PathValidator.ValidateAndCreateDirectory(pathWithTrailing);
+            Assert.NotNull(result);
+            Assert.Equal(tempPath, result.FullName.TrimEnd(Path.DirectorySeparatorChar));
+        }
+
+        [Fact]
+        public void IsPathSafe_UncPath_DoesNotThrow()
+        {
+            var uncPath = @"\\server\share\folder";
+            var baseDir = Path.GetTempPath();
+            var exception = Record.Exception(() => PathValidator.IsPathSafe(uncPath, baseDir));
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("über-cool")]
+        [InlineData("文件")]
+        [InlineData("パス")]
+        public void IsPathSafe_UnicodePath_ReturnsTrue(string pathComponent)
+        {
+            var exception = Record.Exception(() => PathValidator.IsPathSafe(pathComponent));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void IsPathSafe_TrailingSeparator_ReturnsTrue()
+        {
+            var safePath = Path.Combine(Environment.CurrentDirectory, "folder") + Path.DirectorySeparatorChar;
+            var result = PathValidator.IsPathSafe(safePath);
+            Assert.True(result);
         }
     }
 }

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -167,7 +167,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithPathTooLong_ReturnsNull()
+        public void ValidateAndCreateDirectory_WithPathTooLong_DoesNotThrow()
         {
             // Arrange - Create a path longer than max path length
             string longPath = Path.Combine(Path.GetTempPath(), new string('a', 300));
@@ -298,8 +298,8 @@ namespace Zipper
         [InlineData("パス")]
         public void IsPathSafe_UnicodePath_ReturnsTrue(string pathComponent)
         {
-            var exception = Record.Exception(() => PathValidator.IsPathSafe(pathComponent));
-            Assert.Null(exception);
+            var result = PathValidator.IsPathSafe(pathComponent);
+            Assert.True(result);
         }
 
         [Fact]

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -7,7 +7,7 @@ public class PerformanceBenchmarkRunnerTests
     [Fact]
     public async Task RunBenchmarks_CompletesWithoutThrowing()
     {
-        var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks());
+        var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks(new StringWriter()));
         Assert.Null(exception);
     }
 

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -1,0 +1,73 @@
+using Xunit;
+
+namespace Zipper
+{
+    public class PerformanceBenchmarkRunnerTests
+    {
+        [Fact]
+        public async Task RunBenchmarks_WritesAllFourSections()
+        {
+            var output = await CaptureOutputAsync();
+
+            Assert.Contains("Parallel vs Sequential", output);
+            Assert.Contains("Memory Pool Performance", output);
+            Assert.Contains("Scalability", output);
+            Assert.Contains("Allocation Impact", output);
+            Assert.Contains("Benchmark Suite Complete", output);
+        }
+
+        [Fact]
+        public async Task RunBenchmarks_PrintsTimingMetrics()
+        {
+            var output = await CaptureOutputAsync();
+
+            Assert.Contains("ms", output);
+            Assert.Contains("files/sec", output);
+            Assert.Contains("Status", output);
+        }
+
+        [Fact]
+        public async Task RunBenchmarks_CompletesWithoutThrowing()
+        {
+            var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks());
+            Assert.Null(exception);
+        }
+
+        private static async Task<string> CaptureOutputAsync()
+        {
+            var outputPath = Path.Combine(Path.GetTempPath(), $"bench_out_{Guid.NewGuid()}.txt");
+            try
+            {
+                var originalOut = Console.Out;
+                using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+                using var streamWriter = new StreamWriter(fileStream);
+                Console.SetOut(streamWriter);
+
+                try
+                {
+                    await PerformanceBenchmarkRunner.RunBenchmarks();
+                }
+                finally
+                {
+                    await streamWriter.FlushAsync();
+                    Console.SetOut(originalOut);
+                }
+
+                return await File.ReadAllTextAsync(outputPath);
+            }
+            finally
+            {
+                if (File.Exists(outputPath))
+                {
+                    try
+                    {
+                        File.Delete(outputPath);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -35,41 +35,21 @@ namespace Zipper
 
         private static async Task<string> CaptureOutputAsync()
         {
-            var outputPath = Path.Combine(Path.GetTempPath(), $"bench_out_{Guid.NewGuid()}.txt");
+            var originalOut = Console.Out;
+            using var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+
             try
             {
-                var originalOut = Console.Out;
-
-                using (var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read))
-                using (var streamWriter = new StreamWriter(fileStream))
-                {
-                    Console.SetOut(streamWriter);
-                    try
-                    {
-                        await PerformanceBenchmarkRunner.RunBenchmarks();
-                    }
-                    finally
-                    {
-                        await streamWriter.FlushAsync();
-                        Console.SetOut(originalOut);
-                    }
-                }
-
-                return await File.ReadAllTextAsync(outputPath);
+                await PerformanceBenchmarkRunner.RunBenchmarks();
             }
             finally
             {
-                if (File.Exists(outputPath))
-                {
-                    try
-                    {
-                        File.Delete(outputPath);
-                    }
-                    catch
-                    {
-                    }
-                }
+                await stringWriter.FlushAsync();
+                Console.SetOut(originalOut);
             }
+
+            return stringWriter.ToString();
         }
     }
 }

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -39,18 +39,20 @@ namespace Zipper
             try
             {
                 var originalOut = Console.Out;
-                using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read);
-                using var streamWriter = new StreamWriter(fileStream);
-                Console.SetOut(streamWriter);
 
-                try
+                using (var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                using (var streamWriter = new StreamWriter(fileStream))
                 {
-                    await PerformanceBenchmarkRunner.RunBenchmarks();
-                }
-                finally
-                {
-                    await streamWriter.FlushAsync();
-                    Console.SetOut(originalOut);
+                    Console.SetOut(streamWriter);
+                    try
+                    {
+                        await PerformanceBenchmarkRunner.RunBenchmarks();
+                    }
+                    finally
+                    {
+                        await streamWriter.FlushAsync();
+                        Console.SetOut(originalOut);
+                    }
                 }
 
                 return await File.ReadAllTextAsync(outputPath);

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -1,55 +1,42 @@
 using Xunit;
 
-namespace Zipper
+namespace Zipper.Tests;
+
+public class PerformanceBenchmarkRunnerTests
 {
-    public class PerformanceBenchmarkRunnerTests
+    [Fact]
+    public async Task RunBenchmarks_CompletesWithoutThrowing()
     {
-        [Fact]
-        public async Task RunBenchmarks_WritesAllFourSections()
-        {
-            var output = await CaptureOutputAsync();
+        var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks());
+        Assert.Null(exception);
+    }
 
-            Assert.Contains("Parallel vs Sequential", output);
-            Assert.Contains("Memory Pool Performance", output);
-            Assert.Contains("Scalability", output);
-            Assert.Contains("Allocation Impact", output);
-            Assert.Contains("Benchmark Suite Complete", output);
-        }
+    [Fact]
+    public async Task RunBenchmarks_WritesAllFourSections()
+    {
+        var output = await CaptureOutputAsync();
 
-        [Fact]
-        public async Task RunBenchmarks_PrintsTimingMetrics()
-        {
-            var output = await CaptureOutputAsync();
+        Assert.Contains("Parallel vs Sequential", output);
+        Assert.Contains("Memory Pool", output);
+        Assert.Contains("Scalability", output);
+        Assert.Contains("Allocation", output);
+        Assert.Contains("Benchmark Suite Complete", output);
+    }
 
-            Assert.Contains("ms", output);
-            Assert.Contains("files/sec", output);
-            Assert.Contains("Status", output);
-        }
+    [Fact]
+    public async Task RunBenchmarks_PrintsTimingMetrics()
+    {
+        var output = await CaptureOutputAsync();
 
-        [Fact]
-        public async Task RunBenchmarks_CompletesWithoutThrowing()
-        {
-            var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks());
-            Assert.Null(exception);
-        }
+        Assert.Contains("ms", output);
+        Assert.Contains("files/sec", output);
+        Assert.Contains("Status", output);
+    }
 
-        private static async Task<string> CaptureOutputAsync()
-        {
-            var originalOut = Console.Out;
-            using var stringWriter = new StringWriter();
-            Console.SetOut(stringWriter);
-
-            try
-            {
-                await PerformanceBenchmarkRunner.RunBenchmarks();
-            }
-            finally
-            {
-                await stringWriter.FlushAsync();
-                Console.SetOut(originalOut);
-            }
-
-            return stringWriter.ToString();
-        }
+    private static async Task<string> CaptureOutputAsync()
+    {
+        var writer = new StringWriter();
+        await PerformanceBenchmarkRunner.RunBenchmarks(writer);
+        return writer.ToString();
     }
 }

--- a/src/Zipper.Tests/PlaceholderFilesTests.cs
+++ b/src/Zipper.Tests/PlaceholderFilesTests.cs
@@ -1,0 +1,123 @@
+using Xunit;
+
+namespace Zipper
+{
+    public class PlaceholderFilesTests
+    {
+        [Fact]
+        public void GetContent_Pdf_ReturnsNonEmptyBytes()
+        {
+            var content = PlaceholderFiles.GetContent("pdf");
+            Assert.NotEmpty(content);
+        }
+
+        [Fact]
+        public void GetContent_Pdf_StartsWithPdfMagicBytes()
+        {
+            var content = PlaceholderFiles.GetContent("pdf");
+            Assert.Equal(0x25, content[0]);
+            Assert.Equal(0x50, content[1]);
+            Assert.Equal(0x44, content[2]);
+            Assert.Equal(0x46, content[3]);
+        }
+
+        [Fact]
+        public void GetContent_Jpg_ReturnsNonEmptyBytes()
+        {
+            var content = PlaceholderFiles.GetContent("jpg");
+            Assert.NotEmpty(content);
+        }
+
+        [Fact]
+        public void GetContent_Jpg_StartsWithJpegMagicBytes()
+        {
+            var content = PlaceholderFiles.GetContent("jpg");
+            Assert.Equal(0xFF, content[0]);
+            Assert.Equal(0xD8, content[1]);
+        }
+
+        [Fact]
+        public void GetContent_Tiff_ReturnsNonEmptyBytes()
+        {
+            var content = PlaceholderFiles.GetContent("tiff");
+            Assert.NotEmpty(content);
+        }
+
+        [Fact]
+        public void GetContent_Tiff_StartsWithTiffMagicBytes()
+        {
+            var content = PlaceholderFiles.GetContent("tiff");
+            Assert.Equal(0x49, content[0]);
+            Assert.Equal(0x49, content[1]);
+            Assert.Equal(0x2A, content[2]);
+            Assert.Equal(0x00, content[3]);
+        }
+
+        [Fact]
+        public void GetContent_UnknownType_ReturnsEmptyArray()
+        {
+            var content = PlaceholderFiles.GetContent("unknown");
+            Assert.Empty(content);
+        }
+
+        [Fact]
+        public void GetContent_IsCaseInsensitive_Lowercase()
+        {
+            var lower = PlaceholderFiles.GetContent("pdf");
+            var upper = PlaceholderFiles.GetContent("PDF");
+            Assert.Equal(lower, upper);
+        }
+
+        [Fact]
+        public void GetContent_IsCaseInsensitive_MixedCase()
+        {
+            var lower = PlaceholderFiles.GetContent("jpg");
+            var mixed = PlaceholderFiles.GetContent("JpG");
+            Assert.Equal(lower, mixed);
+        }
+
+        [Fact]
+        public void GetContent_EmptyString_ReturnsEmptyArray()
+        {
+            var content = PlaceholderFiles.GetContent(string.Empty);
+            Assert.Empty(content);
+        }
+
+        [Fact]
+        public void GetContent_NullString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => PlaceholderFiles.GetContent(null!));
+        }
+
+        [Fact]
+        public void GetRandomAttachment_ReturnsNonNull()
+        {
+            var attachment = PlaceholderFiles.GetRandomAttachment();
+            Assert.NotNull(attachment);
+            Assert.NotNull(attachment.Value.filename);
+            Assert.NotEmpty(attachment.Value.content);
+        }
+
+        [Fact]
+        public void GetRandomAttachment_FilenameHasCorrectExtension()
+        {
+            var nullableAttachment = PlaceholderFiles.GetRandomAttachment();
+            Assert.NotNull(nullableAttachment);
+            var attachment = nullableAttachment.Value;
+            Assert.StartsWith("attachment.", attachment.filename);
+            Assert.True(attachment.filename.EndsWith(".jpg") || attachment.filename.EndsWith(".pdf") || attachment.filename.EndsWith(".tiff"));
+        }
+
+        [Fact]
+        public void ExtractedText_IsNonEmpty()
+        {
+            Assert.NotEmpty(PlaceholderFiles.ExtractedText);
+        }
+
+        [Fact]
+        public void EmlExtractedText_IsNonEmpty()
+        {
+            Assert.NotEmpty(PlaceholderFiles.EmlExtractedText);
+        }
+    }
+}

--- a/src/Zipper.Tests/PlaceholderFilesTests.cs
+++ b/src/Zipper.Tests/PlaceholderFilesTests.cs
@@ -1,123 +1,122 @@
 using Xunit;
 
-namespace Zipper
+namespace Zipper;
+
+public class PlaceholderFilesTests
 {
-    public class PlaceholderFilesTests
+    [Fact]
+    public void GetContent_Pdf_ReturnsNonEmptyBytes()
     {
-        [Fact]
-        public void GetContent_Pdf_ReturnsNonEmptyBytes()
-        {
-            var content = PlaceholderFiles.GetContent("pdf");
-            Assert.NotEmpty(content);
-        }
+        var content = PlaceholderFiles.GetContent("pdf");
+        Assert.NotEmpty(content);
+    }
 
-        [Fact]
-        public void GetContent_Pdf_StartsWithPdfMagicBytes()
-        {
-            var content = PlaceholderFiles.GetContent("pdf");
-            Assert.Equal(0x25, content[0]);
-            Assert.Equal(0x50, content[1]);
-            Assert.Equal(0x44, content[2]);
-            Assert.Equal(0x46, content[3]);
-        }
+    [Fact]
+    public void GetContent_Pdf_StartsWithPdfMagicBytes()
+    {
+        var content = PlaceholderFiles.GetContent("pdf");
+        Assert.Equal(0x25, content[0]);
+        Assert.Equal(0x50, content[1]);
+        Assert.Equal(0x44, content[2]);
+        Assert.Equal(0x46, content[3]);
+    }
 
-        [Fact]
-        public void GetContent_Jpg_ReturnsNonEmptyBytes()
-        {
-            var content = PlaceholderFiles.GetContent("jpg");
-            Assert.NotEmpty(content);
-        }
+    [Fact]
+    public void GetContent_Jpg_ReturnsNonEmptyBytes()
+    {
+        var content = PlaceholderFiles.GetContent("jpg");
+        Assert.NotEmpty(content);
+    }
 
-        [Fact]
-        public void GetContent_Jpg_StartsWithJpegMagicBytes()
-        {
-            var content = PlaceholderFiles.GetContent("jpg");
-            Assert.Equal(0xFF, content[0]);
-            Assert.Equal(0xD8, content[1]);
-        }
+    [Fact]
+    public void GetContent_Jpg_StartsWithJpegMagicBytes()
+    {
+        var content = PlaceholderFiles.GetContent("jpg");
+        Assert.Equal(0xFF, content[0]);
+        Assert.Equal(0xD8, content[1]);
+    }
 
-        [Fact]
-        public void GetContent_Tiff_ReturnsNonEmptyBytes()
-        {
-            var content = PlaceholderFiles.GetContent("tiff");
-            Assert.NotEmpty(content);
-        }
+    [Fact]
+    public void GetContent_Tiff_ReturnsNonEmptyBytes()
+    {
+        var content = PlaceholderFiles.GetContent("tiff");
+        Assert.NotEmpty(content);
+    }
 
-        [Fact]
-        public void GetContent_Tiff_StartsWithTiffMagicBytes()
-        {
-            var content = PlaceholderFiles.GetContent("tiff");
-            Assert.Equal(0x49, content[0]);
-            Assert.Equal(0x49, content[1]);
-            Assert.Equal(0x2A, content[2]);
-            Assert.Equal(0x00, content[3]);
-        }
+    [Fact]
+    public void GetContent_Tiff_StartsWithTiffMagicBytes()
+    {
+        var content = PlaceholderFiles.GetContent("tiff");
+        Assert.Equal(0x49, content[0]);
+        Assert.Equal(0x49, content[1]);
+        Assert.Equal(0x2A, content[2]);
+        Assert.Equal(0x00, content[3]);
+    }
 
-        [Fact]
-        public void GetContent_UnknownType_ReturnsEmptyArray()
-        {
-            var content = PlaceholderFiles.GetContent("unknown");
-            Assert.Empty(content);
-        }
+    [Fact]
+    public void GetContent_UnknownType_ReturnsEmptyArray()
+    {
+        var content = PlaceholderFiles.GetContent("unknown");
+        Assert.Empty(content);
+    }
 
-        [Fact]
-        public void GetContent_IsCaseInsensitive_Lowercase()
-        {
-            var lower = PlaceholderFiles.GetContent("pdf");
-            var upper = PlaceholderFiles.GetContent("PDF");
-            Assert.Equal(lower, upper);
-        }
+    [Fact]
+    public void GetContent_IsCaseInsensitive_Lowercase()
+    {
+        var lower = PlaceholderFiles.GetContent("pdf");
+        var upper = PlaceholderFiles.GetContent("PDF");
+        Assert.Equal(lower, upper);
+    }
 
-        [Fact]
-        public void GetContent_IsCaseInsensitive_MixedCase()
-        {
-            var lower = PlaceholderFiles.GetContent("jpg");
-            var mixed = PlaceholderFiles.GetContent("JpG");
-            Assert.Equal(lower, mixed);
-        }
+    [Fact]
+    public void GetContent_IsCaseInsensitive_MixedCase()
+    {
+        var lower = PlaceholderFiles.GetContent("jpg");
+        var mixed = PlaceholderFiles.GetContent("JpG");
+        Assert.Equal(lower, mixed);
+    }
 
-        [Fact]
-        public void GetContent_EmptyString_ReturnsEmptyArray()
-        {
-            var content = PlaceholderFiles.GetContent(string.Empty);
-            Assert.Empty(content);
-        }
+    [Fact]
+    public void GetContent_EmptyString_ReturnsEmptyArray()
+    {
+        var content = PlaceholderFiles.GetContent(string.Empty);
+        Assert.Empty(content);
+    }
 
-        [Fact]
-        public void GetContent_NullString_Throws()
-        {
-            Assert.Throws<ArgumentNullException>(() => PlaceholderFiles.GetContent(null!));
-        }
+    [Fact]
+    public void GetContent_NullString_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => PlaceholderFiles.GetContent(null!));
+    }
 
-        [Fact]
-        public void GetRandomAttachment_ReturnsNonNull()
-        {
-            var attachment = PlaceholderFiles.GetRandomAttachment();
-            Assert.NotNull(attachment);
-            Assert.NotNull(attachment.Value.filename);
-            Assert.NotEmpty(attachment.Value.content);
-        }
+    [Fact]
+    public void GetRandomAttachment_ReturnsNonNull()
+    {
+        var attachment = PlaceholderFiles.GetRandomAttachment();
+        Assert.NotNull(attachment);
+        Assert.NotNull(attachment.Value.filename);
+        Assert.NotEmpty(attachment.Value.content);
+    }
 
-        [Fact]
-        public void GetRandomAttachment_FilenameHasCorrectExtension()
-        {
-            var nullableAttachment = PlaceholderFiles.GetRandomAttachment();
-            Assert.NotNull(nullableAttachment);
-            var attachment = nullableAttachment.Value;
-            Assert.StartsWith("attachment.", attachment.filename);
-            Assert.True(attachment.filename.EndsWith(".jpg") || attachment.filename.EndsWith(".pdf") || attachment.filename.EndsWith(".tiff"));
-        }
+    [Fact]
+    public void GetRandomAttachment_FilenameHasCorrectExtension()
+    {
+        var nullableAttachment = PlaceholderFiles.GetRandomAttachment();
+        Assert.NotNull(nullableAttachment);
+        var attachment = nullableAttachment.Value;
+        Assert.StartsWith("attachment.", attachment.filename);
+        Assert.True(attachment.filename.EndsWith(".jpg") || attachment.filename.EndsWith(".pdf") || attachment.filename.EndsWith(".tiff"));
+    }
 
-        [Fact]
-        public void ExtractedText_IsNonEmpty()
-        {
-            Assert.NotEmpty(PlaceholderFiles.ExtractedText);
-        }
+    [Fact]
+    public void ExtractedText_IsNonEmpty()
+    {
+        Assert.NotEmpty(PlaceholderFiles.ExtractedText);
+    }
 
-        [Fact]
-        public void EmlExtractedText_IsNonEmpty()
-        {
-            Assert.NotEmpty(PlaceholderFiles.EmlExtractedText);
-        }
+    [Fact]
+    public void EmlExtractedText_IsNonEmpty()
+    {
+        Assert.NotEmpty(PlaceholderFiles.EmlExtractedText);
     }
 }

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -355,4 +355,88 @@ public class ProductionSetTests : IDisposable
             },
         };
     }
+
+    [Fact]
+    public async Task ProductionSet_FileCountOne_CreatesSingleFile()
+    {
+        var request = this.CreateTestRequest(count: 1);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.Equal(1, result.TotalDocuments);
+        Assert.Equal(1, result.VolumeCount);
+
+        var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.*", SearchOption.AllDirectories);
+        Assert.Single(nativeFiles);
+    }
+
+    [Fact]
+    public async Task ProductionSet_VolumeSizeOne_EveryFileInOwnVolume()
+    {
+        var request = this.CreateTestRequest(count: 5, volumeSize: 1);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.Equal(5, result.VolumeCount);
+
+        var volDirs = Directory.GetDirectories(Path.Combine(result.ProductionPath, "NATIVES"));
+        Assert.Equal(5, volDirs.Length);
+    }
+
+    [Fact]
+    public async Task ProductionSet_VolumeSizeExceedsCount_SingleVolume()
+    {
+        var request = this.CreateTestRequest(count: 5, volumeSize: 100);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.Equal(1, result.VolumeCount);
+
+        var volDirs = Directory.GetDirectories(Path.Combine(result.ProductionPath, "NATIVES"));
+        Assert.Single(volDirs);
+    }
+
+    [Theory]
+    [InlineData("docx")]
+    [InlineData("xlsx")]
+    public async Task ProductionSet_WithOfficeTypes_CreatesNativeFiles(string fileType)
+    {
+        var request = this.CreateTestRequest(count: 3, fileType: fileType);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), $"*.{fileType}", SearchOption.AllDirectories);
+        Assert.Equal(3, nativeFiles.Length);
+
+        foreach (var file in nativeFiles)
+        {
+            var info = new FileInfo(file);
+            Assert.True(info.Length > 0);
+        }
+    }
+
+    [Fact]
+    public async Task ProductionSet_WithTiff_CreatesNativeFiles()
+    {
+        var request = this.CreateTestRequest(count: 3, fileType: "tiff");
+        request.TiffPageRange = (1, 5);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.tiff", SearchOption.AllDirectories);
+        Assert.Equal(3, nativeFiles.Length);
+
+        foreach (var file in nativeFiles)
+        {
+            var info = new FileInfo(file);
+            Assert.True(info.Length > 0);
+        }
+    }
+
+    [Fact]
+    public async Task ProductionSet_WithCustomEncoding_ProducesValidDat()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Encoding = "UTF-16";
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath, System.Text.Encoding.Unicode);
+        Assert.Contains("DOCID", datContent);
+        Assert.Equal(4, datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+    }
 }

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -1,19 +1,11 @@
 using System.IO.Compression;
 using System.Threading.Channels;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Zipper.Tests
 {
     public class ZipArchiveServiceTests
     {
-        private readonly ITestOutputHelper output;
-
-        public ZipArchiveServiceTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
-
         [Fact]
         public async Task CreateArchiveAsync_WithBasicFiles_CreatesValidArchive()
         {

--- a/src/Zipper.Tests/Zipper.Tests.csproj
+++ b/src/Zipper.Tests/Zipper.Tests.csproj
@@ -17,6 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Zipper.Tests/packages.lock.json
+++ b/src/Zipper.Tests/packages.lock.json
@@ -24,6 +24,12 @@
         "resolved": "13.0.4",
         "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.15.0, )",
+        "resolved": "4.15.0",
+        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+      },
       "StyleCop.Analyzers": {
         "type": "Direct",
         "requested": "[1.2.0-beta.556, )",

--- a/src/Zipper.csproj
+++ b/src/Zipper.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -30,6 +30,12 @@
         "resolved": "8.0.25",
         "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.15.0, )",
+        "resolved": "4.15.0",
+        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+      },
       "SixLabors.ImageSharp": {
         "type": "Direct",
         "requested": "[3.1.12, )",


### PR DESCRIPTION
## Summary
- Complete test coverage for T3-T14 across 10 test files (982 insertions)
- Add Roslynator.Analyzers 4.15.0 for additional bug-detection rules
- Enable CA reliability rules (CA1062, CA1854, CA1861, IDE0051, IDE0052)
- Add pre-commit `dotnet format --verify-no-changes` and `dotnet restore --locked-mode`
- Fix 22 existing analyzer violations (null checks, StringComparison, dead code)
- Update AGENTS.md workflow with post-change check and CI monitoring steps

## Test plan
- [x] All 606 unit tests pass
- [x] Build clean with 0 warnings, 0 errors
- [x] CI pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added null argument validation across services to prevent null reference exceptions
  * Improved case-insensitive file type comparisons for more reliable behavior
  * Enhanced memory pool handling for better file generation efficiency
  * Improved exception stack trace preservation

* **Chores**
  * Added code analysis tooling (Roslynator.Analyzers) for improved code quality
  * Introduced skills lockfile for version pinning and consistency
  * Updated developer workflow documentation with pre-commit linting guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->