### PR TITLE
E2E goldens: harness scaffold (runner, lib helpers, README)

### DIFF
--- a/tests/goldens/README.md
+++ b/tests/goldens/README.md
@@ -1,0 +1,109 @@
+# E2E Goldens — Harness
+
+This directory holds the **byte-exact regression gate** for Zipper's
+end-to-end output. The existing E2E suite under `tests/` validates structure
+(file counts, headers, encodings); the goldens layer validates that the
+*actual bytes* on disk match a pre-captured fixture.
+
+This ticket (#197) ships **only the plumbing** — runner, lib helpers, an
+empty scenarios table, and this README. Captured scenarios and CI wiring
+land in follow-up tickets:
+
+- `#198` — capture and commit 15 scenarios.
+- `#199` — wire the goldens job into `pr.yml`.
+
+## Layout
+
+```
+tests/goldens/
+├── README.md              # this file
+├── run-goldens.sh         # the runner — drives scenarios.tsv
+├── scenarios.tsv          # pipe-delimited table; populated by #198
+├── fixtures/              # checked-in golden output, one dir per scenario
+└── lib/
+    ├── diff-loadfile.sh   # bounded byte-diff with first-divergence context
+    ├── sha-manifest.sh    # deterministic sha256 manifest of a tree
+    └── _test/             # bats-core unit tests for the helpers
+        ├── diff-loadfile.bats
+        └── sha-manifest.bats
+```
+
+## scenarios.tsv
+
+The table is **pipe-delimited** (despite the `.tsv` extension — kept for
+compatibility with downstream tooling that expects the filename). Header:
+
+```
+scenario_name | cli_args | seed | description
+```
+
+- `scenario_name` — short kebab-case identifier; also the fixture directory
+  name under `fixtures/`.
+- `cli_args` — exact argv (minus the executable) handed to Zipper. The seed
+  is exposed as the `SEED` env var; the CLI command is responsible for
+  consuming it.
+- `seed` — RNG seed used for that scenario. Must be deterministic.
+- `description` — short human note; not parsed.
+
+Lines starting with `#` and blank lines are ignored.
+
+## Running scenarios
+
+```sh
+# Diff every scenario against its fixture.
+ZIPPER_CLI=/path/to/zipper ./tests/goldens/run-goldens.sh
+
+# Run just one scenario for debugging.
+ZIPPER_CLI=/path/to/zipper ./tests/goldens/run-goldens.sh --scenario foo-basic
+
+# Re-capture fixtures (intentional regeneration only — never in CI).
+ZIPPER_CLI=/path/to/zipper ./tests/goldens/run-goldens.sh --capture
+```
+
+The runner produces an `sha256` manifest of both the captured fixture
+directory and the freshly-generated output, diffs the manifests, and on any
+divergence drops down to a per-file byte diff that prints the first
+mismatching line plus three lines of context on each side.
+
+## Adding a scenario
+
+1. Append a row to `scenarios.tsv`.
+2. Run with `--capture` to populate `fixtures/<scenario_name>/`:
+   ```sh
+   ZIPPER_CLI=$(pwd)/src/Zipper/bin/Release/net9.0/Zipper \
+     ./tests/goldens/run-goldens.sh --capture --scenario <scenario_name>
+   ```
+3. Inspect the fixture by hand — open the load file, check the headers,
+   confirm the seed produces the expected categorical distribution. Goldens
+   are only useful if a human signed off on the bytes once.
+4. Commit the fixture directory alongside the row.
+
+## When a golden fails
+
+Goldens go red when **output bytes change**. There are two reasons:
+
+1. **Unintended regression.** Something in the codepath drifted: a refactor
+   re-ordered enumerable iteration, a change of culture-aware formatting
+   crept in, a default seed flipped. Treat as a real failure — fix the
+   code, leave the fixture alone.
+2. **Intentional change.** A new field was added to a load file, an output
+   format was bumped, a generator's distribution was deliberately tuned.
+   Re-capture the affected scenarios with `--capture`, eyeball the diff,
+   and commit the new fixture in the same PR as the code change.
+
+The first lines of `run-goldens.sh`'s output point at the divergence; for
+load files we never dump the whole thing — just the first mismatching line
+plus three lines of context.
+
+## Helper unit tests
+
+The lib helpers carry their own [bats-core][bats] tests under
+`lib/_test/`. They run locally with:
+
+```sh
+bats tests/goldens/lib/_test/
+```
+
+CI wiring for the helpers + scenarios is part of `#199`.
+
+[bats]: https://github.com/bats-core/bats-core

--- a/tests/goldens/lib/_test/diff-loadfile.bats
+++ b/tests/goldens/lib/_test/diff-loadfile.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Unit tests for tests/goldens/lib/diff-loadfile.sh.
+#
+# Run with:  bats tests/goldens/lib/_test/diff-loadfile.bats
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../diff-loadfile.sh"
+  TMPDIR_LOCAL="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_LOCAL"
+}
+
+@test "errors when called with no args" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "errors when files are missing" {
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/missing-a" "$TMPDIR_LOCAL/missing-b"
+  [ "$status" -eq 2 ]
+}
+
+@test "identical files exit 0 silently" {
+  printf 'one\ntwo\nthree\n' >"$TMPDIR_LOCAL/a"
+  printf 'one\ntwo\nthree\n' >"$TMPDIR_LOCAL/b"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/a" "$TMPDIR_LOCAL/b"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "differing files exit 1 with first-divergence info" {
+  printf 'one\ntwo\nthree\nfour\n' >"$TMPDIR_LOCAL/a"
+  printf 'one\nTWO\nthree\nfour\n' >"$TMPDIR_LOCAL/b"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/a" "$TMPDIR_LOCAL/b"
+  [ "$status" -eq 1 ]
+  # The diagnostic is on stderr; bats merges it into $output.
+  [[ "$output" == *"First differing line: 2"* ]]
+  [[ "$output" == *"two"* ]]
+  [[ "$output" == *"TWO"* ]]
+}
+
+@test "trailing newline difference is detected" {
+  printf 'a\nb\n' >"$TMPDIR_LOCAL/a"
+  printf 'a\nb'   >"$TMPDIR_LOCAL/b"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/a" "$TMPDIR_LOCAL/b"
+  [ "$status" -eq 1 ]
+}
+
+@test "output is bounded — does not dump entire file" {
+  # 5000 lines, differ on line 10. We should print far fewer lines than 5000.
+  python3 -c "import sys; sys.stdout.write('\n'.join(f'line{i}' for i in range(1, 5001)) + '\n')" >"$TMPDIR_LOCAL/a"
+  python3 -c "import sys
+out = ['line%d' % i for i in range(1, 5001)]
+out[9] = 'DIVERGED'
+sys.stdout.write('\n'.join(out) + '\n')" >"$TMPDIR_LOCAL/b"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/a" "$TMPDIR_LOCAL/b"
+  [ "$status" -eq 1 ]
+  # ctx=3 → expect at most ~12 diagnostic lines, well under 100.
+  count=$(printf '%s\n' "$output" | wc -l)
+  [ "$count" -lt 100 ]
+  [[ "$output" == *"First differing line: 10"* ]]
+}

