### PR TITLE
E2E: Chaos Engine anomaly-type + scenario coverage (B1/B2/B3)

### DIFF
--- a/src/Zipper.Tests/ChaosEngineTests.cs
+++ b/src/Zipper.Tests/ChaosEngineTests.cs
@@ -668,6 +668,7 @@ namespace Zipper
                 types.Count >= 2,
                 $"Expected at least 2 distinct anomaly types with all types enabled, got {types.Count}: {string.Join(", ", types)}");
         }
+
         [Fact]
         public void AnomalyLineNumbers_AllMatchShouldInterceptTargets()
         {

--- a/src/Zipper.Tests/ChaosEngineTests.cs
+++ b/src/Zipper.Tests/ChaosEngineTests.cs
@@ -668,5 +668,86 @@ namespace Zipper
                 types.Count >= 2,
                 $"Expected at least 2 distinct anomaly types with all types enabled, got {types.Count}: {string.Join(", ", types)}");
         }
+        [Fact]
+        public void AnomalyLineNumbers_AllMatchShouldInterceptTargets()
+        {
+            // Verifies that every numeric LineNumber in Anomalies corresponds to a line
+            // where ShouldIntercept returned true — the invariant the E2E tests rely on.
+            const int totalLines = 100;
+            var engine = new ChaosEngine(
+                totalLines: totalLines,
+                chaosAmount: "10",
+                chaosTypes: "mixed-delimiters,quotes,columns,eol",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            string line = "\u00feValue1\u00fe\u0014\u00feValue2\u00fe\u0014\u00feValue3\u00fe";
+            var interceptedLines = new HashSet<long>();
+
+            for (int i = 1; i <= totalLines; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    engine.Intercept(i, line, $"DOC{i:D8}");
+                    interceptedLines.Add(i);
+                }
+            }
+
+            // Every numeric line number in Anomalies must be an intercepted line
+            foreach (var anomaly in engine.Anomalies)
+            {
+                if (long.TryParse(anomaly.LineNumber, out var lineNum))
+                {
+                    Assert.Contains(lineNum, interceptedLines);
+                }
+            }
+
+            // Count should match (each intercepted line produces exactly one anomaly for non-encoding types)
+            Assert.Equal(interceptedLines.Count, engine.Anomalies.Count);
+        }
+
+        [Fact]
+        public void AnomalyLineNumbers_NonInterceptedLines_HaveNoAnomalies()
+        {
+            // Verifies that lines NOT selected by ShouldIntercept appear in no anomaly record.
+            const int totalLines = 50;
+            var engine = new ChaosEngine(
+                totalLines: totalLines,
+                chaosAmount: "5",
+                chaosTypes: "columns",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "|",
+                quoteDelimiter: "\"",
+                eol: "\r\n",
+                seed: 42);
+
+            string line = "\"Val1\"|\"Val2\"|\"Val3\"";
+
+            for (int i = 1; i <= totalLines; i++)
+            {
+                if (engine.ShouldIntercept(i))
+                {
+                    engine.Intercept(i, line, $"DOC{i:D8}");
+                }
+            }
+
+            var anomalyLines = engine.Anomalies
+                .Select(a => long.TryParse(a.LineNumber, out var n) ? (long?)n : null)
+                .Where(n => n.HasValue)
+                .Select(n => n!.Value)
+                .ToHashSet();
+
+            // Non-intercepted lines must not appear in any anomaly
+            for (int i = 1; i <= totalLines; i++)
+            {
+                if (!engine.ShouldIntercept(i))
+                {
+                    Assert.DoesNotContain((long)i, anomalyLines);
+                }
+            }
+        }
     }
 }

--- a/tests/fixtures/chaos-anomaly-types.txt
+++ b/tests/fixtures/chaos-anomaly-types.txt
@@ -1,0 +1,14 @@
+# DAT chaos anomaly types (LoadFileFormat.Dat — default)
+# Source: ChaosEngine.cs DatChaosTypes
+mixed-delimiters
+quotes
+columns
+eol
+encoding
+# OPT chaos anomaly types (LoadFileFormat.Opt — requires --loadfile-format opt)
+# Source: ChaosEngine.cs OptChaosTypes
+opt-boundary
+opt-columns
+opt-pagecount
+opt-path
+opt-batesid

--- a/tests/fixtures/chaos-scenario-types.tsv
+++ b/tests/fixtures/chaos-scenario-types.tsv
@@ -1,0 +1,7 @@
+scenario_name	chaos_types	format
+structured-import-failures	mixed-delimiters,quotes,columns	dat
+encoding-nightmare	encoding,mixed-delimiters	dat
+broken-boundaries	opt-boundary,opt-pagecount,opt-path	opt
+field-overflow	eol,columns	dat
+full-chaos		dat
+transfer-encoding-failures	mixed-delimiters,encoding,quotes	dat

--- a/tests/fixtures/chaos-scenarios.txt
+++ b/tests/fixtures/chaos-scenarios.txt
@@ -1,0 +1,6 @@
+structured-import-failures
+encoding-nightmare
+broken-boundaries
+field-overflow
+full-chaos
+transfer-encoding-failures

