### PR TITLE
chore: simplify AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ TODO.md
 
 # Planning artifacts
 .planning/
+
+# Coverage
+coverage*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,32 @@
 # AI Agent Instructions for Zipper
 
-**Behavior:** Think step-by-step before coding. Output COMPLETE files (no placeholders/ellipses). Fix root causes, not symptoms. Match existing style. If unsure, ask for clarification – do not assume. Include error handling. Self-review for bugs/security. Suggest incremental changes over massive rewrites. **All discussions, documentation, and code must use the ubiquitous language terms defined in UBIQUITOUS_LANGUAGE.md.**
+**Behavior:** Think step-by-step before coding. Output COMPLETE files (no placeholders/ellipses). Fix root causes, not symptoms. Match existing style. If unsure, ask for clarification – do not assume. Include error handling. Self-review for bugs/security. Suggest incremental changes over massive rewrites.
 
 ---
 
-## Ubiquitous Language
+## How To Use This File
 
-**REQUIRED:** Read and follow [UBIQUITOUS_LANGUAGE.md](UBIQUITOUS_LANGUAGE.md) for all discussions, documentation, and code reviews. Use canonical terms (Archive, Native File, Load File, Bates Number, etc.) — the file defines each with aliases to avoid.
-
-**Usage:** grep the file before writing docs/PRs; flag non-canonical terms in review.
+- This file is the agent workflow guide. Product behavior → [Requirements.md](Requirements.md). User-facing usage → [README.md](README.md). Domain terms → [UBIQUITOUS_LANGUAGE.md](UBIQUITOUS_LANGUAGE.md).
+- If an issue body, README.md, Requirements.md, and implementation disagree, stop and identify the conflict explicitly before coding. Do not silently choose one source.
 
 ---
-
 
 ## Commands
 
 ```bash
-# Restore (run after clone or adding packages)
-dotnet restore zipper.sln
+dotnet restore zipper.sln                # Restore (after clone or adding packages)
+dotnet build zipper.sln                  # Build
+dotnet publish -c Release               # Publish
+dotnet run --project src/Zipper.csproj -- [args]  # Run
 
-# Build
-dotnet publish -c Release
+# Tests
+dotnet test src/Zipper.Tests/Zipper.Tests.csproj                              # Unit tests (must pass before commit)
+dotnet test src/Zipper.Tests/Zipper.Tests.csproj --filter "FullyQualifiedName~ClassName"  # Single test class
 
-# Run
-dotnet run --project src/Zipper.csproj -- [args]
+# Lint
+dotnet format --verify-no-changes src/   # Quick lint (run after every code change)
 
-# Unit Tests (must pass before commit)
-dotnet test src/Zipper.Tests/Zipper.Tests.csproj
-
-# Single test class
-dotnet test src/Zipper.Tests/Zipper.Tests.csproj --filter "FullyQualifiedName~ClassName"
-
-# Lint (runs automatically before every commit via pre-commit hook)
-dotnet format --verify-no-changes
-
-# Quick lint (run after every code change before staging)
-dotnet format --verify-no-changes src/
-
-# E2E Tests (must pass before push - enforced by git hooks)
+# E2E (must pass before push)
 ./tests/run-tests.sh   # Linux/macOS
 tests/run-tests.bat    # Windows
 ```
@@ -47,104 +36,69 @@ tests/run-tests.bat    # Windows
 ## Critical Rules
 
 > [!IMPORTANT]
-> **Domain Language Mandatory**: Refer to UBIQUITOUS_LANGUAGE.md when discussing any Zipper concept. Use canonical terms (Archive, Native File, Load File, Metadata, Folder, Volume, Email, Attachment, Bates Number, Chaos Engine, Loadfile-Only Mode) consistently in all code, comments, and documentation.
+> **Domain Language:** Read and follow [UBIQUITOUS_LANGUAGE.md](UBIQUITOUS_LANGUAGE.md) for all code, comments, documentation, and reviews. Grep the file before writing docs/PRs; flag non-canonical terms in review.
 
 > [!CAUTION]