--- a/tests/goldens/lib/_test/sha-manifest.bats
+++ b/tests/goldens/lib/_test/sha-manifest.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+# Unit tests for tests/goldens/lib/sha-manifest.sh.
+#
+# Run with:  bats tests/goldens/lib/_test/sha-manifest.bats
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../sha-manifest.sh"
+  TMPDIR_LOCAL="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_LOCAL"
+}
+
+@test "errors when no args" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+}
+
+@test "errors when path is not a directory" {
+  run bash "$SCRIPT" "$TMPDIR_LOCAL/does-not-exist"
+  [ "$status" -eq 1 ]
+}
+
+@test "empty directory produces empty output" {
+  run bash "$SCRIPT" "$TMPDIR_LOCAL"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "single file produces one manifest line" {
+  printf 'hello\n' >"$TMPDIR_LOCAL/a.txt"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL"
+  [ "$status" -eq 0 ]
+  # sha256("hello\n") = 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+  [[ "$output" == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03  a.txt" ]]
+}
+
+@test "output is sorted by relative path" {
+  mkdir -p "$TMPDIR_LOCAL/sub"
+  printf 'a\n' >"$TMPDIR_LOCAL/zeta.txt"
+  printf 'b\n' >"$TMPDIR_LOCAL/alpha.txt"
+  printf 'c\n' >"$TMPDIR_LOCAL/sub/inner.txt"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL"
+  [ "$status" -eq 0 ]
+  paths=$(printf '%s\n' "$output" | awk '{print $2}')
+  expected=$'alpha.txt\nsub/inner.txt\nzeta.txt'
+  [[ "$paths" == "$expected" ]]
+}
+
+@test "output is deterministic across runs" {
+  printf 'one\n'  >"$TMPDIR_LOCAL/a.txt"
+  printf 'two\n'  >"$TMPDIR_LOCAL/b.txt"
+  printf 'three\n' >"$TMPDIR_LOCAL/c.txt"
+  run1=$(bash "$SCRIPT" "$TMPDIR_LOCAL")
+  run2=$(bash "$SCRIPT" "$TMPDIR_LOCAL")
+  [[ "$run1" == "$run2" ]]
+}
+
+@test "no trailing blank line" {
+  printf 'x\n' >"$TMPDIR_LOCAL/only.txt"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL"
+  [ "$status" -eq 0 ]
+  # `output` from `run` strips one trailing newline; check raw bytes.
+  raw="$(bash "$SCRIPT" "$TMPDIR_LOCAL" | od -c | tail -1)"
+  # Last printed char should be newline immediately after the path; no extra blank line.
+  [[ "$(bash "$SCRIPT" "$TMPDIR_LOCAL" | wc -l)" -eq 1 ]]
+}
+
+@test "handles nested directories" {
+  mkdir -p "$TMPDIR_LOCAL/a/b/c"
+  printf 'deep\n' >"$TMPDIR_LOCAL/a/b/c/file.txt"
+  printf 'top\n'  >"$TMPDIR_LOCAL/top.txt"
+  run bash "$SCRIPT" "$TMPDIR_LOCAL"
+  [ "$status" -eq 0 ]
+  paths=$(printf '%s\n' "$output" | awk '{print $2}')
+  expected=$'a/b/c/file.txt\ntop.txt'
+  [[ "$paths" == "$expected" ]]
+}

--- a/tests/goldens/lib/diff-loadfile.sh
+++ b/tests/goldens/lib/diff-loadfile.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# diff-loadfile.sh — byte-exact diff for load files, with bounded output.
+#
+# Usage:
+#   diff-loadfile.sh <expected-file> <actual-file>
+#
+# Behaviour:
+#   - Exit 0, no output:  files are byte-identical.
+#   - Exit 1, useful output: files differ. Prints the first differing line
+#     number, the expected vs actual line, and up to 3 lines of context on
+#     each side. Load files can be hundreds of MB — we never dump the whole
+#     thing.
+#   - Exit 2: bad arguments / files not readable.
+#
+# Implementation notes:
+#   - We compare bytes, not characters, so trailing-newline differences and
+#     CRLF vs LF are surfaced.
+#   - The "first differing line" is computed by streaming both files in
+#     parallel; we stop on the first mismatch and only read enough trailing
+#     context to print 3 more lines from each side.
+
+set -euo pipefail
+
+CONTEXT=3
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: diff-loadfile.sh <expected-file> <actual-file>" >&2
+  exit 2
+fi
+
+expected="$1"
+actual="$2"
+
+for f in "$expected" "$actual"; do
+  if [[ ! -r "$f" ]]; then
+    echo "diff-loadfile.sh: not readable: $f" >&2
+    exit 2
+  fi
+done
+
+# Fast path — byte-identical via cmp.
+if cmp -s -- "$expected" "$actual"; then
+  exit 0
+fi
+
+# Slow path — find the first differing line and print bounded context.
+# (Variable names avoid `exp` / `act` which collide with gawk builtins.)
+awk -v ctx="$CONTEXT" -v expfile="$expected" -v actfile="$actual" '
+  BEGIN {
+    # Read both files line-by-line in lockstep.
+    while (1) {
+      e_ok = (getline e_line < expfile)
+      a_ok = (getline a_line < actfile)
+      if (e_ok <= 0 && a_ok <= 0) {
+        # Both ended at the same line count without finding a textual diff.
+        # cmp already told us they differ in bytes (e.g. trailing newline),
+        # so report that explicitly.
+        printf("Files differ in trailing bytes (line counts equal at %d).\n", lineno) > "/dev/stderr"
+        exit 1
+      }
+      lineno++
+      e_buf[lineno] = (e_ok > 0) ? e_line : "<EOF>"
+      a_buf[lineno] = (a_ok > 0) ? a_line : "<EOF>"
+      if (e_buf[lineno] != a_buf[lineno]) {
+        first = lineno
+        break
+      }
+    }
+
+    # Print preceding context (up to ctx lines, both files identical there).
+    start = (first - ctx > 1) ? first - ctx : 1
+    printf("First differing line: %d\n", first) > "/dev/stderr"
+    printf("--- expected: %s\n", expfile) > "/dev/stderr"
+    printf("+++ actual:   %s\n", actfile) > "/dev/stderr"
+    for (i = start; i < first; i++) {
+      printf("  %6d  %s\n", i, e_buf[i]) > "/dev/stderr"
+    }
+    printf("- %6d  %s\n", first, e_buf[first]) > "/dev/stderr"
+    printf("+ %6d  %s\n", first, a_buf[first]) > "/dev/stderr"
+
+    # Print up to ctx trailing lines from each side.
+    for (j = 1; j <= ctx; j++) {
+      e_ok = (getline e_line < expfile)
+      a_ok = (getline a_line < actfile)
+      if (e_ok <= 0 && a_ok <= 0) break
+      ln = first + j
+      e_show = (e_ok > 0) ? e_line : "<EOF>"
+      a_show = (a_ok > 0) ? a_line : "<EOF>"
+      printf("  %6d  expected: %s\n", ln, e_show) > "/dev/stderr"
+      printf("  %6d  actual:   %s\n", ln, a_show) > "/dev/stderr"
+    }
+    exit 1
+  }
+'

--- a/tests/goldens/lib/sha-manifest.sh
+++ b/tests/goldens/lib/sha-manifest.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# sha-manifest.sh — emit a deterministic sha256 manifest for a directory tree.
+#
+# Usage:
+#   sha-manifest.sh <root-dir>
+#
+# Output (to stdout):
+#   "<sha256>  <relative-path>\n" — one line per regular file, sorted by path.
+#
+# Exit codes:
+#   0  success
+#   1  bad arguments / root not a directory
+#   2  hashing helper missing
+#
+# Notes:
+#   - Paths are sorted with `LC_ALL=C sort` so output is byte-stable across
+#     platforms regardless of locale.
+#   - Symlinks are followed only when they resolve to a regular file inside
+#     the tree; broken symlinks are skipped silently (matches `find -type f`).
+#   - Output uses a single trailing newline at the end of the last line; no
+#     extra blank line.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: sha-manifest.sh <root-dir>" >&2
+  exit 1
+fi
+
+root="$1"
+
+if [[ ! -d "$root" ]]; then
+  echo "sha-manifest.sh: not a directory: $root" >&2
+  exit 1
+fi
+
+# Pick the available sha256 hasher. macOS ships `shasum`, most Linux distros
+# ship `sha256sum`; we accept either.
+hasher=""
+if command -v sha256sum >/dev/null 2>&1; then
+  hasher="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  hasher="shasum -a 256"
+else
+  echo "sha-manifest.sh: need sha256sum or shasum on PATH" >&2
+  exit 2
+fi
+
+# Walk the tree, hash each regular file, normalise the path to a relative
+# form (with a leading "./" stripped), and sort.
+(
+  cd "$root"
+  # -print0 + read -d '' keeps us safe on filenames with spaces or newlines.
+  find . -type f -print0 \
+    | LC_ALL=C sort -z \
+    | while IFS= read -r -d '' f; do
+        rel="${f#./}"
+        # `sha256sum` prints "<hash>  <path>"; we substitute the path with our
+        # cleaned relative form so output is identical regardless of how
+        # `find` rendered the original entry.
+        h=$($hasher "$f" | awk '{print $1}')
+        printf '%s  %s\n' "$h" "$rel"
+      done
+)

--- a/tests/goldens/run-goldens.sh
+++ b/tests/goldens/run-goldens.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# run-goldens.sh — drive the Zipper CLI against scenarios.tsv and byte-compare
+# its output to checked-in fixtures.
+#
+# Usage:
+#   run-goldens.sh [--capture] [--scenario NAME]
+#
+#   --capture           Write fresh fixtures instead of diffing. Used by the
+#                       capture tickets when intentionally regenerating
+#                       goldens. Never used in CI.
+#   --scenario NAME     Run only the row whose `scenario_name` equals NAME,
+#                       for debugging.
+#
+# scenarios.tsv contract:
+#   - Header row first (pipe-delimited): scenario_name | cli_args | seed | description
+#   - Empty body OK — exits 0 with no work done. This ticket ships an empty
+#     table on purpose; capture tickets populate it.
+#   - Comment lines start with `#` and are ignored.
+#
+# Exit codes:
+#   0  all scenarios matched their fixtures (or scenarios.tsv was empty).
+#   1  one or more scenarios diverged.
+#   2  bad arguments / scenarios.tsv missing / Zipper CLI not runnable.
+
+set -euo pipefail
+
+GOLDENS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$GOLDENS_DIR/lib"
+FIXTURES_DIR="$GOLDENS_DIR/fixtures"
+SCENARIOS_FILE="$GOLDENS_DIR/scenarios.tsv"
+
+CAPTURE=0
+ONLY_SCENARIO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --capture) CAPTURE=1; shift ;;
+    --scenario) ONLY_SCENARIO="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '1,30p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "run-goldens.sh: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$SCENARIOS_FILE" ]]; then
+  echo "run-goldens.sh: scenarios.tsv not found at $SCENARIOS_FILE" >&2
+  exit 2
+fi
+
+# Walk the scenarios file. We accept either tab or pipe as separator on the
+# header row to stay forward-compatible; data rows must match the header.
+header_seen=0
+total=0
+ran=0
+failed=0
+
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+  # Strip CR (Windows-authored TSVs) and skip blank/comment lines.
+  line="${raw_line%$'\r'}"
+  [[ -z "$line" ]] && continue
+  [[ "${line:0:1}" == "#" ]] && continue
+
+  if [[ $header_seen -eq 0 ]]; then
+    header_seen=1
+    continue
+  fi
+
+  total=$((total + 1))
+
+  # Pipe-delimited per the issue spec.
+  IFS='|' read -r scenario_name cli_args seed description <<<"$line"
+  scenario_name="$(echo "$scenario_name" | xargs)"
+  cli_args="$(echo "$cli_args" | sed 's/^ *//;s/ *$//')"
+  seed="$(echo "$seed" | xargs)"
+
+  if [[ -n "$ONLY_SCENARIO" && "$ONLY_SCENARIO" != "$scenario_name" ]]; then
+    continue
+  fi
+
+  ran=$((ran + 1))
+  echo "==> scenario: $scenario_name"
+
+  fixture_dir="$FIXTURES_DIR/$scenario_name"
+  work_dir="$(mktemp -d)"
+  trap 'rm -rf "$work_dir"' EXIT
+
+  # Resolve the Zipper CLI. Capture/diff scenarios are populated in follow-up
+  # tickets; until then this script is exercised only with empty/no rows.
+  zipper_cli="${ZIPPER_CLI:-}"
+  if [[ -z "$zipper_cli" ]]; then
+    echo "run-goldens.sh: ZIPPER_CLI env var must point at the Zipper executable" >&2
+    exit 2
+  fi
+
+  # shellcheck disable=SC2086 # cli_args is intentionally word-split here.
+  ( cd "$work_dir" && SEED="$seed" "$zipper_cli" $cli_args )
+
+  if [[ $CAPTURE -eq 1 ]]; then
+    rm -rf "$fixture_dir"
+    mkdir -p "$fixture_dir"
+    cp -R "$work_dir"/. "$fixture_dir"/
+    echo "    captured -> $fixture_dir"
+  else
+    if [[ ! -d "$fixture_dir" ]]; then
+      echo "    MISSING fixture dir: $fixture_dir" >&2
+      failed=$((failed + 1))
+      continue
+    fi
+    expected_manifest="$(mktemp)"
+    actual_manifest="$(mktemp)"
+    bash "$LIB_DIR/sha-manifest.sh" "$fixture_dir" >"$expected_manifest"
+    bash "$LIB_DIR/sha-manifest.sh" "$work_dir"    >"$actual_manifest"
+    if ! diff -u "$expected_manifest" "$actual_manifest"; then
+      echo "    manifest mismatch — running per-file diff to surface first divergence"
+      while IFS=  read -r relpath; do
+        e="$fixture_dir/$relpath"
+        a="$work_dir/$relpath"
+        if [[ -f "$e" && -f "$a" ]]; then
+          if ! bash "$LIB_DIR/diff-loadfile.sh" "$e" "$a"; then
+            failed=$((failed + 1))
+            break
+          fi
+        fi
+      done < <(awk '{print $2}' "$expected_manifest")
+    fi
+    rm -f "$expected_manifest" "$actual_manifest"
+  fi
+
+  rm -rf "$work_dir"
+  trap - EXIT
+done <"$SCENARIOS_FILE"
+
+if [[ $total -eq 0 ]]; then
+  echo "run-goldens.sh: scenarios.tsv has no data rows; nothing to do."
+  exit 0
+fi
+
+echo "ran=$ran  failed=$failed  total=$total"
+[[ $failed -eq 0 ]]

