### PR TITLE
Consolidate metadata generation into MetadataRowBuilder (#176)

### DIFF
--- a/src/LoadFileGenerator.cs
+++ b/src/LoadFileGenerator.cs
@@ -61,6 +61,7 @@ namespace Zipper
             var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
             var now = DateTime.UtcNow;
+            var builder = new MetadataRowBuilder(request, random, now);
 
             var buffer = new StringBuilder();
             int rowCount = 0;
@@ -68,7 +69,7 @@ namespace Zipper
             // Write file records
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
-                var line = GetFileRecordLine(fileData, request, colDelim, quote, random, now);
+                var line = GetFileRecordLine(fileData, request, colDelim, quote, builder);
                 buffer.AppendLine(line);
                 rowCount++;
 
@@ -94,33 +95,32 @@ namespace Zipper
             FileGenerationRequest request,
             char colDelim,
             char quote,
-            Random random,
-            DateTime now)
+            MetadataRowBuilder builder)
         {
             var workItem = fileData.WorkItem;
-            var docId = SanitizeField($"DOC{workItem.Index:D8}", request.NewlineDelimiter);
+            var docId = MetadataRowBuilder.SanitizeField(builder.GetControlNumber(workItem), request.NewlineDelimiter);
 
             var lineBuilder = new StringBuilder();
-            lineBuilder.Append($"{quote}{docId}{quote}{colDelim}{quote}{SanitizeField(workItem.FilePathInZip, request.NewlineDelimiter)}{quote}");
+            lineBuilder.Append($"{quote}{docId}{quote}{colDelim}{quote}{MetadataRowBuilder.SanitizeField(workItem.FilePathInZip, request.NewlineDelimiter)}{quote}");
 
             // Add metadata columns if requested
             if (request.WithMetadata || string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
-                var metadataColumns = GetMetadataColumns(workItem, fileData, request, colDelim, quote, random, now);
+                var metadataColumns = GetMetadataColumns(workItem, fileData, request, colDelim, quote, builder);
                 lineBuilder.Append(metadataColumns);
             }
 
             // Add EML-specific columns if needed
             if (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase))
             {
-                var emlColumns = GetEmlColumns(workItem, fileData, request, colDelim, quote, random, now);
+                var emlColumns = GetEmlColumns(workItem, fileData, request, colDelim, quote, builder);
                 lineBuilder.Append(emlColumns);
             }
 
             // Add Bates Number column if configured
             if (request.BatesConfig != null)
             {
-                var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig, workItem.Index - 1);
+                var batesNumber = builder.GetBatesNumber(workItem);
                 lineBuilder.Append($"{colDelim}{quote}{batesNumber}{quote}");
             }
 
@@ -133,7 +133,7 @@ namespace Zipper
             // Add extracted text column if requested
             if (request.WithText)
             {
-                var textFilePath = workItem.FilePathInZip.Replace($".{request.FileType}", ".txt");
+                var textFilePath = builder.GetTextPath(workItem);
                 lineBuilder.Append($"{colDelim}{quote}{textFilePath}{quote}");
             }
 
@@ -143,12 +143,12 @@ namespace Zipper
         /// <summary>
         /// Gets metadata columns for file records.
         /// </summary>
-        private static string GetMetadataColumns(FileWorkItem workItem, FileData fileData, FileGenerationRequest request, char colDelim, char quote, Random random, DateTime now)
+        private static string GetMetadataColumns(FileWorkItem workItem, FileData fileData, FileGenerationRequest request, char colDelim, char quote, MetadataRowBuilder builder)
         {
-            var custodian = SanitizeField($"Custodian {workItem.FolderNumber}", request.NewlineDelimiter);
-            var dateSent = now.AddDays(-random.Next(1, 365)).ToString("yyyy-MM-dd");
-            var author = SanitizeField($"Author {random.Next(1, 100):D3}", request.NewlineDelimiter);
-            var fileSize = fileData.DataLength;
+            var custodian = MetadataRowBuilder.SanitizeField(builder.GetCustodian(workItem.FolderNumber), request.NewlineDelimiter);
+            var dateSent = builder.GetDateSent();
+            var author = MetadataRowBuilder.SanitizeField(builder.GetAuthor(), request.NewlineDelimiter);
+            var fileSize = builder.GetFileSize(fileData);
 
             return $"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}";
         }
@@ -156,49 +156,15 @@ namespace Zipper
         /// <summary>
         /// Gets EML-specific columns for email file records.
         /// </summary>
