### PR TITLE
fix: unify load file writing into single ILoadFileWriter seam (#177)

### DIFF
--- a/.opencode/skills/improve-codebase-architecture
+++ b/.opencode/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+/home/dom/Downloads/repos/skills/skills/engineering/improve-codebase-architecture

--- a/src/LoadFiles/ConcordanceWriter.cs
+++ b/src/LoadFiles/ConcordanceWriter.cs
@@ -14,7 +14,8 @@ internal class ConcordanceWriter : LoadFileWriterBase
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles)
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
         await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -14,7 +14,8 @@ internal class CsvWriter : LoadFileWriterBase
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles)
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
         await using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);

--- a/src/LoadFiles/ILoadFileWriter.cs
+++ b/src/LoadFiles/ILoadFileWriter.cs
@@ -21,6 +21,7 @@ internal interface ILoadFileWriter
     /// <param name="stream">Output stream.</param>
     /// <param name="request">File generation request parameters.</param>
     /// <param name="processedFiles">List of processed file data.</param>
+    /// <param name="chaosEngine">Optional chaos engine for anomaly injection.</param>
     /// <returns>Task representing the write operation.</returns>
-    Task WriteAsync(Stream stream, FileGenerationRequest request, System.Collections.Generic.List<FileData> processedFiles);
+    Task WriteAsync(Stream stream, FileGenerationRequest request, System.Collections.Generic.List<FileData> processedFiles, ChaosEngine? chaosEngine = null);
 }

--- a/src/LoadFiles/LoadFileWriterBase.cs
+++ b/src/LoadFiles/LoadFileWriterBase.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Zipper.LoadFiles;
 
 /// <summary>
@@ -12,7 +14,8 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     public abstract System.Threading.Tasks.Task WriteAsync(
         System.IO.Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles);
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null);
 
     /// <summary>
     /// Gets the file type in lowercase for comparisons.
@@ -140,6 +143,69 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
         }
 
         return field;