-> **Requirement numbers in Requirements.md are IMMUTABLE.** REQ-XXX and FR-XXX numbers must NEVER be changed or renumbered.
+> **Requirement IDs are IMMUTABLE.** REQ-XXX and FR-XXX numbers must NEVER be changed or renumbered.
 
 > [!IMPORTANT]
-> **CLI Documentation Sync**: When modifying CLI args in `CommandLineValidator.cs`, update:
-> 1. `README.md` - Arguments Quick Reference table
-> 2. `Requirements.md` - Add new requirements
-> 3. This file - if adding major features
+> **Documentation Sync:** Any change to CLI behavior, Load File/Audit File/Production Set formats, or Email domain names must update **all** of:
+> 1. `README.md` — Arguments Quick Reference, Argument Interactions, examples
+> 2. `Requirements.md` — add or revise requirements (never renumber)
+> 3. `UBIQUITOUS_LANGUAGE.md` — if domain terms change
+> 4. E2E scripts — both `.sh` and `.bat` for new coverage
+>
+> Verify behavior changes against Requirements.md before committing. Run `grep -n "REQ-XXX" Requirements.md` for each affected requirement.
 
-## Issue Priority Order
+---
 
-**All open issues:** https://github.com/dwojtaszek/zipper/issues
+## Workflow
 
-Tackle in this order: **Blockers** → **Critical** → **High** → **Test Coverage** (fill gaps before refactoring) → **Design** (D1-D6, only after test coverage exists).
+**Issue priority:** Blockers → Critical → High → Test Coverage → Design/Refactor/KISS (only after relevant test coverage exists).
 
-**Workflow per issue:**
+**Current dependency gate:** #198 (E2E golden fixtures + CI job) blocks most refactor work. Do not start design/refactor/KISS issues blocked on #198 until the golden CI job is active.
+
+**Per-issue workflow:**
 1. `git checkout main && git pull`
 2. `git checkout -b fix/ISSUE-NNN-short-desc`
-3. Read the issue body for file paths, line numbers, and fix guidance
+3. Read the issue body; refresh labels, comments, and linked blockers before coding
 4. Write a failing test first (TDD), then implement the fix