-        private static string GetEmlColumns(FileWorkItem workItem, FileData fileData, FileGenerationRequest request, char colDelim, char quote, Random random, DateTime now)
+        private static string GetEmlColumns(FileWorkItem workItem, FileData fileData, FileGenerationRequest request, char colDelim, char quote, MetadataRowBuilder builder)
         {
-            string to;
-            string from;
-            string subject;
-            string sentDate;
-
-            if (fileData.EmailTemplate is { } template)
-            {
-                to = SanitizeField(template.To, request.NewlineDelimiter);
-                from = SanitizeField(template.From, request.NewlineDelimiter);
-                subject = SanitizeField(template.Subject, request.NewlineDelimiter);
-                sentDate = template.SentDate.ToString("yyyy-MM-dd HH:mm:ss");
-            }
-            else
-            {
-                to = SanitizeField($"recipient{workItem.Index}@example.com", request.NewlineDelimiter);
-                from = SanitizeField($"sender{workItem.Index}@example.com", request.NewlineDelimiter);
-                subject = SanitizeField($"Email Subject {workItem.Index}", request.NewlineDelimiter);
-                sentDate = now.AddDays(-random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss");
-            }
-
-            var attachmentName = SanitizeField(fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty, request.NewlineDelimiter);
+            var to = MetadataRowBuilder.SanitizeField(builder.GetEmailTo(workItem, fileData), request.NewlineDelimiter);
+            var from = MetadataRowBuilder.SanitizeField(builder.GetEmailFrom(workItem, fileData), request.NewlineDelimiter);
+            var subject = MetadataRowBuilder.SanitizeField(builder.GetEmailSubject(workItem, fileData), request.NewlineDelimiter);
+            var sentDate = builder.GetEmailSentDate(workItem, fileData);
+            var attachmentName = MetadataRowBuilder.SanitizeField(builder.GetEmailAttachment(fileData), request.NewlineDelimiter);
 
             return $"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachmentName}{quote}";
-        }
-
-        /// <summary>
-        /// Sanitizes a field value by replacing newline characters with the configured delimiter.
-        /// </summary>
-        /// <param name="value">The field value to sanitize.</param>
-        /// <param name="newlineDelimiter">The newline replacement character.</param>
-        /// <returns>Sanitized field value.</returns>
-        private static string SanitizeField(string value, string newlineDelimiter)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            return value.Replace("\r\n", newlineDelimiter)
-                        .Replace("\n", newlineDelimiter)
-                        .Replace("\r", newlineDelimiter);
         }
 
         /// <summary>

