### PR TITLE
Add computed properties on OutputConfig, MetadataConfig, TiffConfig; delegate LoadFileWriterBase helpers

### DIFF
--- a/src/Config/MetadataConfig.cs
+++ b/src/Config/MetadataConfig.cs
@@ -18,7 +18,7 @@ public record MetadataConfig
 
     public bool WithFamilies { get; init; }
 
-    public bool ShouldIncludeEmlColumns(OutputConfig output) => output.IsEml;
+    internal bool ShouldIncludeEmlColumns(OutputConfig output) => output.IsEml;
 
-    public bool ShouldIncludeMetadataColumns(OutputConfig output) => this.WithMetadata || output.IsEml;
+    internal bool ShouldIncludeMetadataColumns(OutputConfig output) => this.WithMetadata || output.IsEml;
 }

--- a/src/Config/MetadataConfig.cs
+++ b/src/Config/MetadataConfig.cs
@@ -17,4 +17,8 @@ public record MetadataConfig
     public int? CustodianCountOverride { get; init; }
 
     public bool WithFamilies { get; init; }
+
+    public bool ShouldIncludeEmlColumns(OutputConfig output) => output.IsEml;
+
+    public bool ShouldIncludeMetadataColumns(OutputConfig output) => this.WithMetadata || output.IsEml;
 }

--- a/src/Config/OutputConfig.cs
+++ b/src/Config/OutputConfig.cs
@@ -17,4 +17,10 @@ public record OutputConfig
     public long? TargetZipSize { get; init; }
 
     public bool IncludeLoadFile { get; init; }
+
+    public string FileTypeLower => this.FileType.ToLowerInvariant();
+
+    public bool IsEml => this.FileTypeLower == "eml";
+
+    public bool IsTiff => this.FileTypeLower == "tiff";
 }

--- a/src/Config/TiffConfig.cs
+++ b/src/Config/TiffConfig.cs
@@ -4,5 +4,5 @@ public record TiffConfig
 {
     public (int Min, int Max)? PageRange { get; init; }
 
-    public bool ShouldIncludePageCount(OutputConfig output) => output.IsTiff && this.PageRange.HasValue;
+    internal bool ShouldIncludePageCount(OutputConfig output) => output.IsTiff && this.PageRange.HasValue;
 }

--- a/src/Config/TiffConfig.cs
+++ b/src/Config/TiffConfig.cs
@@ -3,4 +3,6 @@ namespace Zipper.Config;
 public record TiffConfig
 {
     public (int Min, int Max)? PageRange { get; init; }
+
+    public bool ShouldIncludePageCount(OutputConfig output) => output.IsTiff && this.PageRange.HasValue;
 }

--- a/src/LoadFiles/LoadFileWriterBase.cs
+++ b/src/LoadFiles/LoadFileWriterBase.cs
@@ -115,10 +115,9 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
             return string.Empty;
         }
 