+    }
+
+    /// <summary>
+    /// Gets the end-of-line string from the configured EOL specifier.
+    /// </summary>
+    internal static string GetEolString(string eol) => eol?.ToUpperInvariant() switch
+    {
+        "LF" => "\n",
+        "CR" => "\r",
+        _ => "\r\n",
+    };
+
+    /// <summary>
+    /// Creates a StreamWriter with the configured encoding, leaving the underlying stream open.
+    /// </summary>
+    protected static StreamWriter CreateWriter(Stream stream, FileGenerationRequest request)
+    {
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        return new StreamWriter(stream, encoding, leaveOpen: true);
+    }
+
+    /// <summary>
+    /// Flushes the StringBuilder buffer to the stream in batches.
+    /// </summary>
+    protected static async Task FlushBufferAsync(StreamWriter writer, StringBuilder buffer)
+    {
+        if (buffer.Length > 0)
+        {
+            await writer.WriteAsync(buffer.ToString());
+            buffer.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Applies chaos interception to a line if the Chaos Engine targets this line number.
+    /// </summary>
+    protected static string ApplyChaosInterception(ChaosEngine? chaos, long lineNumber, string line, string recordId)
+    {
+        if (chaos != null && chaos.ShouldIntercept(lineNumber))
+        {
+            return chaos.Intercept(lineNumber, line, recordId);
+        }
+
+        return line;
+    }
+
+    /// <summary>
+    /// Writes encoding anomaly bytes between lines if the Chaos Engine has an anomaly for this boundary.
+    /// Returns true if bytes were written.
+    /// </summary>
+    protected static async Task<bool> WriteEncodingAnomalyBytesAsync(Stream stream, ChaosEngine? chaos, long lineNumber, long nextLineNumber, Encoding encoding)
+    {
+        if (chaos != null)
+        {
+            var anomaly = chaos.GetEncodingAnomaly(lineNumber, nextLineNumber, encoding);
+            if (anomaly != null)
+            {
+                await stream.WriteAsync(anomaly);
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 

--- a/src/LoadFiles/LoadFileWriterFactory.cs
+++ b/src/LoadFiles/LoadFileWriterFactory.cs
@@ -37,7 +37,8 @@ internal class DatWriter : ILoadFileWriter
     public async System.Threading.Tasks.Task WriteAsync(
         System.IO.Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles)
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
     {
         var encoding = Zipper.EncodingHelper.GetEncodingOrDefault(request.Encoding);
 

--- a/src/LoadFiles/LoadfileOnlyDatWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyDatWriter.cs
@@ -23,7 +23,7 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
         using var memStream = new MemoryStream();
 
         // Build header
-        var header = BuildDatHeader(request, colDelim, quote, hasQuote);
+        var header = BuildDatHeader(colDelim, quote, hasQuote);
 
         // Apply chaos to header (line 1)
         header = ApplyChaosInterception(chaosEngine, 1, header, "HEADER");
@@ -45,7 +45,7 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
             long lineNumber = i + 1;
             string recordId = builder.GetControlNumber(i);
 
-            var line = BuildDatRow(i, recordId, request, colDelim, quote, hasQuote, builder);
+            var line = BuildDatRow(i, recordId, colDelim, quote, hasQuote, builder);
 
             line = ApplyChaosInterception(chaosEngine, lineNumber, line, recordId);
 
@@ -82,7 +82,6 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
     }
 
     private static string BuildDatHeader(
-        FileGenerationRequest request,
         char colDelim,
         char quote,
         bool hasQuote)
@@ -116,7 +115,6 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
     private static string BuildDatRow(
         long index,
         string recordId,
-        FileGenerationRequest request,
         char colDelim,
         char quote,
         bool hasQuote,

--- a/src/LoadFiles/LoadfileOnlyDatWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyDatWriter.cs
@@ -1,0 +1,158 @@
+using System.Text;
+
+namespace Zipper.LoadFiles;
+
+internal class LoadfileOnlyDatWriter : LoadFileWriterBase
+{
+    public override string FormatName => "DAT (Metadata)";
+
+    public override string FileExtension => ".dat";
+
+    public override async Task WriteAsync(
+        Stream stream,
+        FileGenerationRequest request,
+        List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
+    {
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var eolString = GetEolString(request.EndOfLine);
+        char colDelim = !string.IsNullOrEmpty(request.ColumnDelimiter) ? request.ColumnDelimiter[0] : '\u0014';
+        char quote = !string.IsNullOrEmpty(request.QuoteDelimiter) ? request.QuoteDelimiter[0] : '\u00fe';
+        bool hasQuote = !string.IsNullOrEmpty(request.QuoteDelimiter);
+
+        using var memStream = new MemoryStream();
+
+        // Build header
+        var header = BuildDatHeader(request, colDelim, quote, hasQuote);
+
+        // Apply chaos to header (line 1)
+        header = ApplyChaosInterception(chaosEngine, 1, header, "HEADER");
+
+        var headerBytes = encoding.GetBytes(header + eolString);
+        await memStream.WriteAsync(headerBytes);
+
+        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+
+#pragma warning disable S2245
+        var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
+#pragma warning restore S2245
+
+        var builder = new MetadataRowBuilder(request, random, now);
+        var buffer = new StringBuilder();
+
+        for (long i = 1; i <= request.FileCount; i++)
+        {
+            long lineNumber = i + 1;
+            string recordId = builder.GetControlNumber(i);
+
+            var line = BuildDatRow(i, recordId, request, colDelim, quote, hasQuote, builder);
+
+            line = ApplyChaosInterception(chaosEngine, lineNumber, line, recordId);
+
+            buffer.Append(line);
+            buffer.Append(eolString);
+
+            // Handle encoding anomalies between lines
+            if (chaosEngine != null && i < request.FileCount)
+            {
+                // Flush current buffer first
+                var bufferedBytes = encoding.GetBytes(buffer.ToString());
+                await memStream.WriteAsync(bufferedBytes);
+                buffer.Clear();
+
+                await WriteEncodingAnomalyBytesAsync(memStream, chaosEngine, lineNumber, lineNumber + 1, encoding);
+            }
+
+            if (buffer.Length > 1000 * 200)
+            {
+                var batchBytes = encoding.GetBytes(buffer.ToString());
+                await memStream.WriteAsync(batchBytes);
+                buffer.Clear();
+            }
+        }
+
+        if (buffer.Length > 0)
+        {
+            var remainingBytes = encoding.GetBytes(buffer.ToString());
+            await memStream.WriteAsync(remainingBytes);
+        }
+
+        memStream.Position = 0;
+        await memStream.CopyToAsync(stream);
+    }
+
+    private static string BuildDatHeader(
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        bool hasQuote)
+    {
+        var sb = new StringBuilder();
+        MetadataRowBuilder.AppendField(sb, "Control Number", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "File Path", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "Custodian", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "Date Sent", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "Author", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "File Size", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "EmailSubject", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "EmailFrom", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "EmailTo", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "EmailSentDate", quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, "ExtractedText", quote, hasQuote);
+
+        return sb.ToString();
+    }
+
+    private static string BuildDatRow(
+        long index,
+        string recordId,
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        bool hasQuote,
+        MetadataRowBuilder builder)
+    {
+        var workItem = new FileWorkItem { Index = index };
+        var sb = new StringBuilder();
+        var custodian = builder.GetCustodianByIndex(index);
+        var dateSent = builder.GetDateSent();
+        var author = builder.GetAuthor();
+        var fileSize = builder.GetFileSize();
+        var filePath = $"NATIVES\\{(index % 50) + 1:D3}\\{recordId}.pdf";
+        var extractedText = $"Sample extracted text content for document {recordId}.";
+
+        MetadataRowBuilder.AppendField(sb, recordId, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, filePath, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, custodian, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, dateSent, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, author, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, fileSize, quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSubject(workItem), quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailFrom(workItem), quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailTo(workItem), quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, builder.GetEmailSentDate(workItem), quote, hasQuote);
+        sb.Append(colDelim);
+        MetadataRowBuilder.AppendField(sb, extractedText, quote, hasQuote);
+
+        return sb.ToString();
+    }
+}

--- a/src/LoadFiles/LoadfileOnlyOptWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyOptWriter.cs
@@ -19,8 +19,6 @@ internal class LoadfileOnlyOptWriter : LoadFileWriterBase
 
         using var memStream = new MemoryStream();
 
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
-
 #pragma warning disable S2245
         var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
 #pragma warning restore S2245

--- a/src/LoadFiles/LoadfileOnlyOptWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyOptWriter.cs
@@ -1,0 +1,65 @@
+using System.Text;
+
+namespace Zipper.LoadFiles;
+
+internal class LoadfileOnlyOptWriter : LoadFileWriterBase
+{
+    public override string FormatName => "OPT (Image)";
+
+    public override string FileExtension => ".opt";
+
+    public override async Task WriteAsync(
+        Stream stream,
+        FileGenerationRequest request,
+        List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
+    {
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var eolString = GetEolString(request.EndOfLine);
+
+        using var memStream = new MemoryStream();
+
+        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+
+#pragma warning disable S2245
+        var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
+#pragma warning restore S2245
+
+        var buffer = new StringBuilder();
+
+        for (long i = 1; i <= request.FileCount; i++)
+        {
+            long lineNumber = i;
+            string batesId = $"IMG{i:D8}";
+            string volume = "VOL001";
+            string imagePath = $"IMAGES\\{batesId}.tif";
+            string docBreak = "Y";
+            string folderBreak = string.Empty;
+            string boxBreak = string.Empty;
+            int pageCount = random.Next(1, 11);
+
+            string line = $"{batesId},{volume},{imagePath},{docBreak},{folderBreak},{boxBreak},{pageCount}";
+
+            line = ApplyChaosInterception(chaosEngine, lineNumber, line, batesId);
+
+            buffer.Append(line);
+            buffer.Append(eolString);
+
+            if (buffer.Length > 1000 * 200)
+            {
+                var batchBytes = encoding.GetBytes(buffer.ToString());
+                await memStream.WriteAsync(batchBytes);
+                buffer.Clear();
+            }
+        }
+
+        if (buffer.Length > 0)
+        {
+            var remainingBytes = encoding.GetBytes(buffer.ToString());
+            await memStream.WriteAsync(remainingBytes);
+        }
+
+        memStream.Position = 0;
+        await memStream.CopyToAsync(stream);
+    }
+}

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -15,7 +15,8 @@ internal class OptWriter : LoadFileWriterBase
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles)
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
         await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);

--- a/src/LoadFiles/ProductionSetDatWriter.cs
+++ b/src/LoadFiles/ProductionSetDatWriter.cs
@@ -14,13 +14,13 @@ internal class ProductionSetDatWriter : LoadFileWriterBase
     {
         var col = string.IsNullOrEmpty(request.ColumnDelimiter) ? "\u0014" : request.ColumnDelimiter;
         var quote = string.IsNullOrEmpty(request.QuoteDelimiter) ? "\u00fe" : request.QuoteDelimiter;
+        var eol = GetEolString(request.EndOfLine);
 
-        await using var writer = new StreamWriter(stream, EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+        await using var writer = CreateWriter(stream, request);
 
         // Header
         var headers = new[] { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
-        var headerLine = string.Join(col, headers.Select(h => $"{quote}{h}{quote}"));
-        await writer.WriteLineAsync(headerLine);
+        await writer.WriteAsync(string.Join(col, headers.Select(h => $"{quote}{h}{quote}")) + eol);
 
         // Data rows
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
@@ -52,8 +52,7 @@ internal class ProductionSetDatWriter : LoadFileWriterBase
                 fileData.DataLength.ToString(),
                 request.FileType.ToUpperInvariant(),
             };
-            var line = string.Join(col, fields.Select(f => $"{quote}{f}{quote}"));
-            await writer.WriteLineAsync(line);
+            await writer.WriteAsync(string.Join(col, fields.Select(f => $"{quote}{f}{quote}")) + eol);
         }
 
         await writer.FlushAsync();

--- a/src/LoadFiles/ProductionSetDatWriter.cs
+++ b/src/LoadFiles/ProductionSetDatWriter.cs
@@ -1,0 +1,61 @@
+namespace Zipper.LoadFiles;
+
+internal class ProductionSetDatWriter : LoadFileWriterBase
+{
+    public override string FormatName => "Production Set DAT";
+
+    public override string FileExtension => ".dat";
+
+    public override async Task WriteAsync(
+        Stream stream,
+        FileGenerationRequest request,
+        List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
+    {
+        var col = string.IsNullOrEmpty(request.ColumnDelimiter) ? "\u0014" : request.ColumnDelimiter;
+        var quote = string.IsNullOrEmpty(request.QuoteDelimiter) ? "\u00fe" : request.QuoteDelimiter;
+
+        await using var writer = new StreamWriter(stream, EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+
+        // Header
+        var headers = new[] { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
+        var headerLine = string.Join(col, headers.Select(h => $"{quote}{h}{quote}"));
+        await writer.WriteLineAsync(headerLine);
+
+        // Data rows
+        foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
+        {
+            var workItem = fileData.WorkItem;
+            var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig!, workItem.Index - 1);
+            var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+                .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif");
+
+            var nativePath = workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
+            var textPath = nativePath.Replace($".{request.FileType}", ".txt");
+            var imagesPath = imagePath.Replace(Path.DirectorySeparatorChar, '\\');
+
+#pragma warning disable S2245
+            var random = request.Seed.HasValue ? new Random(request.Seed.Value + (int)workItem.Index) : Random.Shared;
+#pragma warning restore S2245
+            var builder = new MetadataRowBuilder(request, random, DateTime.UtcNow);
+
+            var fields = new[]
+            {
+                batesNumber,
+                batesNumber,
+                workItem.FolderName,
+                nativePath,
+                textPath,
+                imagesPath,
+                builder.GetCustodian(),
+                builder.GetDateCreated(),
+                fileData.DataLength.ToString(),
+                request.FileType.ToUpperInvariant(),
+            };
+            var line = string.Join(col, fields.Select(f => $"{quote}{f}{quote}"));
+            await writer.WriteLineAsync(line);
+        }
+
+        await writer.FlushAsync();
+    }
+}

--- a/src/LoadFiles/ProductionSetOptWriter.cs
+++ b/src/LoadFiles/ProductionSetOptWriter.cs
@@ -12,7 +12,8 @@ internal class ProductionSetOptWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        await using var writer = new StreamWriter(stream, EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+        var eol = GetEolString(request.EndOfLine);
+        await using var writer = CreateWriter(stream, request);
 
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
@@ -25,7 +26,7 @@ internal class ProductionSetOptWriter : LoadFileWriterBase
             var docBreak = "Y";
             var line = $"{batesNumber},{workItem.FolderName},{imagePath},{docBreak},,1";
 
-            await writer.WriteLineAsync(line);
+            await writer.WriteAsync(line + eol);
         }
 
         await writer.FlushAsync();

--- a/src/LoadFiles/ProductionSetOptWriter.cs
+++ b/src/LoadFiles/ProductionSetOptWriter.cs
@@ -15,9 +15,8 @@ internal class ProductionSetOptWriter : LoadFileWriterBase
         var eol = GetEolString(request.EndOfLine);
         await using var writer = CreateWriter(stream, request);
 
-        foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
+        foreach (var workItem in processedFiles.OrderBy(f => f.WorkItem.Index).Select(f => f.WorkItem))
         {
-            var workItem = fileData.WorkItem;
             var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig!, workItem.Index - 1);
             var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
                 .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")

--- a/src/LoadFiles/ProductionSetOptWriter.cs
+++ b/src/LoadFiles/ProductionSetOptWriter.cs
@@ -1,0 +1,33 @@
+namespace Zipper.LoadFiles;
+
+internal class ProductionSetOptWriter : LoadFileWriterBase
+{
+    public override string FormatName => "Production Set OPT";
+
+    public override string FileExtension => ".opt";
+
+    public override async Task WriteAsync(
+        Stream stream,
+        FileGenerationRequest request,
+        List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
+    {
+        await using var writer = new StreamWriter(stream, EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+
+        foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
+        {
+            var workItem = fileData.WorkItem;
+            var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig!, workItem.Index - 1);
+            var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+                .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
+                .Replace(Path.DirectorySeparatorChar, '\\');
+
+            var docBreak = "Y";
+            var line = $"{batesNumber},{workItem.FolderName},{imagePath},{docBreak},,1";
+
+            await writer.WriteLineAsync(line);
+        }
+
+        await writer.FlushAsync();
+    }
+}

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -16,7 +16,8 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
-        System.Collections.Generic.List<FileData> processedFiles)
+        System.Collections.Generic.List<FileData> processedFiles,
+        ChaosEngine? chaosEngine = null)
     {
         var settings = new XmlWriterSettings
         {

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -29,7 +29,7 @@ internal static class LoadfileOnlyGenerator
         var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.EndOfLine);
         long totalLines = request.LoadFileFormat == LoadFileFormat.Opt
             ? request.FileCount
-            : (long)request.FileCount + 1;
+            : request.FileCount + 1;
 
         ChaosEngine? chaosEngine = null;
         if (request.ChaosMode)

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -1,5 +1,5 @@
 using System.Diagnostics;
-using System.Text;
+using Zipper.LoadFiles;
 
 namespace Zipper;
 
@@ -16,7 +16,6 @@ internal static class LoadfileOnlyGenerator
     /// <returns>Result containing generated file paths and performance metrics.</returns>
     public static async Task<LoadfileOnlyResult> GenerateAsync(FileGenerationRequest request)
     {
-        // Clone to avoid mutating the caller's request object
         request = request.Clone();
 
         var stopwatch = Stopwatch.StartNew();
@@ -27,17 +26,14 @@ internal static class LoadfileOnlyGenerator
         var extension = request.LoadFileFormat == LoadFileFormat.Opt ? ".opt" : ".dat";
         var loadFilePath = Path.Combine(request.OutputPath, $"{baseFileName}{extension}");
 
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
-        var eolString = GetEolString(request.EndOfLine);
+        var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.EndOfLine);
         long totalLines = request.LoadFileFormat == LoadFileFormat.Opt
-            ? request.FileCount // OPT has no header
-            : (long)request.FileCount + 1; // DAT: +1 for header; cast to long to avoid overflow
+            ? request.FileCount
+            : (long)request.FileCount + 1;
 
-        // Initialize chaos engine if enabled
         ChaosEngine? chaosEngine = null;
         if (request.ChaosMode)
         {
-            // Resolve chaos scenario to types and amount
             string? resolvedTypes = request.ChaosTypes;
             string? resolvedAmount = request.ChaosAmount;
 
@@ -46,16 +42,12 @@ internal static class LoadfileOnlyGenerator
                 var scenario = ChaosScenarios.GetByName(request.ChaosScenario);
                 if (scenario != null)
                 {
-                    // Scenario types replace manual types; empty string means "all types"
                     resolvedTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes;
-
-                    // Use scenario default amount unless user explicitly set one
                     if (string.IsNullOrEmpty(resolvedAmount))
                     {
                         resolvedAmount = scenario.DefaultAmount;
                     }
 
-                    // Persist resolved values back to request for accurate audit metadata
                     request.ChaosAmount = resolvedAmount;
                     request.ChaosTypes = resolvedTypes;
 
@@ -77,24 +69,15 @@ internal static class LoadfileOnlyGenerator
                 request.Seed);
         }
 
-#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
-#pragma warning restore S2245
+        ILoadFileWriter writer = request.LoadFileFormat == LoadFileFormat.Opt
+            ? new LoadfileOnlyOptWriter()
+            : new LoadfileOnlyDatWriter();
 
-        // Write the load file
         await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
         {
-            if (request.LoadFileFormat == LoadFileFormat.Opt)
-            {
-                await WriteOptFile(fileStream, request, encoding, eolString, chaosEngine, random);
-            }
-            else
-            {
-                await WriteDatFile(fileStream, request, encoding, eolString, chaosEngine, random);
-            }
+            await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine);
         }
 
-        // Write the companion properties JSON
         string propertiesPath;
         try
         {
@@ -106,7 +89,6 @@ internal static class LoadfileOnlyGenerator
         }
         catch
         {
-            // Clean up partial output on failure
             if (File.Exists(loadFilePath))
             {
                 File.Delete(loadFilePath);
@@ -123,218 +105,6 @@ internal static class LoadfileOnlyGenerator
             PropertiesFilePath = propertiesPath,
             TotalRecords = request.FileCount,
             GenerationTime = stopwatch.Elapsed,
-        };
-    }
-
-    private static async Task WriteDatFile(
-        FileStream stream,
-        FileGenerationRequest request,
-        Encoding encoding,
-        string eol,
-        ChaosEngine? chaos,
-        Random random)
-    {
-        char colDelim = !string.IsNullOrEmpty(request.ColumnDelimiter) ? request.ColumnDelimiter[0] : '\u0014';
-        char quote = !string.IsNullOrEmpty(request.QuoteDelimiter) ? request.QuoteDelimiter[0] : '\u00fe';
-        bool hasQuote = !string.IsNullOrEmpty(request.QuoteDelimiter);
-
-        // Build header
-        var header = BuildDatHeader(request, colDelim, quote, hasQuote);
-
-        // Apply chaos to header (line 1)
-        if (chaos != null && chaos.ShouldIntercept(1))
-        {
-            header = chaos.Intercept(1, header, "HEADER");
-        }
-
-        var headerBytes = encoding.GetBytes(header + eol);
-        await stream.WriteAsync(headerBytes);
-
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
-        var builder = new MetadataRowBuilder(request, random, now);
-        var buffer = new StringBuilder();
-        int batchSize = 1000;
-
-        for (long i = 1; i <= request.FileCount; i++)
-        {
-            long lineNumber = i + 1; // Line 1 is header, data starts at line 2
-            string recordId = builder.GetControlNumber(i);
-
-            var line = BuildDatRow(i, recordId, request, colDelim, quote, hasQuote, builder);
-
-            // Apply chaos if targeted
-            if (chaos != null && chaos.ShouldIntercept(lineNumber))
-            {
-                line = chaos.Intercept(lineNumber, line, recordId);
-            }
-
-            buffer.Append(line);
-            buffer.Append(eol);
-
-            // Handle encoding anomalies between lines
-            if (chaos != null && i < request.FileCount)
-            {
-                var encodingAnomaly = chaos.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
-                if (encodingAnomaly != null)
-                {
-                    // Flush current buffer first
-                    var bufferedBytes = encoding.GetBytes(buffer.ToString());
-                    await stream.WriteAsync(bufferedBytes);
-                    buffer.Clear();
-
-                    // Write invalid bytes directly
-                    await stream.WriteAsync(encodingAnomaly);
-                }
-            }
-
-            if (buffer.Length > batchSize * 200)
-            {
-                var batchBytes = encoding.GetBytes(buffer.ToString());
-                await stream.WriteAsync(batchBytes);
-                buffer.Clear();
-            }
-        }
-
-        if (buffer.Length > 0)
-        {
-            var remainingBytes = encoding.GetBytes(buffer.ToString());
-            await stream.WriteAsync(remainingBytes);
-        }
-    }
-
-    private static async Task WriteOptFile(
-        FileStream stream,
-        FileGenerationRequest request,
-        Encoding encoding,
-        string eol,
-        ChaosEngine? chaos,
-        Random random)
-    {
-        // Opticon 7-column comma-separated format:
-        // BatesNumber,Volume,ImagePath,DocBreak(Y/blank),FolderBreak,BoxBreak,PageCount
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
-        var buffer = new StringBuilder();
-
-        for (long i = 1; i <= request.FileCount; i++)
-        {
-            long lineNumber = i; // No header in Opticon format
-            string batesId = $"IMG{i:D8}";
-            string volume = "VOL001";
-            string imagePath = $"IMAGES\\{batesId}.tif";
-            string docBreak = "Y"; // First page of each document
-            string folderBreak = string.Empty;
-            string boxBreak = string.Empty;
-            int pageCount = random.Next(1, 11);
-
-            string line = $"{batesId},{volume},{imagePath},{docBreak},{folderBreak},{boxBreak},{pageCount}";
-
-            // Apply chaos if targeted
-            if (chaos != null && chaos.ShouldIntercept(lineNumber))
-            {
-                string recordId = batesId;
-                line = chaos.Intercept(lineNumber, line, recordId);
-            }
-
-            buffer.Append(line);
-            buffer.Append(eol);
-
-            if (buffer.Length > 1000 * 200)
-            {
-                var batchBytes = encoding.GetBytes(buffer.ToString());
-                await stream.WriteAsync(batchBytes);
-                buffer.Clear();
-            }
-        }
-
-        if (buffer.Length > 0)
-        {
-            var remainingBytes = encoding.GetBytes(buffer.ToString());
-            await stream.WriteAsync(remainingBytes);
-        }
-    }
-
-    private static string BuildDatHeader(
-        FileGenerationRequest request,
-        char colDelim,
-        char quote,
-        bool hasQuote)
-    {
-        var sb = new StringBuilder();
-        MetadataRowBuilder.AppendField(sb, "Control Number", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "File Path", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "Custodian", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "Date Sent", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "Author", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "File Size", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "EmailSubject", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "EmailFrom", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "EmailTo", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "EmailSentDate", quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, "ExtractedText", quote, hasQuote);
-
-        return sb.ToString();
-    }
-
-    private static string BuildDatRow(
-        long index,
-        string recordId,
-        FileGenerationRequest request,
-        char colDelim,
-        char quote,
-        bool hasQuote,
-        MetadataRowBuilder builder)
-    {
-        var workItem = new FileWorkItem { Index = index };
-        var sb = new StringBuilder();
-        var custodian = builder.GetCustodianByIndex(index);
-        var dateSent = builder.GetDateSent();
-        var author = builder.GetAuthor();
-        var fileSize = builder.GetFileSize();
-        var filePath = $"NATIVES\\{(index % 50) + 1:D3}\\{recordId}.pdf";
-        var extractedText = $"Sample extracted text content for document {recordId}.";
-
-        MetadataRowBuilder.AppendField(sb, recordId, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, filePath, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, custodian, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, dateSent, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, author, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, fileSize, quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailSubject(workItem), quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailFrom(workItem), quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailTo(workItem), quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, builder.GetEmailSentDate(workItem), quote, hasQuote);
-        sb.Append(colDelim);
-        MetadataRowBuilder.AppendField(sb, extractedText, quote, hasQuote);
-
-        return sb.ToString();
-    }
-
-    private static string GetEolString(string eol)
-    {
-        return eol?.ToUpperInvariant() switch
-        {
-            "LF" => "\n",
-            "CR" => "\r",
-            _ => "\r\n", // CRLF default
         };
     }
 }

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Text;
 
 namespace Zipper;
 
@@ -58,8 +57,7 @@ internal static class ProductionSetGenerator
             ?? throw new InvalidOperationException($"Unknown file type: {request.FileType}");
 
         // Generate files and collect records for load files
-        var datRecords = new List<ProductionRecord>();
-        var optRecords = new List<string>();
+        var fileDataList = new List<FileData>();
 
         for (long i = 0; i < request.FileCount; i++)
         {
@@ -97,24 +95,11 @@ internal static class ProductionSetGenerator
             var imageFullPath = Path.Combine(productionPath, imageRelPath);
             await File.WriteAllBytesAsync(imageFullPath, PlaceholderFiles.GetContent("tiff"));
 
-            // Collect DAT record data
-            var record = new ProductionRecord
+            fileDataList.Add(new FileData
             {
-                BatesNumber = batesNumber,
-                NativePath = nativeRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
-                TextPath = textRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
-                ImagePath = imageRelPath.Replace(Path.DirectorySeparatorChar, '\\'),
-                Custodian = builder.GetCustodian(),
-                DateCreated = builder.GetDateCreated(),
-                FileSize = nativeContent.Length,
-                FileType = nativeExt.ToUpperInvariant(),
-                VolumeName = volName,
-            };
-            datRecords.Add(record);
-
-            // OPT line: Bates,VolumeName,ImagePath,DocBreak,BoxBreak,FolderBreak,PageCount
-            var docBreak = "Y";
-            optRecords.Add($"{batesNumber},{volName},{imageRelPath.Replace(Path.DirectorySeparatorChar, '\\')},{docBreak},,1");
+                WorkItem = workItem,
+                DataLength = nativeContent.Length,
+            });
 
             // Progress reporting
             if ((i + 1) % 1000 == 0 || i == request.FileCount - 1)
@@ -127,11 +112,19 @@ internal static class ProductionSetGenerator
 
         // Write DAT load file
         var datPath = Path.Combine(dataDir, "loadfile.dat");
-        await WriteDatLoadFile(datPath, request, datRecords, encoding);
+        var datWriter = new LoadFiles.ProductionSetDatWriter();
+        await using (var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
+        {
+            await datWriter.WriteAsync(datStream, request, fileDataList);
+        }
 
         // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
-        await WriteOptLoadFile(optPath, optRecords, encoding);
+        var optWriter = new LoadFiles.ProductionSetOptWriter();
+        await using (var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
+        {
+            await optWriter.WriteAsync(optStream, request, fileDataList);
+        }
 
         // Write manifest
         var batesStart = BatesNumberGenerator.Generate(batesConfig, 0);
@@ -164,90 +157,6 @@ internal static class ProductionSetGenerator
             GenerationTime = stopwatch.Elapsed,
         };
     }
-
-    private static async Task WriteDatLoadFile(
-        string datPath,
-        FileGenerationRequest request,
-        List<ProductionRecord> records,
-        Encoding encoding)
-    {
-        var col = request.ColumnDelimiter;
-        var quote = request.QuoteDelimiter;
-
-        await using var stream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
-        await using var writer = new StreamWriter(stream, encoding);
-
-        // Header
-        var headers = new[]
-        {
-            "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH",
-            "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE",
-        };
-        var headerLine = string.Join(col, headers.Select(h => $"{quote}{h}{quote}"));
-        await writer.WriteLineAsync(headerLine);
-
-        // Data rows
-        foreach (var record in records)
-        {
-            var fields = new[]
-            {
-                record.BatesNumber,
-                record.BatesNumber,
-                record.VolumeName,
-                record.NativePath,
-                record.TextPath,
-                record.ImagePath,
-                record.Custodian,
-                record.DateCreated,
-                record.FileSize.ToString(),
-                record.FileType,
-            };
-            var line = string.Join(col, fields.Select(f => $"{quote}{f}{quote}"));
-            await writer.WriteLineAsync(line);
-        }
-
-        await writer.FlushAsync();
-    }
-
-    private static async Task WriteOptLoadFile(
-        string optPath,
-        List<string> optLines,
-        Encoding encoding)
-    {
-        await using var stream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
-        await using var writer = new StreamWriter(stream, encoding);
-
-        foreach (var line in optLines)
-        {
-            await writer.WriteLineAsync(line);
-        }
-
-        await writer.FlushAsync();
-    }
-}
-
-/// <summary>
-/// Data record for a single document in a production set DAT.
-/// </summary>
-internal class ProductionRecord
-{
-    public string BatesNumber { get; set; } = string.Empty;
-
-    public string NativePath { get; set; } = string.Empty;
-
-    public string TextPath { get; set; } = string.Empty;
-
-    public string ImagePath { get; set; } = string.Empty;
-
-    public string Custodian { get; set; } = string.Empty;
-
-    public string DateCreated { get; set; } = string.Empty;
-
-    public long FileSize { get; set; }
-
-    public string FileType { get; set; } = string.Empty;
-
-    public string VolumeName { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -35,7 +35,6 @@ internal static class ProductionSetGenerator
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
 #pragma warning restore S2245
-        var builder = new MetadataRowBuilder(request, random, DateTime.UtcNow);
         var batesConfig = request.BatesConfig
             ?? throw new InvalidOperationException("Production set requires Bates configuration. Specify --bates-prefix.");
 

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -90,7 +90,7 @@ namespace Zipper
                 {
                     var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
                     using var loadFileStream = loadFileEntry.Open();
-                    await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles);
+                    await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, null);
 
                     // Return path within the ZIP archive when load file is included
                     actualLoadFilePath = actualLoadFileName;
@@ -99,7 +99,7 @@ namespace Zipper
                 {
                     var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
                     await using var fileStream = new FileStream(currentFilePath, FileMode.Create);
-                    await loadFileWriter.WriteAsync(fileStream, request, processedFiles);
+                    await loadFileWriter.WriteAsync(fileStream, request, processedFiles, null);
                     await fileStream.FlushAsync();
 
                     actualLoadFilePath = currentFilePath;

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -633,6 +633,7 @@ namespace Zipper
                 FileCount = 5,
                 FileType = "pdf",
                 Seed = 42,
+                EndOfLine = "CRLF",
                 OutputPath = this.tempDir,
                 VolumeSize = 5000,
                 BatesConfig = new BatesNumberConfig { Prefix = "TEST", Start = 1, Digits = 8 },
@@ -669,6 +670,7 @@ namespace Zipper
             Assert.Contains("BATES_NUMBER", lines[0]);
             Assert.Contains("NATIVE_PATH", lines[0]);
             Assert.Contains("IMAGE_PATH", lines[0]);
+            Assert.Contains("\r\n", content);
         }
 
         [Fact]
@@ -679,6 +681,7 @@ namespace Zipper
                 FileCount = 3,
                 FileType = "pdf",
                 Seed = 42,
+                EndOfLine = "CRLF",
                 OutputPath = this.tempDir,
                 VolumeSize = 10,
                 BatesConfig = new BatesNumberConfig { Prefix = "PROD", Start = 1, Digits = 6 },
@@ -716,6 +719,8 @@ namespace Zipper
                 Assert.Contains(".tif", line);
                 Assert.Contains("VOL001", line);
             }
+
+            Assert.Contains("\r\n", content);
         }
 
         [Fact]

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -538,6 +538,207 @@ namespace Zipper
             Assert.Contains("1024", dataLine);
         }
 
+        [Fact]
+        public async Task LoadfileOnlyDatWriter_ProducesCorrectFormat()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 5,
+                FileType = "pdf",
+                Seed = 42,
+                Encoding = "UTF-8",
+                EndOfLine = "CRLF",
+            };
+            var writer = new LoadfileOnlyDatWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, new List<FileData>());
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            // Header + 5 data rows
+            Assert.Equal(6, lines.Length);
+            Assert.Contains("Control Number", lines[0]);
+            Assert.Contains("File Path", lines[0]);
+            Assert.Contains("EmailSubject", lines[0]);
+            Assert.Contains("ExtractedText", lines[0]);
+        }
+
+        [Fact]
+        public async Task LoadfileOnlyOptWriter_ProducesCorrectFormat()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 3,
+                FileType = "pdf",
+                Seed = 42,
+                Encoding = "UTF-8",
+                EndOfLine = "CRLF",
+            };
+            var writer = new LoadfileOnlyOptWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, new List<FileData>());
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            // 3 data rows, no header
+            Assert.Equal(3, lines.Length);
+            foreach (var line in lines)
+            {
+                int commaCount = line.Count(c => c == ',');
+                Assert.Equal(6, commaCount);
+                Assert.StartsWith("IMG", line);
+                Assert.Contains("VOL001", line);
+            }
+        }
+
+        [Fact]
+        public async Task LoadfileOnlyDatWriter_WithChaos_ProducesCorruptedLines()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 20,
+                FileType = "pdf",
+                Seed = 42,
+                Encoding = "UTF-8",
+                EndOfLine = "CRLF",
+            };
+
+            var eol = "\r\n";
+            long totalLines = request.FileCount + 1;
+            var chaos = new ChaosEngine(totalLines, "5", null, LoadFileFormat.Dat, "\u0014", "\u00fe", eol, 42);
+
+            var writer = new LoadfileOnlyDatWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, new List<FileData>(), chaos);
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+
+            // Chaos should have modified at least 5 lines
+            Assert.NotEmpty(content);
+
+            // Verify anomalies were tracked
+            Assert.True(chaos.Anomalies.Count > 0);
+        }
+
+        [Fact]
+        public async Task ProductionSetDatWriter_ProducesCorrectFormat()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 5,
+                FileType = "pdf",
+                Seed = 42,
+                OutputPath = this.tempDir,
+                VolumeSize = 5000,
+                BatesConfig = new BatesNumberConfig { Prefix = "TEST", Start = 1, Digits = 8 },
+            };
+
+            var files = new List<FileData>();
+            for (int i = 0; i < 5; i++)
+            {
+                files.Add(new FileData
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = i + 1,
+                        FolderNumber = 1,
+                        FolderName = "VOL001",
+                        FileName = $"TEST{i + 1:D8}.pdf",
+                        FilePathInZip = $"NATIVES\\VOL001\\TEST{i + 1:D8}.pdf",
+                    },
+                    DataLength = 1024 * (i + 1),
+                });
+            }
+
+            var writer = new ProductionSetDatWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, files);
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            // Header + 5 data rows
+            Assert.Equal(6, lines.Length);
+            Assert.Contains("DOCID", lines[0]);
+            Assert.Contains("BATES_NUMBER", lines[0]);
+            Assert.Contains("NATIVE_PATH", lines[0]);
+            Assert.Contains("IMAGE_PATH", lines[0]);
+        }
+
+        [Fact]
+        public async Task ProductionSetOptWriter_ProducesCorrectFormat()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 3,
+                FileType = "pdf",
+                Seed = 42,
+                OutputPath = this.tempDir,
+                VolumeSize = 10,
+                BatesConfig = new BatesNumberConfig { Prefix = "PROD", Start = 1, Digits = 6 },
+            };
+
+            var files = new List<FileData>();
+            for (int i = 0; i < 3; i++)
+            {
+                files.Add(new FileData
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = i + 1,
+                        FolderNumber = 1,
+                        FolderName = "VOL001",
+                        FileName = $"PROD{i + 1:D6}.pdf",
+                        FilePathInZip = $"NATIVES\\VOL001\\PROD{i + 1:D6}.pdf",
+                    },
+                    DataLength = 1024,
+                });
+            }
+
+            var writer = new ProductionSetOptWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, files);
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Equal(3, lines.Length);
+            foreach (var line in lines)
+            {
+                Assert.StartsWith("PROD", line);
+                Assert.Contains(".tif", line);
+                Assert.Contains("VOL001", line);
+            }
+        }
+
+        [Fact]
+        public async Task LoadfileOnlyDatWriter_WithNullEol_FallsBackToCrlf()
+        {
+            var request = new FileGenerationRequest
+            {
+                FileCount = 3,
+                FileType = "pdf",
+                Seed = 42,
+                Encoding = "UTF-8",
+                EndOfLine = string.Empty,
+            };
+            var writer = new LoadfileOnlyDatWriter();
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, new List<FileData>());
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+
+            Assert.Contains("\r\n", content);
+        }
+
         private async Task<string> CaptureCsvOutput(FileGenerationRequest request, List<FileData> files)
         {
             var writer = new LoadFiles.CsvWriter();


### PR DESCRIPTION
## Summary

Unifies the 3 independent writer paths (Standard Pipeline, Loadfile-Only Mode, Production Set Mode) into a single `ILoadFileWriter` seam.

### Changes

- **ILoadFileWriter**: Added optional `ChaosEngine?` parameter to `WriteAsync`
- **LoadFileWriterBase**: Extracted shared utilities (`GetEolString`, `CreateWriter`, `FlushBufferAsync`, `ApplyChaosInterception`, `WriteEncodingAnomalyBytesAsync`)
- **4 new writer classes**: `LoadfileOnlyDatWriter`, `LoadfileOnlyOptWriter`, `ProductionSetDatWriter`, `ProductionSetOptWriter`
- **Deleted inline write methods**: Removed ~246 LOC from `LoadfileOnlyGenerator` and ~121 LOC from `ProductionSetGenerator` (including `ProductionRecord` class)
- **6 new unit tests** verifying format correctness

### Verification

- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 641 tests pass
- ✅ `./tests/run-tests.sh` — all E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced load file generation with support for multiple format writers, including OPT and DAT formats for both load-file-only and production-set scenarios
  * Added support for anomaly injection capabilities in load file generation

* **Tests**
  * Added comprehensive test coverage for the new load file format writers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->