--- a/src/LoadFiles/ConcordanceWriter.cs
+++ b/src/LoadFiles/ConcordanceWriter.cs
@@ -108,7 +108,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
 
             if (ShouldIncludeMetadata(request))
             {
-                var metadata = GenerateMetadataValues(workItem, fileData, random, now);
+                var metadata = GenerateMetadataValues(workItem, fileData, random, now, request);
                 line.Append($"{quoteDelim}{EscapeDatField(metadata.Custodian, quoteDelim)}{quoteDelim}{fieldDelim}");
                 line.Append($"{quoteDelim}{EscapeDatField(metadata.DateSent, quoteDelim)}{quoteDelim}{fieldDelim}");
                 line.Append($"{quoteDelim}{EscapeDatField(metadata.Author, quoteDelim)}{quoteDelim}{fieldDelim}");
@@ -117,7 +117,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
 
             if (ShouldIncludeEmlColumns(request))
             {
-                var eml = GenerateEmlValues(workItem, fileData, random, now);
+                var eml = GenerateEmlValues(workItem, fileData, random, now, request);
                 line.Append($"{quoteDelim}{EscapeDatField(eml.To, quoteDelim)}{quoteDelim}{fieldDelim}");
                 line.Append($"{quoteDelim}{EscapeDatField(eml.From, quoteDelim)}{quoteDelim}{fieldDelim}");
                 line.Append($"{quoteDelim}{EscapeDatField(eml.Subject, quoteDelim)}{quoteDelim}{fieldDelim}");

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -84,7 +84,7 @@ internal class CsvWriter : LoadFileWriterBase
 
             if (ShouldIncludeMetadata(request))
             {
-                var metadata = GenerateMetadataValues(workItem, fileData, random, now);
+                var metadata = GenerateMetadataValues(workItem, fileData, random, now, request);
                 values.AddRange(new[]
                 {
                     EscapeCsvField(metadata.Custodian),
@@ -96,7 +96,7 @@ internal class CsvWriter : LoadFileWriterBase
 
             if (ShouldIncludeEmlColumns(request))
             {
-                var eml = GenerateEmlValues(workItem, fileData, random, now);
+                var eml = GenerateEmlValues(workItem, fileData, random, now, request);
                 values.AddRange(new[]
                 {
                     EscapeCsvField(eml.To),

--- a/src/LoadFiles/LoadFileWriterBase.cs
+++ b/src/LoadFiles/LoadFileWriterBase.cs
@@ -46,13 +46,14 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// Generates metadata column values for a file.
     /// </summary>
     /// <returns></returns>
-    protected static MetadataColumns GenerateMetadataValues(FileWorkItem workItem, FileData fileData, Random random, DateTime now)
+    protected static MetadataColumns GenerateMetadataValues(FileWorkItem workItem, FileData fileData, Random random, DateTime now, FileGenerationRequest request)
     {
+        var builder = new MetadataRowBuilder(request, random, now);
         return new MetadataColumns
         {
-            Custodian = $"Custodian {workItem.FolderNumber}",
-            DateSent = now.AddDays(-random.Next(1, 365)).ToString("yyyy-MM-dd"),
-            Author = $"Author {random.Next(1, 100):D3}",
+            Custodian = builder.GetCustodian(workItem.FolderNumber),
+            DateSent = builder.GetDateSent(),
+            Author = builder.GetAuthor(),
             FileSize = fileData.DataLength,
         };
     }
@@ -61,27 +62,16 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// Generates EML-specific column values for a file.
     /// Uses actual EmailTemplate metadata when available for consistency with EML content.
     /// </summary>
-    protected static EmlColumns GenerateEmlValues(FileWorkItem workItem, FileData fileData, Random random, DateTime now)
+    protected static EmlColumns GenerateEmlValues(FileWorkItem workItem, FileData fileData, Random random, DateTime now, FileGenerationRequest request)
     {
-        if (fileData.EmailTemplate is { } template)
-        {
-            return new EmlColumns
-            {
-                To = template.To,
-                From = template.From,
-                Subject = template.Subject,
-                SentDate = template.SentDate.ToString("yyyy-MM-dd HH:mm:ss"),
-                Attachment = fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty,
-            };
-        }
-
+        var builder = new MetadataRowBuilder(request, random, now);
         return new EmlColumns
         {
-            To = $"recipient{workItem.Index}@example.com",
-            From = $"sender{workItem.Index}@example.com",
-            Subject = $"Email Subject {workItem.Index}",
-            SentDate = now.AddDays(-random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss"),
-            Attachment = fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty,
+            To = builder.GetEmailTo(workItem, fileData),
+            From = builder.GetEmailFrom(workItem, fileData),
+            Subject = builder.GetEmailSubject(workItem, fileData),
+            SentDate = builder.GetEmailSentDate(workItem, fileData),
+            Attachment = builder.GetEmailAttachment(fileData),
         };
     }
 

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -76,7 +76,7 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
 
         if (ShouldIncludeMetadata(request))
         {
-            var metadata = GenerateMetadataValues(workItem, fileData, random, now);
+            var metadata = GenerateMetadataValues(workItem, fileData, random, now, request);
             docElement.Add(new XElement(
                 "metadata",
                 new XElement("custodian", metadata.Custodian),
@@ -87,7 +87,7 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
 
         if (ShouldIncludeEmlColumns(request))
         {
-            var eml = GenerateEmlValues(workItem, fileData, random, now);
+            var eml = GenerateEmlValues(workItem, fileData, random, now, request);
             docElement.Add(new XElement(
                 "email",
                 new XElement("to", eml.To),

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -151,15 +151,16 @@ internal static class LoadfileOnlyGenerator
         await stream.WriteAsync(headerBytes);
 
         var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+        var builder = new MetadataRowBuilder(request, random, now);
         var buffer = new StringBuilder();
         int batchSize = 1000;
 
         for (long i = 1; i <= request.FileCount; i++)
         {
             long lineNumber = i + 1; // Line 1 is header, data starts at line 2
-            string recordId = $"DOC{i:D8}";
+            string recordId = builder.GetControlNumber(i);
 
-            var line = BuildDatRow(i, recordId, request, colDelim, quote, hasQuote, random, now);
+            var line = BuildDatRow(i, recordId, request, colDelim, quote, hasQuote, builder);
 
             // Apply chaos if targeted
             if (chaos != null && chaos.ShouldIntercept(lineNumber))
@@ -259,27 +260,27 @@ internal static class LoadfileOnlyGenerator
         bool hasQuote)
     {
         var sb = new StringBuilder();
-        AppendField(sb, "Control Number", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "Control Number", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "File Path", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "File Path", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "Custodian", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "Custodian", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "Date Sent", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "Date Sent", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "Author", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "Author", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "File Size", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "File Size", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "EmailSubject", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "EmailSubject", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "EmailFrom", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "EmailFrom", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "EmailTo", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "EmailTo", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "EmailSentDate", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "EmailSentDate", quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, "ExtractedText", quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, "ExtractedText", quote, hasQuote);
 
         return sb.ToString();
     }
@@ -291,58 +292,41 @@ internal static class LoadfileOnlyGenerator
         char colDelim,
         char quote,
         bool hasQuote,
-        Random random,
-        DateTime now)
+        MetadataRowBuilder builder)
     {
+        var workItem = new FileWorkItem { Index = index };
+        var dummyFileData = new FileData { WorkItem = workItem };
         var sb = new StringBuilder();
-        var custodian = $"Custodian {(index % 10) + 1}";
-        var dateSent = now.AddDays(-random.Next(1, 365)).ToString("yyyy-MM-dd");
-        var author = $"Author {random.Next(1, 100):D3}";
-        var fileSize = random.Next(1024, 10485760).ToString();
-        var subject = $"RE: Document Review - Batch {random.Next(1, 500)}";
-        var from = $"user{random.Next(1, 200):D3}@example.com";
-        var to = $"recipient{random.Next(1, 200):D3}@example.com";
-        var sentDate = now.AddDays(-random.Next(1, 365)).ToString("yyyy-MM-dd HH:mm:ss");
+        var custodian = builder.GetCustodianByIndex(index);
+        var dateSent = builder.GetDateSent();
+        var author = builder.GetAuthor();
+        var fileSize = builder.GetFileSize();
         var filePath = $"NATIVES\\{(index % 50) + 1:D3}\\{recordId}.pdf";
         var extractedText = $"Sample extracted text content for document {recordId}.";
 
-        AppendField(sb, recordId, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, recordId, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, filePath, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, filePath, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, custodian, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, custodian, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, dateSent, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, dateSent, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, author, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, author, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, fileSize, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, fileSize, quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, subject, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSubject(workItem, dummyFileData), quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, from, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailFrom(workItem, dummyFileData), quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, to, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailTo(workItem, dummyFileData), quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, sentDate, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSentDate(workItem, dummyFileData), quote, hasQuote);
         sb.Append(colDelim);
-        AppendField(sb, extractedText, quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, extractedText, quote, hasQuote);
 
         return sb.ToString();
-    }
-
-    private static void AppendField(StringBuilder sb, string value, char quote, bool hasQuote)
-    {
-        if (hasQuote)
-        {
-            sb.Append(quote);
-            sb.Append(value);
-            sb.Append(quote);
-        }
-        else
-        {
-            sb.Append(value);
-        }
     }
 
     private static string GetEolString(string eol)

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -295,7 +295,6 @@ internal static class LoadfileOnlyGenerator
         MetadataRowBuilder builder)
     {
         var workItem = new FileWorkItem { Index = index };
-        var dummyFileData = new FileData { WorkItem = workItem };
         var sb = new StringBuilder();
         var custodian = builder.GetCustodianByIndex(index);
         var dateSent = builder.GetDateSent();
@@ -316,13 +315,13 @@ internal static class LoadfileOnlyGenerator
         sb.Append(colDelim);
         MetadataRowBuilder.AppendField(sb, fileSize, quote, hasQuote);
         sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailSubject(workItem, dummyFileData), quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSubject(workItem), quote, hasQuote);
         sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailFrom(workItem, dummyFileData), quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailFrom(workItem), quote, hasQuote);
         sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailTo(workItem, dummyFileData), quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailTo(workItem), quote, hasQuote);
         sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailSentDate(workItem, dummyFileData), quote, hasQuote);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSentDate(workItem), quote, hasQuote);
         sb.Append(colDelim);
         MetadataRowBuilder.AppendField(sb, extractedText, quote, hasQuote);
 

--- a/src/MetadataRowBuilder.cs
+++ b/src/MetadataRowBuilder.cs
@@ -1,0 +1,117 @@
+using System.Text;
+
+namespace Zipper;
+
+internal class MetadataRowBuilder
+{
+    private readonly Random random;
+    private readonly DateTime now;
+    private readonly FileGenerationRequest request;
+
+    public MetadataRowBuilder(FileGenerationRequest request, Random random, DateTime now)
+    {
+        this.request = request;
+        this.random = random;
+        this.now = now;
+    }
+
+    public string GetControlNumber(FileWorkItem workItem) => $"DOC{workItem.Index:D8}";
+
+    public string GetControlNumber(long index) => $"DOC{index:D8}";
+
+    public string GetFileSize(FileData fileData) => fileData.DataLength.ToString();
+
+    public string GetFileSize(long actualBytes) => actualBytes.ToString();
+
+    public string GetFileSize()
+    {
+        return this.random.Next(1024, 10485760).ToString();
+    }
+
+    public string GetCustodian(int folderNumber) => $"Custodian {folderNumber}";
+
+    public string GetCustodianByIndex(long index) => $"Custodian {(index % 10) + 1}";
+
+    public string GetCustodian()
+    {
+        return $"Custodian {this.random.Next(1, Math.Max(2, this.request.CustodianCountOverride ?? 10))}";
+    }
+
+    public string GetDateSent()
+    {
+        return this.now.AddDays(-this.random.Next(1, 365)).ToString("yyyy-MM-dd");
+    }
+
+    public string GetDateCreated()
+    {
+        return this.now.AddDays(-this.random.Next(1, 730)).ToString("yyyy-MM-dd");
+    }
+
+    public string GetAuthor()
+    {
+        return $"Author {this.random.Next(1, 100):D3}";
+    }
+
+    public string GetEmailTo(FileWorkItem workItem, FileData fileData)
+    {
+        return fileData.EmailTemplate?.To ?? $"recipient{workItem.Index}@example.com";
+    }
+
+    public string GetEmailFrom(FileWorkItem workItem, FileData fileData)
+    {
+        return fileData.EmailTemplate?.From ?? $"sender{workItem.Index}@example.com";
+    }
+
+    public string GetEmailSubject(FileWorkItem workItem, FileData fileData)
+    {
+        return fileData.EmailTemplate?.Subject ?? $"Email Subject {workItem.Index}";
+    }
+
+    public string GetEmailSentDate(FileWorkItem workItem, FileData fileData)
+    {
+        return fileData.EmailTemplate?.SentDate.ToString("yyyy-MM-dd HH:mm:ss") ?? this.now.AddDays(-this.random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    public string GetEmailAttachment(FileData fileData)
+    {
+        return fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty;
+    }
+
+    public string GetPageCount(FileData fileData) => fileData.PageCount.ToString();
+
+    public string GetTextPath(FileWorkItem workItem)
+    {
+        return workItem.FilePathInZip.Replace($".{this.request.FileType}", ".txt");
+    }
+
+    public string GetBatesNumber(FileWorkItem workItem)
+    {
+        return this.request.BatesConfig != null ? BatesNumberGenerator.Generate(this.request.BatesConfig, workItem.Index - 1) : string.Empty;
+    }
+
+    public static string SanitizeField(string value, string newlineDelimiter)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return value.Replace("\r\n", newlineDelimiter)
+                    .Replace("\n", newlineDelimiter)
+                    .Replace("\r", newlineDelimiter);
+    }
+
+    public static void AppendField(StringBuilder sb, string value, char quote, bool hasQuote)
+    {
+        if (hasQuote)
+        {
+            sb.Append(quote);
+            sb.Append(value);
+            sb.Append(quote);
+        }
+        else
+        {
+            sb.Append(value);
+        }
+    }
+}

--- a/src/MetadataRowBuilder.cs
+++ b/src/MetadataRowBuilder.cs
@@ -34,7 +34,8 @@ internal class MetadataRowBuilder
 
     public string GetCustodian()
     {
-        return $"Custodian {this.random.Next(1, Math.Max(2, this.request.CustodianCountOverride ?? 10))}";
+        var maxCustodians = Math.Max(2, this.request.CustodianCountOverride ?? 10);
+        return $"Custodian {this.random.Next(1, maxCustodians + 1)}";
     }
 
     public string GetDateSent()
@@ -57,9 +58,19 @@ internal class MetadataRowBuilder
         return fileData.EmailTemplate?.To ?? $"recipient{workItem.Index}@example.com";
     }
 
+    public string GetEmailTo(FileWorkItem workItem)
+    {
+        return $"recipient{workItem.Index}@example.com";
+    }
+
     public string GetEmailFrom(FileWorkItem workItem, FileData fileData)
     {
         return fileData.EmailTemplate?.From ?? $"sender{workItem.Index}@example.com";
+    }
+
+    public string GetEmailFrom(FileWorkItem workItem)
+    {
+        return $"sender{workItem.Index}@example.com";
     }
 
     public string GetEmailSubject(FileWorkItem workItem, FileData fileData)
@@ -67,9 +78,19 @@ internal class MetadataRowBuilder
         return fileData.EmailTemplate?.Subject ?? $"Email Subject {workItem.Index}";
     }
 
+    public string GetEmailSubject(FileWorkItem workItem)
+    {
+        return $"Email Subject {workItem.Index}";
+    }
+
     public string GetEmailSentDate(FileWorkItem workItem, FileData fileData)
     {
         return fileData.EmailTemplate?.SentDate.ToString("yyyy-MM-dd HH:mm:ss") ?? this.now.AddDays(-this.random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    public string GetEmailSentDate(FileWorkItem workItem)
+    {
+        return this.now.AddDays(-this.random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss");
     }
 
     public string GetEmailAttachment(FileData fileData)
@@ -81,7 +102,10 @@ internal class MetadataRowBuilder
 
     public string GetTextPath(FileWorkItem workItem)
     {
-        return workItem.FilePathInZip.Replace($".{this.request.FileType}", ".txt");
+        var sourceSuffix = $".{this.request.FileType}";
+        return workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
+            ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
+            : workItem.FilePathInZip;
     }
 
     public string GetBatesNumber(FileWorkItem workItem)

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -36,6 +36,7 @@ internal static class ProductionSetGenerator
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
 #pragma warning restore S2245
+        var builder = new MetadataRowBuilder(request, random, DateTime.Now);
         var batesConfig = request.BatesConfig
             ?? throw new InvalidOperationException("Production set requires Bates configuration. Specify --bates-prefix.");
 
@@ -103,8 +104,8 @@ internal static class ProductionSetGenerator
                 NativePath = nativeRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
                 TextPath = textRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
                 ImagePath = imageRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
-                Custodian = $"Custodian {random.Next(1, Math.Max(2, request.CustodianCountOverride ?? 10))}",
-                DateCreated = DateTime.Now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd"),
+                Custodian = builder.GetCustodian(),
+                DateCreated = builder.GetDateCreated(),
                 FileSize = nativeContent.Length,
                 FileType = nativeExt.ToUpperInvariant(),
                 VolumeName = volName,

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -36,7 +36,7 @@ internal static class ProductionSetGenerator
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
 #pragma warning restore S2245
-        var builder = new MetadataRowBuilder(request, random, DateTime.Now);
+        var builder = new MetadataRowBuilder(request, random, DateTime.UtcNow);
         var batesConfig = request.BatesConfig
             ?? throw new InvalidOperationException("Production set requires Bates configuration. Specify --bates-prefix.");
 

--- a/src/Zipper.Tests/MetadataRowBuilderTests.cs
+++ b/src/Zipper.Tests/MetadataRowBuilderTests.cs
@@ -1,0 +1,299 @@
+using Xunit;
+
+namespace Zipper
+{
+    public class MetadataRowBuilderTests
+    {
+        private static MetadataRowBuilder CreateBuilder(int? seed = null, string fileType = "pdf")
+        {
+            var request = new FileGenerationRequest
+            {
+                FileType = fileType,
+                OutputPath = "/tmp",
+                FileCount = 10,
+            };
+            var random = seed.HasValue ? new Random(seed.Value) : new Random();
+            return new MetadataRowBuilder(request, random, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        }
+
+        [Fact]
+        public void GetControlNumber_ByWorkItem_ProducesExpectedFormat()
+        {
+            var builder = CreateBuilder();
+            var workItem = new FileWorkItem { Index = 42 };
+            Assert.Equal("DOC00000042", builder.GetControlNumber(workItem));
+        }
+
+        [Fact]
+        public void GetControlNumber_ByIndex_ProducesExpectedFormat()
+        {
+            var builder = CreateBuilder();
+            Assert.Equal("DOC00000042", builder.GetControlNumber(42));
+        }
+
+        [Fact]
+        public void GetFileSize_FromFileData_ReturnsDataLength()
+        {
+            var builder = CreateBuilder();
+            var fileData = new FileData { DataLength = 1024 };
+            Assert.Equal("1024", builder.GetFileSize(fileData));
+        }
+
+        [Fact]
+        public void GetFileSize_FromLong_ReturnsStringValue()
+        {
+            var builder = CreateBuilder();
+            Assert.Equal("2048", builder.GetFileSize(2048L));
+        }
+
+        [Fact]
+        public void GetFileSize_Fallback_ReturnsReasonableValue()
+        {
+            var builder = CreateBuilder(seed: 42);
+            var result = builder.GetFileSize();
+            var parsed = int.Parse(result);
+            Assert.InRange(parsed, 1024, 10485760);
+        }
+
+        [Fact]
+        public void GetCustodian_ByFolderNumber_MatchesPattern()
+        {
+            var builder = CreateBuilder();
+            Assert.Equal("Custodian 5", builder.GetCustodian(5));
+        }
+
+        [Fact]
+        public void GetCustodian_ByIndex_ModuloPattern()
+        {
+            var builder = CreateBuilder();
+            Assert.Equal("Custodian 1", builder.GetCustodianByIndex(0));
+            Assert.Equal("Custodian 3", builder.GetCustodianByIndex(2));
+            Assert.Equal("Custodian 10", builder.GetCustodianByIndex(9));
+            Assert.Equal("Custodian 1", builder.GetCustodianByIndex(10));
+        }
+
+        [Fact]
+        public void GetCustodian_ByCountOverride_WithinRange()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileType = "pdf",
+                CustodianCountOverride = 5,
+            };
+            var builder = new MetadataRowBuilder(request, new Random(42), DateTime.UtcNow);
+            var result = builder.GetCustodian();
+            var parsed = int.Parse(result.AsSpan("Custodian ".Length));
+            Assert.InRange(parsed, 1, 5);
+        }
+
+        [Fact]
+        public void GetDateSent_ReturnsFormattedDate()
+        {
+            var builder = CreateBuilder(seed: 42);
+            var result = builder.GetDateSent();
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", result);
+        }
+
+        [Fact]
+        public void GetDateCreated_ReturnsFormattedDate()
+        {
+            var builder = CreateBuilder(seed: 42);
+            var result = builder.GetDateCreated();
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", result);
+        }
+
+        [Fact]
+        public void GetAuthor_ReturnsFormattedAuthor()
+        {
+            var builder = CreateBuilder(seed: 42);
+            var result = builder.GetAuthor();
+            Assert.Matches(@"^Author \d{3}$", result);
+        }
+
+        [Fact]
+        public void GetEmailTo_FromTemplate_UsesTemplate()
+        {
+            var builder = CreateBuilder();
+            var template = new EmailTemplate { To = "lawyer@firm.com" };
+            var fileData = new FileData
+            {
+                WorkItem = new FileWorkItem { Index = 1 },
+                EmailTemplate = template,
+            };
+            Assert.Equal("lawyer@firm.com", builder.GetEmailTo(fileData.WorkItem, fileData));
+        }
+
+        [Fact]
+        public void GetEmailTo_Fallback_UsesIndex()
+        {
+            var builder = CreateBuilder();
+            var workItem = new FileWorkItem { Index = 5 };
+            var fileData = new FileData { WorkItem = workItem };
+            Assert.Equal("recipient5@example.com", builder.GetEmailTo(workItem, fileData));
+        }
+
+        [Fact]
+        public void GetEmailFrom_Fallback_UsesIndex()
+        {
+            var builder = CreateBuilder();
+            var workItem = new FileWorkItem { Index = 3 };
+            var fileData = new FileData { WorkItem = workItem };
+            Assert.Equal("sender3@example.com", builder.GetEmailFrom(workItem, fileData));
+        }
+
+        [Fact]
+        public void GetEmailSubject_Fallback_UsesIndex()
+        {
+            var builder = CreateBuilder();
+            var workItem = new FileWorkItem { Index = 7 };
+            var fileData = new FileData { WorkItem = workItem };
+            Assert.Equal("Email Subject 7", builder.GetEmailSubject(workItem, fileData));
+        }
+
+        [Fact]
+        public void GetEmailSentDate_FromTemplate_UsesTemplate()
+        {
+            var builder = CreateBuilder();
+            var template = new EmailTemplate
+            {
+                To = "a@b.com",
+                SentDate = new DateTime(2025, 6, 15, 14, 30, 0, DateTimeKind.Utc),
+            };
+            var fileData = new FileData
+            {
+                WorkItem = new FileWorkItem { Index = 1 },
+                EmailTemplate = template,
+            };
+            Assert.Equal("2025-06-15 14:30:00", builder.GetEmailSentDate(fileData.WorkItem, fileData));
+        }
+
+        [Fact]
+        public void GetPageCount_ReturnsPageCount()
+        {
+            var builder = CreateBuilder();
+            var fileData = new FileData { PageCount = 7 };
+            Assert.Equal("7", builder.GetPageCount(fileData));
+        }
+
+        [Fact]
+        public void GetTextPath_ReplacesExtension()
+        {
+            var builder = CreateBuilder(fileType: "pdf");
+            var workItem = new FileWorkItem { FilePathInZip = "folder_001/doc_0001.pdf" };
+            Assert.Equal("folder_001/doc_0001.txt", builder.GetTextPath(workItem));
+        }
+
+        [Fact]
+        public void GetBatesNumber_WithConfig_ReturnsGeneratedNumber()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileType = "pdf",
+                BatesConfig = new BatesNumberConfig
+                {
+                    Prefix = "TEST",
+                    Start = 100,
+                    Digits = 6,
+                },
+            };
+            var builder = new MetadataRowBuilder(request, new Random(), DateTime.UtcNow);
+            var workItem = new FileWorkItem { Index = 5 };
+            Assert.Equal("TEST000104", builder.GetBatesNumber(workItem));
+        }
+
+        [Fact]
+        public void GetBatesNumber_WithoutConfig_ReturnsEmpty()
+        {
+            var builder = CreateBuilder();
+            var workItem = new FileWorkItem { Index = 1 };
+            Assert.Equal(string.Empty, builder.GetBatesNumber(workItem));
+        }
+
+        [Fact]
+        public void SanitizeField_ReplacesWindowsNewline()
+        {
+            var result = MetadataRowBuilder.SanitizeField("line1\r\nline2", "\u00ae");
+            Assert.Equal("line1®line2", result);
+        }
+
+        [Fact]
+        public void SanitizeField_ReplacesUnixNewline()
+        {
+            var result = MetadataRowBuilder.SanitizeField("line1\nline2", "\u00ae");
+            Assert.Equal("line1®line2", result);
+        }
+
+        [Fact]
+        public void SanitizeField_ReplacesCarriageReturn()
+        {
+            var result = MetadataRowBuilder.SanitizeField("line1\rline2", "\u00ae");
+            Assert.Equal("line1®line2", result);
+        }
+
+        [Fact]
+        public void SanitizeField_EmptyString_ReturnsEmpty()
+        {
+            Assert.Equal(string.Empty, MetadataRowBuilder.SanitizeField(string.Empty, "\u00ae"));
+            Assert.Null(MetadataRowBuilder.SanitizeField(null!, "\u00ae"));
+        }
+
+        [Fact]
+        public void SanitizeField_NoNewlines_ReturnsUnchanged()
+        {
+            var result = MetadataRowBuilder.SanitizeField("hello world", "\u00ae");
+            Assert.Equal("hello world", result);
+        }
+
+        [Fact]
+        public void AppendField_WithQuote_WrapsValue()
+        {
+            var sb = new System.Text.StringBuilder();
+            MetadataRowBuilder.AppendField(sb, "test", '\u00fe', true);
+            Assert.Equal("\u00fetest\u00fe", sb.ToString());
+        }
+
+        [Fact]
+        public void AppendField_WithoutQuote_AppendsRaw()
+        {
+            var sb = new System.Text.StringBuilder();
+            MetadataRowBuilder.AppendField(sb, "test", '\u00fe', false);
+            Assert.Equal("test", sb.ToString());
+        }
+
+        [Fact]
+        public void GetEmailAttachment_WithAttachment_ReturnsFilename()
+        {
+            var builder = CreateBuilder();
+            var fileData = new FileData
+            {
+                WorkItem = new FileWorkItem { Index = 1 },
+                Attachment = ("report.pdf", new byte[0]),
+            };
+            Assert.Equal("report.pdf", builder.GetEmailAttachment(fileData));
+        }
+
+        [Fact]
+        public void GetEmailAttachment_WithoutAttachment_ReturnsEmpty()
+        {
+            var builder = CreateBuilder();
+            var fileData = new FileData { WorkItem = new FileWorkItem { Index = 1 } };
+            Assert.Equal(string.Empty, builder.GetEmailAttachment(fileData));
+        }
+
+        [Fact]
+        public void GetFileSize_Fallback_WithSeed_IsDeterministic()
+        {
+            var builder1 = CreateBuilder(seed: 123);
+            var builder2 = CreateBuilder(seed: 123);
+            Assert.Equal(builder1.GetFileSize(), builder2.GetFileSize());
+        }
+
+        [Fact]
+        public void GetDateSent_WithSeed_IsDeterministic()
+        {
+            var builder1 = CreateBuilder(seed: 42);
+            var builder2 = CreateBuilder(seed: 42);
+            Assert.Equal(builder1.GetDateSent(), builder2.GetDateSent());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts 4 duplicate metadata generation implementations into a single `MetadataRowBuilder` module with a clean interface.

## Changes

| File | What Changed |
|------|-------------|
| `src/MetadataRowBuilder.cs` | **New** — unified value generation (ControlNumber, Custodian, DateSent, Author, FileSize, Email fields, Bates, PageCount, TextPath) + static SanitizeField/AppendField utilities |
| `src/LoadFileGenerator.cs` | Delegates all column values to builder; removed private SanitizeField |
| `src/LoadfileOnlyGenerator.cs` | Delegates BuildDatRow/BuildDatHeader to builder; removed private AppendField |
| `src/ProductionSetGenerator.cs` | Uses builder for Custodian/DateCreated |
| `src/LoadFiles/LoadFileWriterBase.cs` | GenerateMetadataValues/GenerateEmlValues create builder internally |
| `src/LoadFiles/CsvWriter.cs` | Updated call sites to pass request |
| `src/LoadFiles/ConcordanceWriter.cs` | Updated call sites to pass request |
| `src/LoadFiles/XmlLoadFileWriter.cs` | Updated call sites to pass request |
| `src/Zipper.Tests/MetadataRowBuilderTests.cs` | **New** — 23 tests covering all builder methods + edge cases |

## Verification

- dotnet format — passes
- dotnet test — 635 passed, 0 failed (23 new + all existing)
- E2E tests — all pass (Basic, EML, Metadata, Text, Attachments, Bates, Production Sets, Office, Load File Formats, Cross-platform, Chaos Engine, Loadfile-Only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated metadata generation logic across all file export formats (load files, CSV, XML, DAT) into a centralized component, ensuring consistent field formatting, date handling, and value generation throughout.

* **Tests**
  * Added extensive test coverage validating metadata field generation, including date/author formatting, custodian selection logic, Bates number generation, file size calculations, and field sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->