--- a/tests/goldens/scenarios.tsv
+++ b/tests/goldens/scenarios.tsv
@@ -1,0 +1,1 @@
+scenario_name | cli_args | seed | description


### PR DESCRIPTION
Closes #197

## Summary

Adds the byte-exact goldens harness scaffold under `tests/goldens/`. Pure plumbing only — no scenarios are captured (#198) and CI is not wired yet (#199), keeping this diff easy to review.

## Changes

- `tests/goldens/run-goldens.sh` — runner that walks `scenarios.tsv`, drives the Zipper CLI per row, sha256-manifests both expected and actual trees, and falls back to per-file diff on any divergence. Supports `--capture` (regenerate fixtures, never used in CI) and `--scenario NAME` (debug a single row). Exits 0 on an empty scenarios table.
- `tests/goldens/lib/sha-manifest.sh` — deterministic `sha256  relative-path` manifest of a directory tree, sorted with `LC_ALL=C`, accepting either `sha256sum` or `shasum -a 256`.
- `tests/goldens/lib/diff-loadfile.sh` — byte-diff with bounded output: prints first differing line plus 3 lines of context, never dumps the whole file.
- `tests/goldens/scenarios.tsv` — pipe-delimited header only; populated by #198.
- `tests/goldens/fixtures/.gitkeep` — placeholder until #198 lands.
- `tests/goldens/README.md` — add-a-scenario / capture / fail workflow documented.
- `tests/goldens/lib/_test/sha-manifest.bats` — bats-core unit tests: argument validation, empty dir, single file (known sha), sort order, determinism, no trailing blank line, nested dirs.
- `tests/goldens/lib/_test/diff-loadfile.bats` — bats-core unit tests: argument validation, missing files, identical-files silent exit, first-divergence message, trailing-newline detection, bounded output on a 5000-line file.

No C# code is touched; `DataGenerator` and friends are unchanged.

## Verification

CI must pass:

- `lint` (`dotnet format --verify-no-changes`)
- `build-and-test` matrix on `ubuntu-latest`, `windows-latest`, `macos-latest` (build, unit tests, E2E suite, Linux coverage ≥ 80%)
- `droid-review` is informational, non-blocking

Manually verified locally:

- `run-goldens.sh` exits 0 on the empty `scenarios.tsv`.
- `sha-manifest.sh` produces deterministic, sorted output (matches `sha256("hello\n")` for a single-file tree).
- `diff-loadfile.sh` is silent + exit 0 on identical files; reports "First differing line" with context on divergence; bounded to ~14 lines of output even for a 5000-line input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive E2E golden test harness with deterministic output verification for end-to-end behavior validation.
  * Includes test infrastructure with scenario runner, file comparison utilities, and SHA-256 manifest generation for byte-exact test fixture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->