-        if (field.Contains(',') || field.Contains('"') || field.Contains('
-') || field.Contains(''))
+        if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
         {
-            return $""{ field.Replace(""", """") }"";
+            return $"\"{field.Replace("\"", "\"\"")}\"";
         }
 
         return field;
@@ -151,11 +150,9 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// </summary>
     internal static string GetEolString(string eol) => eol?.ToUpperInvariant() switch
     {
-        "LF" => "
-",
-        "CR" => "",
-        _ => "
-",
+        "LF" => "\n",
+        "CR" => "\r",
+        _ => "\r\n",
     };
 
     /// <summary>

--- a/src/LoadFiles/LoadFileWriterBase.cs
+++ b/src/LoadFiles/LoadFileWriterBase.cs
@@ -22,28 +22,28 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// </summary>
     /// <returns></returns>
     protected static string GetFileTypeLower(FileGenerationRequest request) =>
-        request.FileType.ToLowerInvariant();
+        request.Output.FileTypeLower;
 
     /// <summary>
     /// Determines if metadata columns should be included.
     /// </summary>
     /// <returns></returns>
     protected static bool ShouldIncludeMetadata(FileGenerationRequest request) =>
-        request.WithMetadata || GetFileTypeLower(request) == "eml";
+        request.Metadata.ShouldIncludeMetadataColumns(request.Output);
 
     /// <summary>
     /// Determines if EML-specific columns should be included.
     /// </summary>
     /// <returns></returns>
     protected static bool ShouldIncludeEmlColumns(FileGenerationRequest request) =>
-        GetFileTypeLower(request) == "eml";
+        request.Metadata.ShouldIncludeEmlColumns(request.Output);
 
     /// <summary>
     /// Determines if page count column should be included.
     /// </summary>
     /// <returns></returns>
     protected static bool ShouldIncludePageCount(FileGenerationRequest request) =>
-        GetFileTypeLower(request) == "tiff" && request.TiffPageRange.HasValue;
+        request.Tiff.ShouldIncludePageCount(request.Output);
 
     /// <summary>
     /// Generates metadata column values for a file.
@@ -115,9 +115,10 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
             return string.Empty;
         }
 
-        if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
+        if (field.Contains(',') || field.Contains('"') || field.Contains('
+') || field.Contains(''))
         {
-            return $"\"{field.Replace("\"", "\"\"")}\"";
+            return $""{ field.Replace(""", """") }"";
         }
 
         return field;
@@ -150,9 +151,11 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// </summary>
     internal static string GetEolString(string eol) => eol?.ToUpperInvariant() switch
     {
-        "LF" => "\n",
-        "CR" => "\r",
-        _ => "\r\n",
+        "LF" => "
+",
+        "CR" => "",
+        _ => "
+",
     };
 
     /// <summary>

--- a/src/Zipper.Tests/MetadataConfigTests.cs
+++ b/src/Zipper.Tests/MetadataConfigTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using Zipper.Config;
+
+namespace Zipper.Tests
+{
+    public class MetadataConfigTests
+    {
+        [Theory]
+        [InlineData("eml", true)]
+        [InlineData("EML", true)]
+        [InlineData("pdf", false)]
+        [InlineData("tiff", false)]
+        [InlineData("docx", false)]
+        public void ShouldIncludeEmlColumns_TrueOnlyForEmlFileType(string fileType, bool expected)
+        {
+            // Arrange
+            var metadata = new MetadataConfig();
+            var output = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, metadata.ShouldIncludeEmlColumns(output));
+        }
+
+        [Theory]
+        [InlineData(true, "pdf", true)]
+        [InlineData(false, "pdf", false)]
+        [InlineData(false, "eml", true)]
+        [InlineData(true, "eml", true)]
+        [InlineData(false, "tiff", false)]
+        [InlineData(true, "tiff", true)]
+        public void ShouldIncludeMetadataColumns_ReturnsExpected(bool withMetadata, string fileType, bool expected)
+        {
+            // Arrange
+            var metadata = new MetadataConfig { WithMetadata = withMetadata };
+            var output = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, metadata.ShouldIncludeMetadataColumns(output));
+        }
+    }
+}

--- a/src/Zipper.Tests/OutputConfigTests.cs
+++ b/src/Zipper.Tests/OutputConfigTests.cs
@@ -1,0 +1,65 @@
+using Xunit;
+using Zipper.Config;
+
+namespace Zipper.Tests
+{
+    public class OutputConfigTests
+    {
+        [Theory]
+        [InlineData("pdf", "pdf")]
+        [InlineData("PDF", "pdf")]
+        [InlineData("Pdf", "pdf")]
+        [InlineData("eml", "eml")]
+        [InlineData("EML", "eml")]
+        [InlineData("Eml", "eml")]
+        [InlineData("tiff", "tiff")]
+        [InlineData("TIFF", "tiff")]
+        [InlineData("docx", "docx")]
+        [InlineData("xlsx", "xlsx")]
+        [InlineData("jpg", "jpg")]
+        [InlineData("jpeg", "jpeg")]
+        [InlineData("png", "png")]
+        [InlineData("bmp", "bmp")]
+        [InlineData("txt", "txt")]
+        public void FileTypeLower_ReturnsLowercaseFileType(string fileType, string expected)
+        {
+            // Arrange
+            var config = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, config.FileTypeLower);
+        }
+
+        [Theory]
+        [InlineData("eml", true)]
+        [InlineData("EML", true)]
+        [InlineData("Eml", true)]
+        [InlineData("pdf", false)]
+        [InlineData("tiff", false)]
+        [InlineData("docx", false)]
+        public void IsEml_ReturnsTrueOnlyForEmlFileType(string fileType, bool expected)
+        {
+            // Arrange
+            var config = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, config.IsEml);
+        }
+
+        [Theory]
+        [InlineData("tiff", true)]
+        [InlineData("TIFF", true)]
+        [InlineData("Tiff", true)]
+        [InlineData("pdf", false)]
+        [InlineData("eml", false)]
+        [InlineData("docx", false)]
+        public void IsTiff_ReturnsTrueOnlyForTiffFileType(string fileType, bool expected)
+        {
+            // Arrange
+            var config = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, config.IsTiff);
+        }
+    }
+}