-5. **Run lint + tests after EVERY code change:**
-   - `dotnet format --verify-no-changes src/` — quick lint check
-   - `dotnet test src/Zipper.Tests/Zipper.Tests.csproj --no-build` — quick test (if build hasn't changed)
-   - `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` — full test + build (after structural changes)
+5. Run `dotnet format --verify-no-changes src/` and `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` after every change
 6. Commit and create PR
-7. **Monitor CI after PR:** After creating or updating a PR, monitor GitHub CI status until all checks pass. If CI fails, diagnose and fix before requesting review.
+7. Monitor CI until all checks pass; fix failures before requesting review
 
-## Requirement-Driven Changes
+**Test location:** `src/Zipper.Tests/` (NOT the root `Zipper.Tests/` which is obsolete).
 
-> [!IMPORTANT]
-> **Every code change that alters behavior MUST be verified against Requirements.md and README.md.**
-> 
-> **Before committing:**
-> 1. Identify which REQ-XXX requirements are affected by the change
-> 2. Check if the change violates any existing requirement — if so, flag it before implementing
-> 3. If a requirement must change, update the requirement text (never change REQ numbers — they are IMMUTABLE per the CAUTION block above)
-> 4. Update README.md if the change affects: CLI arguments, format specifications, behavior descriptions, the Arguments Quick Reference table, or the Argument Interactions section
-> 5. Run `grep -n "REQ_XXX" Requirements.md` to verify all referenced requirements still exist
-> 
-> **Review checklist for code review:**
-> - [ ] Code behavior matches Requirements.md (no violations)
-> - [ ] CLI argument changes reflected in README.md Arguments Quick Reference table
-> - [ ] CLI argument changes reflected in Requirements.md argument descriptions
-> - [ ] Format changes align with Section 8 (Load File Format Standards)
-> - [ ] New options documented in README.md examples section
-> - [ ] Argument interactions updated in both README.md and Requirements.md Section 10
-
-**Test Location:** All unit tests go in `src/Zipper.Tests/` (NOT the root `Zipper.Tests/` which is obsolete).
-
-**Pre-commit Hook:** The `.git/hooks/pre-commit` hook runs `dotnet format --verify-no-changes`, auto-formats staged C# files, then runs unit tests on every `git commit`. To bypass: `git commit --no-verify`.
-
-**E2E Tests:** Must verify actual output (file counts, headers, content). All new E2E tests need both `.sh` and `.bat` implementations.
+**Pre-commit hook:** Runs lint + auto-format + unit tests on every `git commit`. Bypass: `git commit --no-verify`.
 
 ---
 
 ## Project Structure
 
-**Solution:** `zipper.sln` (build with `dotnet build zipper.sln`)  
-**Warnings as Errors:** Enabled - fix all warnings before commit
+**Solution:** `zipper.sln` — **Warnings as Errors** enabled.
 
 | Path | Purpose |
 |------|---------|
-| `src/Zipper.csproj` | Main application |
 | `src/Program.cs` | Entry point, CLI orchestration, mode dispatch |
-| `src/CommandLineValidator.cs` | CLI parsing, validation, request assembly |
+| `src/Cli/` | CLI parsing, validation, help text, request assembly |
 | `src/FileGenerationRequest.cs` | Configuration object (40+ properties) shared across pipeline |
 | `src/ParallelFileGenerator.cs` | Channel-based producer-consumer pipeline (standard mode) |
 | `src/ZipArchiveService.cs` | Archive creation + Load File writing (consumer side) |
 | `src/LoadfileOnlyGenerator.cs` | Standalone Load File generation (DAT/OPT) + Chaos |
-| `src/ProductionSetGenerator.cs` | Production set directory tree + Load Files |
+| `src/ProductionSetGenerator.cs` | Production Set directory tree + Load Files |
 | `src/ChaosEngine.cs` | Chaos Anomaly injection engine (Floyd's algorithm) |
-| `src/ChaosAnomaly.cs` | Anomaly record for audit tracking |
-| `src/ChaosScenario.cs` | Named, reproducible Chaos configurations |
 | `src/LoadfileAuditWriter.cs` | `_properties.json` audit file writer |
 | `src/ProductionManifestWriter.cs` | `_manifest.json` production manifest writer |
-| `src/OfficeFileGenerator.cs` | DOCX/XLSX Native File generation |
 | `src/EmlGenerationService.cs` | Email Native File generation |
 | `src/EmailBuilder.cs` | MIME construction for Email Native Files |
-| `src/EmailTemplateSystem.cs` | Email template data (categories, bodies, addresses) |
+| `src/OfficeFileGenerator.cs` | DOCX/XLSX Native File generation |
 | `src/PlaceholderFiles.cs` | Pre-computed byte content for PDF, JPG, TIFF |
-| `src/FileDistributionHelper.cs` | Distribution facade (proportional/gaussian/exponential) |
-| `src/TiffMultiPageGenerator.cs` | TIFF page range parsing and generation |
 | `src/BatesNumberGenerator.cs` | Bates Number generation |
-| `src/PathValidator.cs` | Path traversal protection |
-| `src/EncodingHelper.cs` | Encoding name resolution (UTF-8, UTF-16, ANSI) |
-| `src/ContentTypeHelper.cs` | MIME type mapping by extension |
-| `src/PerformanceMonitor.cs` | Real-time progress, throughput, ETA |
-| `src/PerformanceBenchmarkRunner.cs` | Built-in benchmark suite |
-| `src/MemoryPoolManager.cs` | `MemoryPool<byte>.Shared` wrapper |
 | `src/LoadFiles/` | Load File writers (DAT, OPT, CSV, XML, Concordance) |
 | `src/Profiles/` | Column profile system (loader, data generator, built-ins) |
 | `src/Zipper.Tests/` | Unit tests |
 | `tests/` | E2E test scripts |
 
-**For full CLI arguments and options:** See [README.md](README.md)  
-**For requirements and specifications:** See [Requirements.md](Requirements.md)
 
 ---
 
@@ -152,85 +106,39 @@ Tackle in this order: **Blockers** → **Critical** → **High** → **Test Cove
 
 ### Three Generation Modes
 
-`Program.Main` dispatches to one of three paths based on CLI flags:
-
 | Mode | Trigger | Entry Point | Output |
 |------|---------|-------------|--------|
 | **Standard** | default | `ParallelFileGenerator.GenerateFilesAsync()` | Archive (.zip) + Load File |
 | **Loadfile-Only** | `--loadfile-only` | `LoadfileOnlyGenerator.GenerateAsync()` | Load File + `_properties.json` audit |
 | **Production Set** | `--production-set` | `ProductionSetGenerator.GenerateAsync()` | Directory tree (NATIVES/IMAGES/DATA/TEXT) + Load Files |
 
-**Which mode to use?**
-
-| If you need... | Use... | Flag |
-|----------------|--------|------|
-| A single Archive with Load File | Standard | (default, no flag needed) |
-| Only a Load File, no Archive | Loadfile-Only | `--loadfile-only` |
-| Structured production set (NATIVES/IMAGES/DATA/TEXT Folders) with cross-referenced Load Files | Production Set | `--production-set` (requires `--bates-prefix`) |
-| Chaos anomaly injection | Loadfile-Only + Chaos | `--loadfile-only --chaos-mode` |
-| Output wrapped in Archive | Standard (or Production Set + `--production-zip`) | |
-
-### Standard Pipeline (Channel-Based Producer-Consumer)
+### Standard Pipeline
 
 `ParallelFileGenerator` uses `System.Threading.Channels` for a 3-stage pipeline:
 
-1. **Work channel** (`CreateWorkChannel`): Produces `FileWorkItem` objects (Folder assignment, file index) using the configured distribution algorithm. Bounded channel provides backpressure.
-2. **Generation** (`ProcessFileWorkAsync`): N concurrent producers read from work channel, call `GenerateFileData()` (placeholder content + optional padding), write `FileData` to result channel. Email with Attachments or Extracted Text forces `Concurrency = 1`.
-3. **Archive writing** (`ZipArchiveService.CreateArchiveAsync`): Single consumer reads from result channel, writes ZIP entries sequentially, accumulates `processedFiles` list, then writes Load Files via `ILoadFileWriter` implementations.
-
-Memory: `MemoryPool<byte>.Shared` rented via `IMemoryOwner<byte>` for normal files, direct allocation fallback for oversized. Padding uses `RandomNumberGenerator.Fill` for non-compressible data.
-
-### Load File Writers
-
-`LoadFiles/` directory: `ILoadFileWriter` interface + `LoadFileWriterBase` abstract class + `LoadFileWriterFactory`. Each format is a subclass:
-
-- `DatWriter` (in `LoadFileWriterFactory.cs`) — Concordance DAT with configurable delimiters
-- `OptWriter` — Opticon comma-delimited
-- `CsvWriter` — Standard CSV
-- `XmlLoadFileWriter` — EDRM-XML
-- `ConcordanceWriter` — Concordance DAT with standard delimiters
-
-**Which format to use?**
-
-| If consumer uses... | Use... | CLI value | Notes |
-|---------------------|--------|-----------|-------|
-| Concordance (standard) | DAT | `dat` | Configurable delimiters via `--dat-delimiters` / `--delimiter-*` |
-| Opticon | OPT | `opt` | Comma-delimited, no-header format |
-| Standard CSV | CSV | `csv` | Comma-separated with header |
-| EDRM XML | XML | `edrm-xml` | XML schema per EDRM standard |
-| Concordance (legacy fixed delimiters) | Concordance | `concordance` | Uses `þ` (254) / `Þ` (222) fixed delimiters |
-| Multiple outputs | Any combination | `--load-file-formats dat,opt,csv` | Comma-separated list |
+1. **Work channel**: Produces `FileWorkItem` objects using the configured distribution algorithm. Bounded channel provides backpressure.
+2. **Generation**: N concurrent producers generate file data and write to result channel. Email with Attachments or Extracted Text forces `Concurrency = 1`.
+3. **Archive writing**: Single consumer (`ZipArchiveService`) writes ZIP entries, then writes Load Files via `ILoadFileWriter` implementations.
 
 ### Chaos Engine (Loadfile-Only Mode only)
 
-`ChaosEngine` intercepts Load File lines using Floyd's algorithm for O(k) exact random sampling of lines to corrupt. Supports DAT Anomaly types (`mixed-delimiters`, `quotes`, `columns`, `eol`, `encoding`) and OPT types (`opt-boundary`, `opt-columns`, `opt-pagecount`, `opt-path`, `opt-batesid`). Injected Anomalies tracked in `_properties.json` via `LoadfileAuditWriter`.
-
-### Distribution Algorithms
-
-`ProportionalDistribution`, `GaussianDistribution`, `ExponentialDistribution` — static classes. `FileDistributionHelper` facade. Each is O(1) per file.
-
-### Column Profile System
-
-`Profiles/` directory: `ColumnProfileLoader` validates and loads JSON profiles (built-in or custom file). `DataGenerator` produces column values by type. `BuiltInProfiles` embeds minimal/standard/litigation/full definitions in C#.
+`ChaosEngine` uses Floyd's algorithm for O(k) exact random sampling of lines to corrupt. DAT types: `mixed-delimiters`, `quotes`, `columns`, `eol`, `encoding`. OPT types: `opt-boundary`, `opt-columns`, `opt-pagecount`, `opt-path`, `opt-batesid`. Tracked in `_properties.json` via `LoadfileAuditWriter`.
 
 ---
 
 ## Key Invariants
 
-- **Request immutability:** `FileGenerationRequest` must not be mutated after passing to a generator. Used across concurrent tasks. Callers `Clone()` before modifying. `Clone()` is shallow via `MemberwiseClone` — reference-type properties (ColumnProfile, BatesConfig, LoadFileFormats) are shared between original and clone.
-- **MemoryOwner lifecycle:** `MemoryOwner.Dispose()` in `ZipArchiveService:73` happens before Load File writing. Load File writers access `Data.Length` only — accessing `.Span` after disposal is use-after-free (issue #132).
-- **Path separators:** Load File paths use backslash `\` (eDiscovery convention). ZIP entry paths use forward slash `/` (ZIP spec). `ProductionSetGenerator` converts via `.Replace(Path.DirectorySeparatorChar, '\\')`.
-- **Loadfile-Only vs standard metadata:** `LoadfileOnlyGenerator` and the standard `DatWriter` use separate metadata generation paths. Same seed + same count can produce different metadata rows.
+- **Request immutability:** `FileGenerationRequest` must not be mutated after passing to a generator. Callers `Clone()` before modifying. `Clone()` is shallow — reference-type properties are shared.
+- **MemoryOwner lifecycle:** Disposed before Load File writing. Writers access `Data.Length` only — accessing `.Span` after disposal is use-after-free.
+- **Path separators:** Load File paths use `\` (eDiscovery convention). ZIP entries use `/` (ZIP spec).
+- **Loadfile-Only scope:** Writes DAT or OPT only. Do not add CSV/XML Loadfile-Only scenarios without changing implementation + docs first.
+- **Audit File schema:** camelCase throughout — `chaosMode.injectedAnomalies[*].errorType`, `lineNumber`, `recordID`. Not PascalCase, not snake_case.
 
 ---
 
-## Code Patterns
+## Code Style
 
 ```csharp
-// Email forces sequential processing with attachments
-if (request.FileType == "eml" && (request.WithText || request.AttachmentRate > 0))
-    request.Concurrency = 1;
-
 // Cross-platform ANSI encoding — MUST register at startup in Program.Main
 System.Text.Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
@@ -238,8 +146,6 @@ System.Text.Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 await writer.FlushAsync();  // NOT: await writer.DisposeAsync();
 ```
 
-**Performance:** Distribution algorithms must be O(1) per file. Use `Span<T>`, `ArrayPool<T>`, avoid allocations in hot paths.
-
-**Style:** C# 8.0+, file-scoped namespaces, nullable reference types, switch expressions, pattern matching.
-
-**No Copyright Headers:** Do NOT add copyright, license, or file header comments (e.g. `// <copyright ...>`) to any files. This project does not use file-level copyright headers.
+- C# 8.0+, file-scoped namespaces, nullable reference types, switch expressions, pattern matching
+- Distribution algorithms must be O(1) per file. Use `Span<T>`, `ArrayPool<T>`, avoid allocations in hot paths
+- **No copyright headers** — do not add `// <copyright ...>` to any files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## Unreleased
-
-### Breaking Changes
-
-- Loadfile-Only Mode `_properties.json` audit files now use `camelCase` JSON property names.
-- Common schema updates include `FileName` -> `fileName`, `Format` -> `format`, `TotalRecords` -> `totalRecords`, `ChaosMode.Enabled` -> `chaosMode.enabled`, and `InjectedAnomalies[*].RecordID` -> `injectedAnomalies[*].recordID`.
-- Repository-managed tooling has been updated to the new audit file schema. Any external tooling that parses `_properties.json` must be updated before consuming this branch.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,16 @@ Compatibility checklist:
 | `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
 | `--production-zip`, `--volume-size` | Require `--production-set` |
 
+### Maintainer Notes for Issue Authors
+
+When writing or updating issue scopes, use the current CLI names and Audit File schema:
+
+- Use `--load-file-format` for general Load File format selection and `--loadfile-format` as the Loadfile-Only Mode alias. There is no `--format` flag.
+- Use `--production-set --output-path <directory>` for Production Set output. `--production-set` does not take a path value.
+- Use `--chaos-mode --chaos-types <type> --chaos-amount <N|N%>` for Chaos Engine examples. Omit `--chaos-mode` for a non-Chaos baseline.
+- Loadfile-Only Mode currently supports DAT and OPT output only.
+- `_properties.json` uses camelCase JSON. Chaos Anomalies are under `chaosMode.injectedAnomalies[*]` with `errorType`, `lineNumber`, and `recordID`.
+
 ### Column Profiles
 
 Column profiles allow you to generate rich, configurable metadata with up to 200 columns. Built-in profiles:

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -118,7 +118,7 @@
 
 | Term | Definition | Aliases to avoid |
 |------|-----------|-----------------|
-| **Generation Request** | The complete configuration (all CLI arguments) for a single generation job. Encapsulated in `FileGenerationRequest`. | Request, job specification |
+| **Generation Request** | The complete configuration (all CLI arguments) for a single generation job. Encapsulated in `FileGenerationRequest` and grouped by sub-configs such as Output, Metadata, Load File, Delimiters, Bates, TIFF, Chaos, and Production. New code should prefer the sub-config tree over flat pass-through properties. | Request, job specification |
 | **File Generation** | The process of creating all **Native Files** for an **Archive** or **Production Set**, distributed across **Folders** or **Volumes** according to the **Generation Request**. | File creation, document generation |
 | **Parallel Generation** | Multi-threaded **File Generation** with configurable worker pools optimized for available CPU cores. | Concurrent generation, parallel processing |
 | **Worker Pool** | The set of background threads performing **Parallel Generation**. Size is auto-detected based on CPU core count. | Thread pool, worker threads |


### PR DESCRIPTION
## Description

Simplifies `AGENTS.md` by:
- Removing redundancies (e.g., duplicated Ubiquitous Language mentions, repetitive CLI doc sync rules)
- Removing overload and verbose commands that belong in the README or workflow scripts
- Migrating the two durable invariants from the retired `CODEBASE_REVIEW.md` (Loadfile-Only scope and Audit File camelCase schema) into the Key Invariants section.

This ensures the agent instructions are concise, up-to-date, and easier for AI models to parse without losing any critical compliance checks.