--- a/tests/fixtures/properties.schema.json
+++ b/tests/fixtures/properties.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Zipper _properties.json",
+  "description": "Schema for the audit file emitted by LoadfileAuditWriter in loadfile-only mode.",
+  "type": "object",
+  "required": ["fileName", "format", "totalRecords", "properties", "chaosMode"],
+  "additionalProperties": false,
+  "properties": {
+    "fileName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "format": {
+      "type": "string",
+      "minLength": 1
+    },
+    "totalRecords": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "properties": {
+      "type": "object",
+      "required": ["encoding", "lineEnding", "delimiters"],
+      "additionalProperties": false,
+      "properties": {
+        "encoding": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lineEnding": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delimiters": {
+          "type": "object",
+          "required": ["column", "quote", "newline", "multiValue", "nestedValue"],
+          "additionalProperties": false,
+          "properties": {
+            "column":      { "type": "string" },
+            "quote":       { "type": "string" },
+            "newline":     { "type": "string" },
+            "multiValue":  { "type": "string" },
+            "nestedValue": { "type": "string" }
+          }
+        }
+      }
+    },
+    "chaosMode": {
+      "type": "object",
+      "required": ["enabled", "totalAnomalies"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "targetAmount": {
+          "type": ["string", "null"]
+        },
+        "totalAnomalies": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "injectedAnomalies": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "required": ["lineNumber", "recordID", "column", "errorType", "description"],
+            "additionalProperties": false,
+            "properties": {
+              "lineNumber":   { "type": "string" },
+              "recordID":     { "type": "string" },
+              "column":       { "type": "string" },
+              "errorType":    { "type": "string", "minLength": 1 },
+              "description":  { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/goldens/lib/validate-properties-json.sh
+++ b/tests/goldens/lib/validate-properties-json.sh
@@ -26,26 +26,37 @@ if [[ ! -f "$SCHEMA_FILE" ]]; then
 fi
 
 # --- Try ajv-cli (preferred, authoritative) ---
-# Run ajv only when npx is available. Capture its exit code:
-#   0  → JSON passed validation → exit 0 (done)
-#   1  → JSON failed validation → exit 1 (error; do NOT fall through to jq)
-#   127→ ajv-cli not installed  → fall through to jq fallback
+# In ajv-cli@5: exit 0 = data is valid, exit 1 = data is invalid.
+# Use 'npx --yes' to auto-install if not already present.
+# Only fall through to jq when npx cannot install/find ajv-cli (exit 127 or 1 from npx itself).
+#
+# Strategy:
+#   1. Check if ajv-cli is reachable via npx (probe with --help; install if needed).
+#   2. If probe succeeds, run validation authoritatively.
+#   3. If probe fails (not installable / network offline), fall through to jq.
 if command -v npx >/dev/null 2>&1; then
+    # Probe: install ajv-cli@5 if absent, then verify it answers --help.
     set +e
-    npx --yes ajv-cli@5 validate -s "$SCHEMA_FILE" -d "$JSON_FILE" \
-        --valid --errors=text 2>/dev/null
-    AJV_EXIT=$?
+    npx --yes ajv-cli@5 --help >/dev/null 2>&1
+    PROBE_EXIT=$?
     set -e
-    if [[ $AJV_EXIT -eq 0 ]]; then
-        # Validation passed
-        echo "[validate-properties-json] OK (ajv): $JSON_FILE"
-        exit 0
-    elif [[ $AJV_EXIT -ne 127 ]]; then
-        # ajv ran but found the JSON invalid; do not fall through to jq
-        echo "[validate-properties-json] FAIL (ajv): $JSON_FILE" >&2
-        exit 1
+
+    if [[ $PROBE_EXIT -eq 0 ]]; then
+        # ajv-cli is available; run validation authoritatively.
+        set +e
+        npx ajv-cli@5 validate -s "$SCHEMA_FILE" -d "$JSON_FILE"
+        AJV_EXIT=$?
+        set -e
+
+        if [[ $AJV_EXIT -eq 0 ]]; then
+            echo "[validate-properties-json] OK (ajv): $JSON_FILE"
+            exit 0
+        else
+            echo "[validate-properties-json] FAIL (ajv): $JSON_FILE" >&2
+            exit 1
+        fi
     fi
-    # AJV_EXIT=127 → ajv binary unavailable; fall through to jq fallback
+    # Probe failed: ajv not installable; fall through to jq
 fi
 
 # --- Fallback: jq hand-rolled checks ---

--- a/tests/goldens/lib/validate-properties-json.sh
+++ b/tests/goldens/lib/validate-properties-json.sh
@@ -25,13 +25,27 @@ if [[ ! -f "$SCHEMA_FILE" ]]; then
     exit 1
 fi
 
-# --- Try ajv-cli (preferred) ---
+# --- Try ajv-cli (preferred, authoritative) ---
+# Run ajv only when npx is available. Capture its exit code:
+#   0  → JSON passed validation → exit 0 (done)
+#   1  → JSON failed validation → exit 1 (error; do NOT fall through to jq)
+#   127→ ajv-cli not installed  → fall through to jq fallback
 if command -v npx >/dev/null 2>&1; then
-    # ajv-cli@5 uses ajv v8 and supports draft-07
-    if npx --yes ajv-cli@5 validate -s "$SCHEMA_FILE" -d "$JSON_FILE" \
-            --valid --errors=text 2>/dev/null; then
+    set +e
+    npx --yes ajv-cli@5 validate -s "$SCHEMA_FILE" -d "$JSON_FILE" \
+        --valid --errors=text 2>/dev/null
+    AJV_EXIT=$?
+    set -e
+    if [[ $AJV_EXIT -eq 0 ]]; then
+        # Validation passed
+        echo "[validate-properties-json] OK (ajv): $JSON_FILE"
         exit 0
+    elif [[ $AJV_EXIT -ne 127 ]]; then
+        # ajv ran but found the JSON invalid; do not fall through to jq
+        echo "[validate-properties-json] FAIL (ajv): $JSON_FILE" >&2
+        exit 1
     fi
+    # AJV_EXIT=127 → ajv binary unavailable; fall through to jq fallback
 fi
 
 # --- Fallback: jq hand-rolled checks ---
@@ -59,4 +73,4 @@ _check ".properties.delimiters.quote"
 _check ".chaosMode.enabled"
 _check ".chaosMode.totalAnomalies"
 
-echo "[validate-properties-json] OK: $JSON_FILE"
+echo "[validate-properties-json] OK (jq): $JSON_FILE"

--- a/tests/goldens/lib/validate-properties-json.sh
+++ b/tests/goldens/lib/validate-properties-json.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# validate-properties-json.sh — validate a _properties.json file against the committed schema.
+#
+# Usage:
+#   bash tests/goldens/lib/validate-properties-json.sh <json-file> [schema-file]
+#
+# <json-file>   : path to the _properties.json to validate
+# [schema-file] : optional path to the JSON Schema; defaults to
+#                 tests/fixtures/properties.schema.json relative to this script
+
+set -euo pipefail
+
+JSON_FILE="${1:?Usage: validate-properties-json.sh <json-file> [schema-file]}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA_FILE="${2:-$SCRIPT_DIR/../../fixtures/properties.schema.json}"
+
+if [[ ! -f "$JSON_FILE" ]]; then
+    echo "[validate-properties-json] ERROR: file not found: $JSON_FILE" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SCHEMA_FILE" ]]; then
+    echo "[validate-properties-json] ERROR: schema not found: $SCHEMA_FILE" >&2
+    exit 1
+fi
+
+# --- Try ajv-cli (preferred) ---
+if command -v npx >/dev/null 2>&1; then
+    # ajv-cli@5 uses ajv v8 and supports draft-07
+    if npx --yes ajv-cli@5 validate -s "$SCHEMA_FILE" -d "$JSON_FILE" \
+            --valid --errors=text 2>/dev/null; then
+        exit 0
+    fi
+fi
+
+# --- Fallback: jq hand-rolled checks ---
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[validate-properties-json] WARNING: neither ajv nor jq available; skipping schema validation" >&2
+    exit 0
+fi
+
+_check() {
+    local field="$1"
+    local value
+    value=$(jq -r "$field // empty" "$JSON_FILE" 2>/dev/null)
+    if [[ -z "$value" ]]; then
+        echo "[validate-properties-json] FAIL: missing required field $field in $JSON_FILE" >&2
+        exit 1
+    fi
+}
+
+_check ".fileName"
+_check ".format"
+_check ".totalRecords"
+_check ".properties.encoding"
+_check ".properties.lineEnding"
+_check ".properties.delimiters.column"
+_check ".properties.delimiters.quote"
+_check ".chaosMode.enabled"
+# totalAnomalies can be 0 — use a different check
+if ! jq -e '.chaosMode | has("totalAnomalies")' "$JSON_FILE" >/dev/null 2>&1; then
+    echo "[validate-properties-json] FAIL: .chaosMode.totalAnomalies missing in $JSON_FILE" >&2
+    exit 1
+fi
+
+echo "[validate-properties-json] OK: $JSON_FILE"

--- a/tests/goldens/lib/validate-properties-json.sh
+++ b/tests/goldens/lib/validate-properties-json.sh
@@ -40,11 +40,10 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
+# Use jq -e with != null so boolean false values pass (false != null is true in jq).
 _check() {
     local field="$1"
-    local value
-    value=$(jq -r "$field // empty" "$JSON_FILE" 2>/dev/null)
-    if [[ -z "$value" ]]; then
+    if ! jq -e "$field != null" "$JSON_FILE" >/dev/null 2>&1; then
         echo "[validate-properties-json] FAIL: missing required field $field in $JSON_FILE" >&2
         exit 1
     fi
@@ -58,10 +57,6 @@ _check ".properties.lineEnding"
 _check ".properties.delimiters.column"
 _check ".properties.delimiters.quote"
 _check ".chaosMode.enabled"
-# totalAnomalies can be 0 — use a different check
-if ! jq -e '.chaosMode | has("totalAnomalies")' "$JSON_FILE" >/dev/null 2>&1; then
-    echo "[validate-properties-json] FAIL: .chaosMode.totalAnomalies missing in $JSON_FILE" >&2
-    exit 1
-fi
+_check ".chaosMode.totalAnomalies"
 
 echo "[validate-properties-json] OK: $JSON_FILE"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -523,4 +523,9 @@ if ! bash ./tests/run-e2e-loadfile.sh; then
 fi
 print_success "Loadfile-only tests passed."
 
+# Test 13: Chaos anomaly-type and scenario coverage
+print_info "Running chaos anomaly coverage tests..."
+bash ./tests/test-chaos-anomaly-coverage.sh
+print_success "Chaos anomaly coverage tests passed."
+
 print_success "All tests passed successfully!"

--- a/tests/test-chaos-anomaly-coverage.sh
+++ b/tests/test-chaos-anomaly-coverage.sh
@@ -9,6 +9,8 @@
 #
 # Must be called from the repository root:
 #   bash ./tests/test-chaos-anomaly-coverage.sh
+#
+# Bash 3.2 compatible (required for macOS /bin/bash).
 
 set -euo pipefail
 
@@ -34,42 +36,20 @@ function validate_properties_json() {
     bash "$GOLDENS_LIB_DIR/validate-properties-json.sh" "$1"
 }
 
+# Lookup a field from the scenario-types TSV. Usage: tsv_lookup <scenario> <field_index>
+# field_index: 2=chaos_types, 3=format (1-based)
+function tsv_lookup() {
+    local scenario="$1"
+    local field="$2"
+    grep "^${scenario}	" "$FIXTURES_DIR/chaos-scenario-types.tsv" \
+        | cut -f"$field" | head -1
+}
+
 PASSED=0
 TOTAL=0
 
 rm -rf "$TEST_OUTPUT_DIR"
 mkdir -p "$TEST_OUTPUT_DIR"
-
-# ---------------------------------------------------------------------------
-# Load fixture lists
-# ---------------------------------------------------------------------------
-# DAT types: all lines that do NOT start with 'opt-' (or '#' or empty)
-mapfile -t DAT_TYPES < <(
-    grep -v '^#' "$FIXTURES_DIR/chaos-anomaly-types.txt" \
-    | grep -v '^[[:space:]]*$' \
-    | grep -v '^opt-'
-)
-
-# OPT types: lines starting with 'opt-'
-mapfile -t OPT_TYPES < <(
-    grep -v '^#' "$FIXTURES_DIR/chaos-anomaly-types.txt" \
-    | grep -v '^[[:space:]]*$' \
-    | grep '^opt-'
-)
-
-# Scenario names (one per line, skip blank)
-mapfile -t SCENARIO_NAMES < <(
-    grep -v '^[[:space:]]*$' "$FIXTURES_DIR/chaos-scenarios.txt"
-)
-
-# Scenario → format + chaos_types from TSV (skip header row)
-declare -A SCENARIO_FORMAT
-declare -A SCENARIO_TYPES
-while IFS=$'\t' read -r name types fmt; do
-    [[ "$name" == "scenario_name" ]] && continue
-    SCENARIO_FORMAT["$name"]="${fmt:-dat}"
-    SCENARIO_TYPES["$name"]="${types:-}"
-done < "$FIXTURES_DIR/chaos-scenario-types.tsv"
 
 # ---------------------------------------------------------------------------
 # B3 prep: validate existing golden _properties.json files up-front
@@ -100,9 +80,14 @@ BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline_opt" -name "*.opt" | head -1)
 [[ -z "$BASELINE_OPT" ]] && print_error "No baseline OPT file generated"
 
 # ---------------------------------------------------------------------------
-# B1 — per-Anomaly-Type: DAT types
+# B1 — per-Anomaly-Type: DAT types (all non-'opt-' lines in fixture)
 # ---------------------------------------------------------------------------
-for TYPE in "${DAT_TYPES[@]}"; do
+while IFS= read -r TYPE; do
+    # Skip comments, blank lines, and OPT types
+    case "$TYPE" in
+        ''|'#'*|opt-*) continue ;;
+    esac
+
     TOTAL=$((TOTAL + 1))
     SAFE="${TYPE//-/_}"
     OUT_DIR="$TEST_OUTPUT_DIR/dat_type_${SAFE}"
@@ -124,12 +109,12 @@ for TYPE in "${DAT_TYPES[@]}"; do
 
     # Set equality: only the requested type appears
     TYPES_PRESENT=$(jq -r '[.chaosMode.injectedAnomalies[]?.errorType] | unique | sort | .[]' \
-        "$PROPS" 2>/dev/null | paste -sd ',' || true)
+        "$PROPS" 2>/dev/null | paste -sd ',' - || true)
     if [[ "$TYPES_PRESENT" != "$TYPE" ]]; then
         print_error "Type mismatch for $TYPE: got '$TYPES_PRESENT'"
     fi
 
-    # Unique line numbers (duplicates would indicate a bug)
+    # Unique line numbers (duplicates indicate a bug)
     DUP_LINES=$(jq -r '
         [.chaosMode.injectedAnomalies[]?.lineNumber]
         | group_by(.)
@@ -137,9 +122,9 @@ for TYPE in "${DAT_TYPES[@]}"; do
         | .[0]? // empty' "$PROPS" 2>/dev/null || true)
     [[ -n "$DUP_LINES" ]] && print_error "Duplicate line numbers for type: $TYPE"
 
-    # Numeric line numbers must be in [1, totalRecords+1]
+    # Numeric line numbers must be in [1, totalRecords+1] (header=1, data=2..N+1)
     TOTAL_RECORDS=$(jq '.totalRecords' "$PROPS")
-    MAX_LINE=$(( TOTAL_RECORDS + 1 ))  # header is line 1, data is 2..501
+    MAX_LINE=$(( TOTAL_RECORDS + 1 ))
     BAD_LINES=$(jq -r --argjson max "$MAX_LINE" '
         [.chaosMode.injectedAnomalies[]?
          | select(.lineNumber | test("^[0-9]+$"))
@@ -148,8 +133,7 @@ for TYPE in "${DAT_TYPES[@]}"; do
         | .[]?' "$PROPS" 2>/dev/null || true)
     [[ -n "$BAD_LINES" ]] && print_error "Line number out of [1,$MAX_LINE] for type: $TYPE: $BAD_LINES"
 
-    # Baseline diff: the chaos file must differ from the no-chaos baseline.
-    # (For 'encoding', differences are at the byte level — still detectable via cmp.)
+    # Baseline diff: chaos file must differ from no-chaos baseline
     CHAOS_DAT=$(find "$OUT_DIR/run1" -name "*.dat" | head -1)
     if cmp -s "$BASELINE_DAT" "$CHAOS_DAT" 2>/dev/null; then
         print_error "Chaos DAT identical to baseline for type: $TYPE — anomaly not injected?"
@@ -167,12 +151,19 @@ for TYPE in "${DAT_TYPES[@]}"; do
 
     PASSED=$((PASSED + 1))
     print_success "B1 DAT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
-done
+done < "$FIXTURES_DIR/chaos-anomaly-types.txt"
 
 # ---------------------------------------------------------------------------
-# B1 — per-Anomaly-Type: OPT types
+# B1 — per-Anomaly-Type: OPT types (lines starting with 'opt-')
 # ---------------------------------------------------------------------------
-for TYPE in "${OPT_TYPES[@]}"; do
+while IFS= read -r TYPE; do
+    # Only process opt- lines; skip comments and blank
+    case "$TYPE" in
+        ''|'#'*) continue ;;
+        opt-*) ;;
+        *) continue ;;
+    esac
+
     TOTAL=$((TOTAL + 1))
     SAFE="${TYPE//-/_}"
     OUT_DIR="$TEST_OUTPUT_DIR/opt_type_${SAFE}"
@@ -191,7 +182,7 @@ for TYPE in "${OPT_TYPES[@]}"; do
     [[ "$ANOMALY_COUNT" -le 0 ]] && print_error "No anomalies for OPT type: $TYPE"
 
     TYPES_PRESENT=$(jq -r '[.chaosMode.injectedAnomalies[]?.errorType] | unique | sort | .[]' \
-        "$PROPS" 2>/dev/null | paste -sd ',' || true)
+        "$PROPS" 2>/dev/null | paste -sd ',' - || true)
     [[ "$TYPES_PRESENT" != "$TYPE" ]] \
         && print_error "Type mismatch for OPT $TYPE: got '$TYPES_PRESENT'"
 
@@ -229,29 +220,34 @@ for TYPE in "${OPT_TYPES[@]}"; do
 
     PASSED=$((PASSED + 1))
     print_success "B1 OPT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
-done
+done < "$FIXTURES_DIR/chaos-anomaly-types.txt"
 
 # ---------------------------------------------------------------------------
 # B2 — per-Scenario coverage
 # ---------------------------------------------------------------------------
-for SCENARIO in "${SCENARIO_NAMES[@]}"; do
+while IFS= read -r SCENARIO; do
     [[ -z "$SCENARIO" ]] && continue
+
     TOTAL=$((TOTAL + 1))
     SAFE="${SCENARIO//-/_}"
     OUT_DIR="$TEST_OUTPUT_DIR/scenario_${SAFE}"
-    FMT="${SCENARIO_FORMAT[$SCENARIO]:-dat}"
-    DECLARED_TYPES="${SCENARIO_TYPES[$SCENARIO]:-}"
+
+    # Look up format and declared chaos types from TSV (skip header line)
+    FMT=$(tsv_lookup "$SCENARIO" 3)
+    DECLARED_TYPES=$(tsv_lookup "$SCENARIO" 2)
+    FMT="${FMT:-dat}"
 
     print_info "B2 Scenario: $SCENARIO (format: $FMT)"
 
-    FORMAT_ARG=()
-    [[ "$FMT" == "opt" ]] && FORMAT_ARG=(--loadfile-format opt)
+    # Build format arg
+    FORMAT_FLAG=""
+    [[ "$FMT" == "opt" ]] && FORMAT_FLAG="--loadfile-format opt"
 
     # Run 1
+    # shellcheck disable=SC2086
     zipper --loadfile-only --count 1000 \
         --output-path "$OUT_DIR/run1" \
-        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 \
-        "${FORMAT_ARG[@]}"
+        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 $FORMAT_FLAG
 
     PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
     [[ -z "$PROPS" ]] && print_error "No _properties.json for scenario: $SCENARIO"
@@ -261,7 +257,7 @@ for SCENARIO in "${SCENARIO_NAMES[@]}"; do
     ANOMALY_COUNT=$(jq '.chaosMode.totalAnomalies' "$PROPS")
     [[ "$ANOMALY_COUNT" -le 0 ]] && print_error "No anomalies for scenario: $SCENARIO"
 
-    # Assert every actual type is within the declared set (skip check for full-chaos)
+    # Assert every actual type is within the declared set (full-chaos has empty declared set)
     if [[ -n "$DECLARED_TYPES" ]]; then
         while IFS= read -r actual_type; do
             [[ -z "$actual_type" ]] && continue
@@ -272,10 +268,11 @@ for SCENARIO in "${SCENARIO_NAMES[@]}"; do
     fi
 
     # Determinism
+    # shellcheck disable=SC2086
     zipper --loadfile-only --count 1000 \
         --output-path "$OUT_DIR/run2" \
-        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 \
-        "${FORMAT_ARG[@]}"
+        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 $FORMAT_FLAG
+
     PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
 
     if [[ "$FMT" == "opt" ]]; then
@@ -292,7 +289,7 @@ for SCENARIO in "${SCENARIO_NAMES[@]}"; do
 
     PASSED=$((PASSED + 1))
     print_success "B2 Scenario '$SCENARIO' — PASSED (anomalies: $ANOMALY_COUNT)"
-done
+done < "$FIXTURES_DIR/chaos-scenarios.txt"
 
 # ---------------------------------------------------------------------------
 # Cleanup & summary

--- a/tests/test-chaos-anomaly-coverage.sh
+++ b/tests/test-chaos-anomaly-coverage.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# test-chaos-anomaly-coverage.sh
+#
+# E2E: Chaos Engine anomaly-type + scenario coverage.
+# Addresses issues:
+#   B1 (#200) — per-Anomaly-Type assertions + _properties.json audit
+#   B2 (#201, absorbed into #200) — per-Scenario coverage
+#   B3 (#202, absorbed into #200) — _properties.json schema validation
+#
+# Must be called from the repository root:
+#   bash ./tests/test-chaos-anomaly-coverage.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+GOLDENS_LIB_DIR="$SCRIPT_DIR/goldens/lib"
+TEST_OUTPUT_DIR="$SCRIPT_DIR/results/chaos-coverage"
+
+# shellcheck source=./_zipper-cli.sh
+source "$SCRIPT_DIR/_zipper-cli.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function print_success() { echo -e "\e[42m[ SUCCESS ]\e[0m $1"; }
+function print_info()    { echo -e "\e[44m[ INFO ]\e[0m $1"; }
+function print_error()   {
+    echo -e "\e[41m[ ERROR ]\e[0m $1" >&2
+    exit 1
+}
+
+function validate_properties_json() {
+    bash "$GOLDENS_LIB_DIR/validate-properties-json.sh" "$1"
+}
+
+PASSED=0
+TOTAL=0
+
+rm -rf "$TEST_OUTPUT_DIR"
+mkdir -p "$TEST_OUTPUT_DIR"
+
+# ---------------------------------------------------------------------------
+# Load fixture lists
+# ---------------------------------------------------------------------------
+# DAT types: all lines that do NOT start with 'opt-' (or '#' or empty)
+mapfile -t DAT_TYPES < <(
+    grep -v '^#' "$FIXTURES_DIR/chaos-anomaly-types.txt" \
+    | grep -v '^[[:space:]]*$' \
+    | grep -v '^opt-'
+)
+
+# OPT types: lines starting with 'opt-'
+mapfile -t OPT_TYPES < <(
+    grep -v '^#' "$FIXTURES_DIR/chaos-anomaly-types.txt" \
+    | grep -v '^[[:space:]]*$' \
+    | grep '^opt-'
+)
+
+# Scenario names (one per line, skip blank)
+mapfile -t SCENARIO_NAMES < <(
+    grep -v '^[[:space:]]*$' "$FIXTURES_DIR/chaos-scenarios.txt"
+)
+
+# Scenario → format + chaos_types from TSV (skip header row)
+declare -A SCENARIO_FORMAT
+declare -A SCENARIO_TYPES
+while IFS=$'\t' read -r name types fmt; do
+    [[ "$name" == "scenario_name" ]] && continue
+    SCENARIO_FORMAT["$name"]="${fmt:-dat}"
+    SCENARIO_TYPES["$name"]="${types:-}"
+done < "$FIXTURES_DIR/chaos-scenario-types.tsv"
+
+# ---------------------------------------------------------------------------
+# B3 prep: validate existing golden _properties.json files up-front
+# ---------------------------------------------------------------------------
+TOTAL=$((TOTAL + 1))
+print_info "B3: Validating committed golden _properties.json fixtures..."
+GOLDEN_COUNT=0
+while IFS= read -r -d '' prop_file; do
+    validate_properties_json "$prop_file"
+    GOLDEN_COUNT=$((GOLDEN_COUNT + 1))
+done < <(find "$SCRIPT_DIR/goldens/fixtures" -name "*_properties.json" -print0)
+print_info "Validated $GOLDEN_COUNT golden fixture(s)"
+PASSED=$((PASSED + 1))
+print_success "Golden fixture schema validation — PASSED"
+
+# ---------------------------------------------------------------------------
+# Generate no-chaos baselines (for diff assertions)
+# ---------------------------------------------------------------------------
+print_info "Generating no-chaos DAT baseline (seed 42, count 500)..."
+zipper --loadfile-only --count 500 --output-path "$TEST_OUTPUT_DIR/baseline_dat" --seed 42
+BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline_dat" -name "*.dat" | head -1)
+[[ -z "$BASELINE_DAT" ]] && print_error "No baseline DAT file generated"
+
+print_info "Generating no-chaos OPT baseline (seed 42, count 500)..."
+zipper --loadfile-only --loadfile-format opt --count 500 \
+    --output-path "$TEST_OUTPUT_DIR/baseline_opt" --seed 42
+BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline_opt" -name "*.opt" | head -1)
+[[ -z "$BASELINE_OPT" ]] && print_error "No baseline OPT file generated"
+
+# ---------------------------------------------------------------------------
+# B1 — per-Anomaly-Type: DAT types
+# ---------------------------------------------------------------------------
+for TYPE in "${DAT_TYPES[@]}"; do
+    TOTAL=$((TOTAL + 1))
+    SAFE="${TYPE//-/_}"
+    OUT_DIR="$TEST_OUTPUT_DIR/dat_type_${SAFE}"
+    print_info "B1 DAT: $TYPE"
+
+    # Run 1
+    zipper --loadfile-only --count 500 --output-path "$OUT_DIR/run1" \
+        --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
+
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    [[ -z "$PROPS" ]] && print_error "No _properties.json for type: $TYPE"
+
+    # B3: schema
+    validate_properties_json "$PROPS"
+
+    # At least one anomaly
+    ANOMALY_COUNT=$(jq '.chaosMode.totalAnomalies' "$PROPS")
+    [[ "$ANOMALY_COUNT" -le 0 ]] && print_error "No anomalies for type: $TYPE"
+
+    # Set equality: only the requested type appears
+    TYPES_PRESENT=$(jq -r '[.chaosMode.injectedAnomalies[]?.errorType] | unique | sort | .[]' \
+        "$PROPS" 2>/dev/null | paste -sd ',' || true)
+    if [[ "$TYPES_PRESENT" != "$TYPE" ]]; then
+        print_error "Type mismatch for $TYPE: got '$TYPES_PRESENT'"
+    fi
+
+    # Unique line numbers (duplicates would indicate a bug)
+    DUP_LINES=$(jq -r '
+        [.chaosMode.injectedAnomalies[]?.lineNumber]
+        | group_by(.)
+        | map(select(length > 1))
+        | .[0]? // empty' "$PROPS" 2>/dev/null || true)
+    [[ -n "$DUP_LINES" ]] && print_error "Duplicate line numbers for type: $TYPE"
+
+    # Numeric line numbers must be in [1, totalRecords+1]
+    TOTAL_RECORDS=$(jq '.totalRecords' "$PROPS")
+    MAX_LINE=$(( TOTAL_RECORDS + 1 ))  # header is line 1, data is 2..501
+    BAD_LINES=$(jq -r --argjson max "$MAX_LINE" '
+        [.chaosMode.injectedAnomalies[]?
+         | select(.lineNumber | test("^[0-9]+$"))
+         | .lineNumber | tonumber
+         | select(. < 1 or . > $max)]
+        | .[]?' "$PROPS" 2>/dev/null || true)
+    [[ -n "$BAD_LINES" ]] && print_error "Line number out of [1,$MAX_LINE] for type: $TYPE: $BAD_LINES"
+
+    # Baseline diff: the chaos file must differ from the no-chaos baseline.
+    # (For 'encoding', differences are at the byte level — still detectable via cmp.)
+    CHAOS_DAT=$(find "$OUT_DIR/run1" -name "*.dat" | head -1)
+    if cmp -s "$BASELINE_DAT" "$CHAOS_DAT" 2>/dev/null; then
+        print_error "Chaos DAT identical to baseline for type: $TYPE — anomaly not injected?"
+    fi
+
+    # Determinism: run 2 must produce byte-identical output
+    zipper --loadfile-only --count 500 --output-path "$OUT_DIR/run2" \
+        --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
+    CHAOS_DAT2=$(find "$OUT_DIR/run2" -name "*.dat" | head -1)
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+    cmp -s "$CHAOS_DAT" "$CHAOS_DAT2" \
+        || print_error "Determinism failed (DAT differs) for type: $TYPE"
+    cmp -s "$PROPS" "$PROPS2" \
+        || print_error "Determinism failed (_properties.json differs) for type: $TYPE"
+
+    PASSED=$((PASSED + 1))
+    print_success "B1 DAT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
+done
+
+# ---------------------------------------------------------------------------
+# B1 — per-Anomaly-Type: OPT types
+# ---------------------------------------------------------------------------
+for TYPE in "${OPT_TYPES[@]}"; do
+    TOTAL=$((TOTAL + 1))
+    SAFE="${TYPE//-/_}"
+    OUT_DIR="$TEST_OUTPUT_DIR/opt_type_${SAFE}"
+    print_info "B1 OPT: $TYPE"
+
+    zipper --loadfile-only --loadfile-format opt --count 500 \
+        --output-path "$OUT_DIR/run1" \
+        --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
+
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    [[ -z "$PROPS" ]] && print_error "No _properties.json for OPT type: $TYPE"
+
+    validate_properties_json "$PROPS"
+
+    ANOMALY_COUNT=$(jq '.chaosMode.totalAnomalies' "$PROPS")
+    [[ "$ANOMALY_COUNT" -le 0 ]] && print_error "No anomalies for OPT type: $TYPE"
+
+    TYPES_PRESENT=$(jq -r '[.chaosMode.injectedAnomalies[]?.errorType] | unique | sort | .[]' \
+        "$PROPS" 2>/dev/null | paste -sd ',' || true)
+    [[ "$TYPES_PRESENT" != "$TYPE" ]] \
+        && print_error "Type mismatch for OPT $TYPE: got '$TYPES_PRESENT'"
+
+    DUP_LINES=$(jq -r '
+        [.chaosMode.injectedAnomalies[]?.lineNumber]
+        | group_by(.)
+        | map(select(length > 1))
+        | .[0]? // empty' "$PROPS" 2>/dev/null || true)
+    [[ -n "$DUP_LINES" ]] && print_error "Duplicate line numbers for OPT type: $TYPE"
+
+    TOTAL_RECORDS=$(jq '.totalRecords' "$PROPS")
+    MAX_LINE=$(( TOTAL_RECORDS + 1 ))
+    BAD_LINES=$(jq -r --argjson max "$MAX_LINE" '
+        [.chaosMode.injectedAnomalies[]?
+         | select(.lineNumber | test("^[0-9]+$"))
+         | .lineNumber | tonumber
+         | select(. < 1 or . > $max)]
+        | .[]?' "$PROPS" 2>/dev/null || true)
+    [[ -n "$BAD_LINES" ]] && print_error "Line number out of [1,$MAX_LINE] for OPT type: $TYPE"
+
+    CHAOS_OPT=$(find "$OUT_DIR/run1" -name "*.opt" | head -1)
+    if cmp -s "$BASELINE_OPT" "$CHAOS_OPT" 2>/dev/null; then
+        print_error "Chaos OPT identical to baseline for type: $TYPE — anomaly not injected?"
+    fi
+
+    zipper --loadfile-only --loadfile-format opt --count 500 \
+        --output-path "$OUT_DIR/run2" \
+        --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
+    CHAOS_OPT2=$(find "$OUT_DIR/run2" -name "*.opt" | head -1)
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+    cmp -s "$CHAOS_OPT" "$CHAOS_OPT2" \
+        || print_error "Determinism failed (OPT differs) for type: $TYPE"
+    cmp -s "$PROPS" "$PROPS2" \
+        || print_error "Determinism failed (_properties.json differs) for OPT type: $TYPE"
+
+    PASSED=$((PASSED + 1))
+    print_success "B1 OPT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
+done
+
+# ---------------------------------------------------------------------------
+# B2 — per-Scenario coverage
+# ---------------------------------------------------------------------------
+for SCENARIO in "${SCENARIO_NAMES[@]}"; do
+    [[ -z "$SCENARIO" ]] && continue
+    TOTAL=$((TOTAL + 1))
+    SAFE="${SCENARIO//-/_}"
+    OUT_DIR="$TEST_OUTPUT_DIR/scenario_${SAFE}"
+    FMT="${SCENARIO_FORMAT[$SCENARIO]:-dat}"
+    DECLARED_TYPES="${SCENARIO_TYPES[$SCENARIO]:-}"
+
+    print_info "B2 Scenario: $SCENARIO (format: $FMT)"
+
+    FORMAT_ARG=()
+    [[ "$FMT" == "opt" ]] && FORMAT_ARG=(--loadfile-format opt)
+
+    # Run 1
+    zipper --loadfile-only --count 1000 \
+        --output-path "$OUT_DIR/run1" \
+        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 \
+        "${FORMAT_ARG[@]}"
+
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    [[ -z "$PROPS" ]] && print_error "No _properties.json for scenario: $SCENARIO"
+
+    validate_properties_json "$PROPS"
+
+    ANOMALY_COUNT=$(jq '.chaosMode.totalAnomalies' "$PROPS")
+    [[ "$ANOMALY_COUNT" -le 0 ]] && print_error "No anomalies for scenario: $SCENARIO"
+
+    # Assert every actual type is within the declared set (skip check for full-chaos)
+    if [[ -n "$DECLARED_TYPES" ]]; then
+        while IFS= read -r actual_type; do
+            [[ -z "$actual_type" ]] && continue
+            if ! echo ",$DECLARED_TYPES," | grep -q ",$actual_type,"; then
+                print_error "Scenario $SCENARIO: unexpected type '$actual_type' (declared: $DECLARED_TYPES)"
+            fi
+        done < <(jq -r '[.chaosMode.injectedAnomalies[]?.errorType] | unique | .[]' "$PROPS" 2>/dev/null || true)
+    fi
+
+    # Determinism
+    zipper --loadfile-only --count 1000 \
+        --output-path "$OUT_DIR/run2" \
+        --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 \
+        "${FORMAT_ARG[@]}"
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+
+    if [[ "$FMT" == "opt" ]]; then
+        FILE1=$(find "$OUT_DIR/run1" -name "*.opt" | head -1)
+        FILE2=$(find "$OUT_DIR/run2" -name "*.opt" | head -1)
+    else
+        FILE1=$(find "$OUT_DIR/run1" -name "*.dat" | head -1)
+        FILE2=$(find "$OUT_DIR/run2" -name "*.dat" | head -1)
+    fi
+    cmp -s "$FILE1" "$FILE2" \
+        || print_error "Determinism failed (load file differs) for scenario: $SCENARIO"
+    cmp -s "$PROPS" "$PROPS2" \
+        || print_error "Determinism failed (_properties.json differs) for scenario: $SCENARIO"
+
+    PASSED=$((PASSED + 1))
+    print_success "B2 Scenario '$SCENARIO' — PASSED (anomalies: $ANOMALY_COUNT)"
+done
+
+# ---------------------------------------------------------------------------
+# Cleanup & summary
+# ---------------------------------------------------------------------------
+rm -rf "$TEST_OUTPUT_DIR"
+echo ""
+print_success "Chaos coverage: $PASSED/$TOTAL tests passed."

--- a/tests/test-chaos-anomaly-coverage.sh
+++ b/tests/test-chaos-anomaly-coverage.sh
@@ -146,8 +146,11 @@ while IFS= read -r TYPE; do
     PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
     cmp -s "$CHAOS_DAT" "$CHAOS_DAT2" \
         || print_error "Determinism failed (DAT differs) for type: $TYPE"
-    cmp -s "$PROPS" "$PROPS2" \
-        || print_error "Determinism failed (_properties.json differs) for type: $TYPE"
+    # Compare _properties.json content excluding fileName (which contains a timestamp)
+    PROPS_CANONICAL=$(jq 'del(.fileName)' "$PROPS")
+    PROPS2_CANONICAL=$(jq 'del(.fileName)' "$PROPS2")
+    [[ "$PROPS_CANONICAL" != "$PROPS2_CANONICAL" ]] \
+        && print_error "Determinism failed (_properties.json differs) for type: $TYPE"
 
     PASSED=$((PASSED + 1))
     print_success "B1 DAT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
@@ -215,8 +218,10 @@ while IFS= read -r TYPE; do
     PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
     cmp -s "$CHAOS_OPT" "$CHAOS_OPT2" \
         || print_error "Determinism failed (OPT differs) for type: $TYPE"
-    cmp -s "$PROPS" "$PROPS2" \
-        || print_error "Determinism failed (_properties.json differs) for OPT type: $TYPE"
+    PROPS_CANONICAL=$(jq 'del(.fileName)' "$PROPS")
+    PROPS2_CANONICAL=$(jq 'del(.fileName)' "$PROPS2")
+    [[ "$PROPS_CANONICAL" != "$PROPS2_CANONICAL" ]] \
+        && print_error "Determinism failed (_properties.json differs) for OPT type: $TYPE"
 
     PASSED=$((PASSED + 1))
     print_success "B1 OPT type '$TYPE' — PASSED (anomalies: $ANOMALY_COUNT)"
@@ -284,8 +289,10 @@ while IFS= read -r SCENARIO; do
     fi
     cmp -s "$FILE1" "$FILE2" \
         || print_error "Determinism failed (load file differs) for scenario: $SCENARIO"
-    cmp -s "$PROPS" "$PROPS2" \
-        || print_error "Determinism failed (_properties.json differs) for scenario: $SCENARIO"
+    PROPS_CANONICAL=$(jq 'del(.fileName)' "$PROPS")
+    PROPS2_CANONICAL=$(jq 'del(.fileName)' "$PROPS2")
+    [[ "$PROPS_CANONICAL" != "$PROPS2_CANONICAL" ]] \
+        && print_error "Determinism failed (_properties.json differs) for scenario: $SCENARIO"
 
     PASSED=$((PASSED + 1))
     print_success "B2 Scenario '$SCENARIO' — PASSED (anomalies: $ANOMALY_COUNT)"


### PR DESCRIPTION
Closes #200

## Summary

Adds comprehensive E2E coverage for the Chaos Engine, addressing the full scope of issue #200 (which absorbed former issues #201 and #202).

## Changes

- `tests/test-chaos-anomaly-coverage.sh` - new E2E test script: B1 per-Anomaly-Type assertions, B2 per-Scenario coverage, B3 _properties.json schema validation
- `tests/fixtures/chaos-anomaly-types.txt` - committed enumeration of all 10 DAT+OPT chaos types
- `tests/fixtures/chaos-scenarios.txt` - committed list of all 6 built-in scenarios
- `tests/fixtures/chaos-scenario-types.tsv` - scenario-to-type+format mapping for B2 assertions
- `tests/fixtures/properties.schema.json` - JSON Schema draft-07 for _properties.json
- `tests/goldens/lib/validate-properties-json.sh` - schema validator (ajv-cli preferred, jq fallback)
- `src/Zipper.Tests/ChaosEngineTests.cs` - two new [Fact] unit tests: AnomalyLineNumbers_AllMatchShouldInterceptTargets and AnomalyLineNumbers_NonInterceptedLines_HaveNoAnomalies
- `tests/run-tests.sh` - wires in test-chaos-anomaly-coverage.sh as Test 13

## Verification

- `dotnet test` must pass (includes 2 new [Fact] tests in ChaosEngineTests)
- `bash ./tests/run-tests.sh` (E2E suite) must pass, including Test 13
- All 10 per-type and 6 per-scenario tests must reach PASSED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for chaos engine anomaly injection, ensuring accurate line number tracking and coverage across all anomaly types and scenarios.
  * Introduced test fixtures and schema validation to verify audit output structure and anomaly data integrity.
  * Extended test suite with dedicated chaos anomaly coverage verification step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->