### PR TITLE
Unify mode dispatch via IGenerationMode + GenerationRunner

### DIFF
--- a/src/GenerationRunner.cs
+++ b/src/GenerationRunner.cs
@@ -1,0 +1,28 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Wraps a mode's RunAsync with the shared try/catch and exit-code conversion previously
+    /// duplicated across Program.GenerateFiles, Program.RunLoadfileOnly, and Program.RunProductionSet.
+    /// </summary>
+    internal static class GenerationRunner
+    {
+        /// <summary>
+        /// Runs the mode and returns 0 on success, 1 on any unhandled exception.
+        /// Exception messages are written to standard error in the legacy format
+        /// (<c>"\nAn error occurred: {message}"</c>).
+        /// </summary>
+        public static async Task<int> RunAsync(IGenerationMode mode, FileGenerationRequest request)
+        {
+            try
+            {
+                await mode.RunAsync(request);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(string.Format("\nAn error occurred: {0}", ex.Message));
+                return 1;
+            }
+        }
+    }
+}

--- a/src/IGenerationMode.cs
+++ b/src/IGenerationMode.cs
@@ -1,0 +1,15 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Represents one of the program's generation modes (Standard, Loadfile-Only, Production Set).
+    /// Each implementation owns its own config logging, generator invocation, and result printing.
+    /// Errors are propagated as exceptions and turned into a non-zero exit code by <see cref="GenerationRunner"/>.
+    /// </summary>
+    internal interface IGenerationMode
+    {
+        /// <summary>
+        /// Runs the mode end-to-end. Throws on failure; the runner translates exceptions into exit code 1.
+        /// </summary>
+        Task RunAsync(FileGenerationRequest request);
+    }
+}

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -1,0 +1,34 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Loadfile-Only generation mode — emits a load file plus its properties sidecar without producing native files.
+    /// </summary>
+    internal class LoadfileOnlyMode : IGenerationMode
+    {
+        public async Task RunAsync(FileGenerationRequest request)
+        {
+            Console.WriteLine("Starting loadfile-only generation...");
+            Console.WriteLine(string.Format("  Format: {0}", request.LoadFileFormat));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
+            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
+            Console.WriteLine(string.Format("  EOL: {0}", request.EndOfLine));
+
+            if (request.ChaosMode)
+            {
+                Console.WriteLine(string.Format("  Chaos Mode: Enabled (amount: {0})", request.ChaosAmount ?? "1%"));
+                if (!string.IsNullOrEmpty(request.ChaosTypes))
+                {
+                    Console.WriteLine(string.Format("  Chaos Types: {0}", request.ChaosTypes));
+                }
+            }
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+            Console.WriteLine(string.Format("  Load file: {0}", result.LoadFilePath));
+            Console.WriteLine(string.Format("  Properties: {0}", result.PropertiesFilePath));
+            Console.WriteLine(string.Format("  Records: {0:N0}", result.TotalRecords));
+        }
+    }
+}

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -1,0 +1,40 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Production Set generation mode — emits a Bates-numbered, volumed production with DAT, OPT, and manifest sidecars.
+    /// </summary>
+    internal class ProductionSetMode : IGenerationMode
+    {
+        public async Task RunAsync(FileGenerationRequest request)
+        {
+            Console.WriteLine("Starting production set generation...");
+            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
+            Console.WriteLine(string.Format("  Volume Size: {0:N0} files/volume", request.VolumeSize));
+            var batesPrefix = request.BatesConfig?.Prefix ?? string.Empty;
+            var batesStart = request.BatesConfig?.Start ?? 1;
+            var batesDigits = request.BatesConfig?.Digits ?? 8;
+            Console.WriteLine(string.Format("  Bates: {0}{1}", batesPrefix, batesStart.ToString($"D{batesDigits}")));
+            if (request.ProductionZip)
+            {
+                Console.WriteLine("  ZIP Output: Enabled");
+            }
+
+            var result = await ProductionSetGenerator.GenerateAsync(request);
+
+            Console.WriteLine(string.Format("\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+            Console.WriteLine(string.Format("  Production: {0}", result.ProductionPath));
+            Console.WriteLine(string.Format("  Documents: {0:N0}", result.TotalDocuments));
+            Console.WriteLine(string.Format("  Bates Range: {0}", result.BatesRange));
+            Console.WriteLine(string.Format("  Volumes: {0}", result.VolumeCount));
+            Console.WriteLine(string.Format("  DAT: {0}", result.DatFilePath));
+            Console.WriteLine(string.Format("  OPT: {0}", result.OptFilePath));
+            Console.WriteLine(string.Format("  Manifest: {0}", result.ManifestPath));
+            if (result.ZipFilePath != null)
+            {
+                Console.WriteLine(string.Format("  ZIP: {0}", result.ZipFilePath));
+            }
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -39,149 +39,28 @@ namespace Zipper
                 return 1; // Error already displayed by CommandLineValidator
             }
 
+            IGenerationMode mode = SelectMode(request);
+            return await GenerationRunner.RunAsync(mode, request);
+        }
+
+        /// <summary>
+        /// Picks the appropriate generation mode based on flags on the request.
+        /// Production Set takes precedence over Loadfile-Only for backward compatibility
+        /// with the previous dispatch order in <c>Main</c>.
+        /// </summary>
+        internal static IGenerationMode SelectMode(FileGenerationRequest request)
+        {
             if (request.LoadfileOnly)
             {
-                return await RunLoadfileOnly(request);
+                return new LoadfileOnlyMode();
             }
 
             if (request.ProductionSet)
             {
-                return await RunProductionSet(request);
+                return new ProductionSetMode();
             }
 
-            bool success = await GenerateFiles(request);
-            return success ? 0 : 1;
-        }
-
-        private static async Task<int> RunProductionSet(FileGenerationRequest request)
-        {
-            Console.WriteLine("Starting production set generation...");
-            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Volume Size: {0:N0} files/volume", request.VolumeSize));
-            var batesPrefix = request.BatesConfig?.Prefix ?? string.Empty;
-            var batesStart = request.BatesConfig?.Start ?? 1;
-            var batesDigits = request.BatesConfig?.Digits ?? 8;
-            Console.WriteLine(string.Format("  Bates: {0}{1}", batesPrefix, batesStart.ToString($"D{batesDigits}")));
-            if (request.ProductionZip)
-            {
-                Console.WriteLine("  ZIP Output: Enabled");
-            }
-
-            try
-            {
-                var result = await ProductionSetGenerator.GenerateAsync(request);
-
-                Console.WriteLine(string.Format("\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
-                Console.WriteLine(string.Format("  Production: {0}", result.ProductionPath));
-                Console.WriteLine(string.Format("  Documents: {0:N0}", result.TotalDocuments));
-                Console.WriteLine(string.Format("  Bates Range: {0}", result.BatesRange));
-                Console.WriteLine(string.Format("  Volumes: {0}", result.VolumeCount));
-                Console.WriteLine(string.Format("  DAT: {0}", result.DatFilePath));
-                Console.WriteLine(string.Format("  OPT: {0}", result.OptFilePath));
-                Console.WriteLine(string.Format("  Manifest: {0}", result.ManifestPath));
-                if (result.ZipFilePath != null)
-                {
-                    Console.WriteLine(string.Format("  ZIP: {0}", result.ZipFilePath));
-                }
-
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(string.Format("\nAn error occurred: {0}", ex.Message));
-                return 1;
-            }
-        }
-
-        private static async Task<int> RunLoadfileOnly(FileGenerationRequest request)
-        {
-            Console.WriteLine("Starting loadfile-only generation...");
-            Console.WriteLine(string.Format("  Format: {0}", request.LoadFileFormat));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
-            Console.WriteLine(string.Format("  EOL: {0}", request.EndOfLine));
-
-            if (request.ChaosMode)
-            {
-                Console.WriteLine(string.Format("  Chaos Mode: Enabled (amount: {0})", request.ChaosAmount ?? "1%"));
-                if (!string.IsNullOrEmpty(request.ChaosTypes))
-                {
-                    Console.WriteLine(string.Format("  Chaos Types: {0}", request.ChaosTypes));
-                }
-            }
-
-            try
-            {
-                var result = await LoadfileOnlyGenerator.GenerateAsync(request);
-
-                Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
-                Console.WriteLine(string.Format("  Load file: {0}", result.LoadFilePath));
-                Console.WriteLine(string.Format("  Properties: {0}", result.PropertiesFilePath));
-                Console.WriteLine(string.Format("  Records: {0:N0}", result.TotalRecords));
-
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(string.Format("\nAn error occurred: {0}", ex.Message));
-                return 1;
-            }
-        }
-
-        private static async Task<bool> GenerateFiles(FileGenerationRequest request)
-        {
-            Console.WriteLine("Starting parallel file generation...");
-            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Folders: {0}", request.Folders));
-            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
-            Console.WriteLine(string.Format("  Distribution: {0}", request.Distribution));
-            if (request.WithMetadata)
-            {
-                Console.WriteLine("  Metadata: Enabled");
-            }
-
-            if (request.WithText)
-            {
-                Console.WriteLine("  Extracted Text: Enabled");
-            }
-
-            if (request.TargetZipSize.HasValue)
-            {
-                Console.WriteLine(string.Format("  Target ZIP Size: {0} MB", request.TargetZipSize.Value / (1024 * 1024)));
-            }
-
-            if (request.IncludeLoadFile)
-            {
-                Console.WriteLine("  Load File: Will be included in zip archive.");
-            }
-
-            try
-            {
-                // Use parallel file generator for improved performance
-                using var generator = new ParallelFileGenerator();
-
-                var result = await generator.GenerateFilesAsync(request);
-
-                Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
-                Console.WriteLine(string.Format("  Archive created: {0}", result.ZipFilePath));
-                Console.WriteLine(string.Format("  Performance: {0:F1} files/second", result.FilesPerSecond));
-                if (!request.IncludeLoadFile)
-                {
-                    Console.WriteLine(string.Format("  Load file created: {0}", result.LoadFilePath));
-                }
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(string.Format("\nAn error occurred: {0}", ex.Message));
-                return false;
-            }
+            return new StandardMode();
         }
     }
 }

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -1,0 +1,51 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Standard parallel file generation mode — produces a ZIP archive plus a load file.
+    /// </summary>
+    internal class StandardMode : IGenerationMode
+    {
+        public async Task RunAsync(FileGenerationRequest request)
+        {
+            Console.WriteLine("Starting parallel file generation...");
+            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
+            Console.WriteLine(string.Format("  Folders: {0}", request.Folders));
+            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
+            Console.WriteLine(string.Format("  Distribution: {0}", request.Distribution));
+            if (request.WithMetadata)
+            {
+                Console.WriteLine("  Metadata: Enabled");
+            }
+
+            if (request.WithText)
+            {
+                Console.WriteLine("  Extracted Text: Enabled");
+            }
+
+            if (request.TargetZipSize.HasValue)
+            {
+                Console.WriteLine(string.Format("  Target ZIP Size: {0} MB", request.TargetZipSize.Value / (1024 * 1024)));
+            }
+
+            if (request.IncludeLoadFile)
+            {
+                Console.WriteLine("  Load File: Will be included in zip archive.");
+            }
+
+            // Use parallel file generator for improved performance
+            using var generator = new ParallelFileGenerator();
+
+            var result = await generator.GenerateFilesAsync(request);
+
+            Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+            Console.WriteLine(string.Format("  Archive created: {0}", result.ZipFilePath));
+            Console.WriteLine(string.Format("  Performance: {0:F1} files/second", result.FilesPerSecond));
+            if (!request.IncludeLoadFile)
+            {
+                Console.WriteLine(string.Format("  Load file created: {0}", result.LoadFilePath));
+            }
+        }
+    }
+}

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -1,0 +1,151 @@
+using Xunit;
+
+namespace Zipper
+{
+    [Collection("ConsoleTests")]
+    public class GenerationRunnerTests
+    {
+        [Fact]
+        public async Task RunAsync_SuccessfulMode_ReturnsZero()
+        {
+            var (exit, _, _) = await RunWithCapture(new SuccessfulMode(), DefaultRequest());
+            Assert.Equal(0, exit);
+        }
+
+        [Fact]
+        public async Task RunAsync_SuccessfulMode_DelegatesToMode()
+        {
+            var mode = new SuccessfulMode();
+            await RunWithCapture(mode, DefaultRequest());
+            Assert.Equal(1, mode.RunCount);
+        }
+
+        [Fact]
+        public async Task RunAsync_ThrowingMode_ReturnsOne()
+        {
+            var (exit, _, _) = await RunWithCapture(new ThrowingMode("boom"), DefaultRequest());
+            Assert.Equal(1, exit);
+        }
+
+        [Fact]
+        public async Task RunAsync_ThrowingMode_PrintsLegacyErrorFormatToStderr()
+        {
+            var (_, _, err) = await RunWithCapture(new ThrowingMode("disk full"), DefaultRequest());
+            Assert.Contains("\nAn error occurred: disk full", err);
+        }
+
+        [Fact]
+        public async Task RunAsync_ThrowingMode_DoesNotWriteErrorToStdout()
+        {
+            var (_, output, _) = await RunWithCapture(new ThrowingMode("boom"), DefaultRequest());
+            Assert.DoesNotContain("An error occurred", output);
+        }
+
+        [Fact]
+        public async Task RunAsync_PassesRequestToMode()
+        {
+            var mode = new RequestCapturingMode();
+            var request = DefaultRequest();
+            await RunWithCapture(mode, request);
+            Assert.Same(request, mode.LastRequest);
+        }
+
+        [Fact]
+        public void Program_SelectMode_LoadfileOnly_ReturnsLoadfileOnlyMode()
+        {
+            var request = DefaultRequest();
+            request.LoadfileOnly = true;
+            Assert.IsType<LoadfileOnlyMode>(Program.SelectMode(request));
+        }
+
+        [Fact]
+        public void Program_SelectMode_ProductionSet_ReturnsProductionSetMode()
+        {
+            var request = DefaultRequest();
+            request.ProductionSet = true;
+            Assert.IsType<ProductionSetMode>(Program.SelectMode(request));
+        }
+
+        [Fact]
+        public void Program_SelectMode_Default_ReturnsStandardMode()
+        {
+            var request = DefaultRequest();
+            Assert.IsType<StandardMode>(Program.SelectMode(request));
+        }
+
+        [Fact]
+        public void Program_SelectMode_LoadfileOnlyTakesPrecedenceOverProductionSet()
+        {
+            var request = DefaultRequest();
+            request.LoadfileOnly = true;
+            request.ProductionSet = true;
+            Assert.IsType<LoadfileOnlyMode>(Program.SelectMode(request));
+        }
+
+        private static async Task<(int exitCode, string stdout, string stderr)> RunWithCapture(IGenerationMode mode, FileGenerationRequest request)
+        {
+            var originalOut = Console.Out;
+            var originalError = Console.Error;
+            try
+            {
+                using var outWriter = new StringWriter();
+                using var errWriter = new StringWriter();
+                Console.SetOut(outWriter);
+                Console.SetError(errWriter);
+                int exit = await GenerationRunner.RunAsync(mode, request);
+                return (exit, outWriter.ToString(), errWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+        }
+
+        private static FileGenerationRequest DefaultRequest()
+        {
+            return new FileGenerationRequest
+            {
+                OutputPath = "/tmp/test",
+                FileCount = 1,
+                FileType = "pdf",
+                Folders = 1,
+            };
+        }
+
+        private sealed class SuccessfulMode : IGenerationMode
+        {
+            public int RunCount { get; private set; }
+
+            public Task RunAsync(FileGenerationRequest request)
+            {
+                this.RunCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class ThrowingMode : IGenerationMode
+        {
+            private readonly string message;
+
+            public ThrowingMode(string message)
+            {
+                this.message = message;
+            }
+
+            public Task RunAsync(FileGenerationRequest request) =>
+                throw new InvalidOperationException(this.message);
+        }
+
+        private sealed class RequestCapturingMode : IGenerationMode
+        {
+            public FileGenerationRequest? LastRequest { get; private set; }
+
+            public Task RunAsync(FileGenerationRequest request)
+            {
+                this.LastRequest = request;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #181.

## Summary

Replaces three nearly-identical mode dispatch methods in `Program.cs` (`GenerateFiles`, `RunLoadfileOnly`, `RunProductionSet`) with a small interface `IGenerationMode` plus a shared `GenerationRunner` that owns the try/catch and exit-code conversion. Each mode lives in its own file.

## Changes

- **New** `src/IGenerationMode.cs` — minimal interface: `Task RunAsync(FileGenerationRequest)`. Errors propagate as exceptions; the runner translates them into exit code 1.
- **New** `src/GenerationRunner.cs` — static helper with the shared try/catch + the legacy `"\nAn error occurred: {0}"` stderr format.
- **New** `src/StandardMode.cs`, `src/LoadfileOnlyMode.cs`, `src/ProductionSetMode.cs` — one adapter per mode, each owning its own config logging, generator invocation, and result printing. Console output is preserved byte-for-byte (same starter line, same field labels, same order).
- **Modified** `src/Program.cs` — `Main` shrinks: ambiguous benchmark/chaos-list special cases unchanged; mode dispatch becomes `IGenerationMode mode = SelectMode(request); return await GenerationRunner.RunAsync(mode, request);`. Adds a small `internal static SelectMode` for testability. Old methods removed.
- **New** `src/Zipper.Tests/GenerationRunnerTests.cs` — 9 tests covering: success returns 0, exception returns 1, exception message printed in legacy format on stderr (and not on stdout), runner passes the request through to the mode, and `Program.SelectMode` returns the right adapter for each flag combination including LoadfileOnly precedence.

## Verification

- `grep -rn "RunLoadfileOnly|RunProductionSet|Program.GenerateFiles" src/` returns nothing.
- Existing `ProgramTests`, `LoadfileOnlyGeneratorTests`, `ProductionSetTests`, `ParallelFileGeneratorTests`, and `IntegrationTests` continue to exercise end-to-end behaviour through the new dispatch.
- CI (build/test on macOS/Ubuntu/Windows + lint + Sonar + CodeQL) must pass before merge.