--- a/src/Zipper.Tests/TiffConfigTests.cs
+++ b/src/Zipper.Tests/TiffConfigTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using Zipper.Config;
+
+namespace Zipper.Tests
+{
+    public class TiffConfigTests
+    {
+        [Theory]
+        [InlineData("tiff", true, true)]
+        [InlineData("tiff", false, false)]
+        [InlineData("pdf", true, false)]
+        [InlineData("pdf", false, false)]
+        [InlineData("eml", true, false)]
+        public void ShouldIncludePageCount_ReturnsExpected(string fileType, bool hasRange, bool expected)
+        {
+            // Arrange
+            var tiff = hasRange ? new TiffConfig { PageRange = (1, 10) } : new TiffConfig();
+            var output = new OutputConfig { FileType = fileType };
+
+            // Act & Assert
+            Assert.Equal(expected, tiff.ShouldIncludePageCount(output));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Additive phase of the FGR refactor (F1 of 4): introduces computed properties on sub-configs and wires `LoadFileWriterBase` helpers to delegate to them. No deletions, no call-site changes, byte-identical output.

Closes #210

## Changes

- **`OutputConfig`**: added `FileTypeLower`, `IsEml`, `IsTiff` computed properties.
- **`MetadataConfig`**: added `ShouldIncludeEmlColumns(OutputConfig)` and `ShouldIncludeMetadataColumns(OutputConfig)` methods.
- **`TiffConfig`**: added `ShouldIncludePageCount(OutputConfig)` method.
- **`LoadFileWriterBase`**: rewired `GetFileTypeLower`, `ShouldIncludeMetadata`, `ShouldIncludeEmlColumns`, `ShouldIncludePageCount` to delegate to the new sub-config methods.
- **`OutputConfigTests.cs`** (new): 27 theory cases covering `FileTypeLower` across all 10 known types, `IsEml` and `IsTiff` matrices.
- **`MetadataConfigTests.cs`** (new): `ShouldIncludeEmlColumns` and `ShouldIncludeMetadataColumns` matrices.
- **`TiffConfigTests.cs`** (new): `ShouldIncludePageCount` matrix over file-type × range combinations.

## Verification

- `dotnet build` must succeed (Warnings as Errors enabled).
- `dotnet format --verify-no-changes` must be clean.
- All unit tests must pass (`dotnet test`).
- Golden CI job must produce zero byte diffs (all 15 scenarios from A2 #198).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EML file metadata handling and page count detection for TIFF files.

* **Tests**
  * Added comprehensive test coverage for file type detection and metadata inclusion logic across EML, TIFF, and other formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->