### PR TITLE
FGR refactor (3/4): rewrite all 106 flat pass-through call sites to sub-config access

### DIFF
--- a/src/EmlFileGenerator.cs
+++ b/src/EmlFileGenerator.cs
@@ -11,14 +11,14 @@ internal sealed class EmlFileGenerator : IFileGenerator
 
     public bool RequiresSequentialProcessing(FileGenerationRequest request)
     {
-        return request.WithText || request.AttachmentRate > 0;
+        return request.Output.WithText || request.LoadFile.AttachmentRate > 0;
     }
 
     public GeneratedFileContent Generate(FileWorkItem workItem, FileGenerationRequest request)
     {
         var emlResult = EmlGenerationService.GenerateEmlContent(
             (int)workItem.Index,
-            request.AttachmentRate);
+            request.LoadFile.AttachmentRate);
 
         return new GeneratedFileContent
         {

--- a/src/LoadFiles/ConcordanceWriter.cs
+++ b/src/LoadFiles/ConcordanceWriter.cs
@@ -18,17 +18,17 @@ internal class ConcordanceWriter : LoadFileWriterBase
         ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
-        await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+        await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding), leaveOpen: true);
 
-        // Concordance DAT format uses request.ColumnDelimiter with DAT escaping (þ quote char doubled)
+        // Concordance DAT format uses request.Delimiters.ColumnDelimiter with DAT escaping (þ quote char doubled)
         // Default column delimiter is ASCII 20 (DC4), quote delimiter is ASCII 254 (þ)
-        char fieldDelim = !string.IsNullOrEmpty(request.ColumnDelimiter) ? request.ColumnDelimiter[0] : ',';
+        char fieldDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : ',';
         char quoteDelim = '\u00fe'; // ASCII 254 — Concordance standard quote character
 
 #pragma warning disable S2245
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+        var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
         await WriteHeaderAsync(writer, request, fieldDelim, quoteDelim);
         await WriteRowsAsync(writer, request, processedFiles, fieldDelim, quoteDelim, random, now);
@@ -64,7 +64,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
             header.Append($"{quoteDelim}ATTACHMENT{quoteDelim}{fieldDelim}");
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             header.Append($"{quoteDelim}BATES{quoteDelim}{fieldDelim}");
         }
@@ -74,7 +74,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
             header.Append($"{quoteDelim}PAGECOUNT{quoteDelim}{fieldDelim}");
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             header.Append($"{quoteDelim}TEXT_PATH{quoteDelim}{fieldDelim}");
         }
@@ -126,7 +126,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
                 line.Append($"{quoteDelim}{EscapeDatField(eml.Attachment, quoteDelim)}{quoteDelim}{fieldDelim}");
             }
 
-            if (request.BatesConfig != null)
+            if (request.Bates != null)
             {
                 line.Append($"{quoteDelim}{EscapeDatField(GenerateBatesNumber(request, workItem), quoteDelim)}{quoteDelim}{fieldDelim}");
             }
@@ -136,7 +136,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
                 line.Append($"{quoteDelim}{EscapeDatField(fileData.PageCount.ToString(), quoteDelim)}{quoteDelim}{fieldDelim}");
             }
 
-            if (request.WithText)
+            if (request.Output.WithText)
             {
                 line.Append($"{quoteDelim}{EscapeDatField(GenerateTextPath(request, workItem), quoteDelim)}{quoteDelim}{fieldDelim}");
             }

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -21,9 +21,9 @@ internal class CsvWriter : LoadFileWriterBase
         await using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);
 
 #pragma warning disable S2245
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+        var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
         await WriteHeaderAsync(writer, request);
         await WriteRowsAsync(writer, request, processedFiles, random, now);
@@ -46,7 +46,7 @@ internal class CsvWriter : LoadFileWriterBase
             headers.AddRange(new[] { "To", "From", "Subject", "Sent Date", "Attachment" });
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             headers.Add("Bates Number");
         }
@@ -56,7 +56,7 @@ internal class CsvWriter : LoadFileWriterBase
             headers.Add("Page Count");
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             headers.Add("Extracted Text");
         }
@@ -108,7 +108,7 @@ internal class CsvWriter : LoadFileWriterBase
                 });
             }
 
-            if (request.BatesConfig != null)
+            if (request.Bates != null)
             {
                 values.Add(EscapeCsvField(GenerateBatesNumber(request, workItem)));
             }
@@ -118,7 +118,7 @@ internal class CsvWriter : LoadFileWriterBase
                 values.Add(fileData.PageCount.ToString());
             }
 
-            if (request.WithText)
+            if (request.Output.WithText)
             {
                 values.Add(EscapeCsvField(GenerateTextPath(request, workItem)));
             }

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -19,7 +19,7 @@ internal class DatWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         // Use leaveOpen: true to avoid disposing the caller's stream
         await using var writer = new StreamWriter(stream, encoding, leaveOpen: true);
@@ -39,15 +39,15 @@ internal class DatWriter : LoadFileWriterBase
         List<FileData> processedFiles)
     {
         // Defensive guards to prevent IndexOutOfRangeException when delimiters are unset
-        char colDelim = !string.IsNullOrEmpty(request.ColumnDelimiter) ? request.ColumnDelimiter[0] : '\u0014';
-        char quote = !string.IsNullOrEmpty(request.QuoteDelimiter) ? request.QuoteDelimiter[0] : '\u00fe';
+        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
+        char quote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
 
         await writer.WriteLineAsync(BuildHeader(request, colDelim, quote));
 
 #pragma warning disable S2245
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+        var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
         var builder = new MetadataRowBuilder(request, random, now);
 
         var buffer = new StringBuilder();
@@ -88,7 +88,7 @@ internal class DatWriter : LoadFileWriterBase
             sb.Append($"{colDelim}{quote}To{quote}{colDelim}{quote}From{quote}{colDelim}{quote}Subject{quote}{colDelim}{quote}Sent Date{quote}{colDelim}{quote}Attachment{quote}");
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             sb.Append($"{colDelim}{quote}Bates Number{quote}");
         }
@@ -98,7 +98,7 @@ internal class DatWriter : LoadFileWriterBase
             sb.Append($"{colDelim}{quote}Page Count{quote}");
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             sb.Append($"{colDelim}{quote}Extracted Text{quote}");
         }
@@ -114,31 +114,31 @@ internal class DatWriter : LoadFileWriterBase
         MetadataRowBuilder builder)
     {
         var workItem = fileData.WorkItem;
-        var docId = MetadataRowBuilder.SanitizeField(builder.GetControlNumber(workItem), request.NewlineDelimiter);
+        var docId = MetadataRowBuilder.SanitizeField(builder.GetControlNumber(workItem), request.Delimiters.NewlineDelimiter);
 
         var sb = new StringBuilder();
-        sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{MetadataRowBuilder.SanitizeField(workItem.FilePathInZip, request.NewlineDelimiter)}{quote}");
+        sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{MetadataRowBuilder.SanitizeField(workItem.FilePathInZip, request.Delimiters.NewlineDelimiter)}{quote}");
 
         if (ShouldIncludeMetadata(request))
         {
-            var custodian = MetadataRowBuilder.SanitizeField(builder.GetCustodian(workItem.FolderNumber), request.NewlineDelimiter);
+            var custodian = MetadataRowBuilder.SanitizeField(builder.GetCustodian(workItem.FolderNumber), request.Delimiters.NewlineDelimiter);
             var dateSent = builder.GetDateSent();
-            var author = MetadataRowBuilder.SanitizeField(builder.GetAuthor(), request.NewlineDelimiter);
+            var author = MetadataRowBuilder.SanitizeField(builder.GetAuthor(), request.Delimiters.NewlineDelimiter);
             var fileSize = builder.GetFileSize(fileData);
             sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
         }
 
         if (ShouldIncludeEmlColumns(request))
         {
-            var to = MetadataRowBuilder.SanitizeField(builder.GetEmailTo(workItem, fileData), request.NewlineDelimiter);
-            var from = MetadataRowBuilder.SanitizeField(builder.GetEmailFrom(workItem, fileData), request.NewlineDelimiter);
-            var subject = MetadataRowBuilder.SanitizeField(builder.GetEmailSubject(workItem, fileData), request.NewlineDelimiter);
+            var to = MetadataRowBuilder.SanitizeField(builder.GetEmailTo(workItem, fileData), request.Delimiters.NewlineDelimiter);
+            var from = MetadataRowBuilder.SanitizeField(builder.GetEmailFrom(workItem, fileData), request.Delimiters.NewlineDelimiter);
+            var subject = MetadataRowBuilder.SanitizeField(builder.GetEmailSubject(workItem, fileData), request.Delimiters.NewlineDelimiter);
             var sentDate = builder.GetEmailSentDate(workItem, fileData);
-            var attachment = MetadataRowBuilder.SanitizeField(builder.GetEmailAttachment(fileData), request.NewlineDelimiter);
+            var attachment = MetadataRowBuilder.SanitizeField(builder.GetEmailAttachment(fileData), request.Delimiters.NewlineDelimiter);
             sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             sb.Append($"{colDelim}{quote}{builder.GetBatesNumber(workItem)}{quote}");
         }
@@ -148,7 +148,7 @@ internal class DatWriter : LoadFileWriterBase
             sb.Append($"{colDelim}{quote}{fileData.PageCount}{quote}");
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             sb.Append($"{colDelim}{quote}{builder.GetTextPath(workItem)}{quote}");
         }

--- a/src/LoadFiles/LoadFileWriterBase.cs
+++ b/src/LoadFiles/LoadFileWriterBase.cs
@@ -84,8 +84,8 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// <returns></returns>
     protected static string GenerateBatesNumber(FileGenerationRequest request, FileWorkItem workItem)
     {
-        return request.BatesConfig != null
-            ? BatesNumberGenerator.Generate(request.BatesConfig, workItem.Index - 1)
+        return request.Bates != null
+            ? BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1)
             : string.Empty;
     }
 
@@ -95,7 +95,7 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// <returns></returns>
     protected static string GenerateTextPath(FileGenerationRequest request, FileWorkItem workItem)
     {
-        return workItem.FilePathInZip.Replace($".{request.FileType}", ".txt");
+        return workItem.FilePathInZip.Replace($".{request.Output.FileType}", ".txt");
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ internal abstract class LoadFileWriterBase : ILoadFileWriter
     /// </summary>
     protected static StreamWriter CreateWriter(Stream stream, FileGenerationRequest request)
     {
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
         return new StreamWriter(stream, encoding, leaveOpen: true);
     }
 

--- a/src/LoadFiles/LoadfileOnlyDatWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyDatWriter.cs
@@ -14,11 +14,11 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
-        var eolString = GetEolString(request.EndOfLine);
-        char colDelim = !string.IsNullOrEmpty(request.ColumnDelimiter) ? request.ColumnDelimiter[0] : '\u0014';
-        char quote = !string.IsNullOrEmpty(request.QuoteDelimiter) ? request.QuoteDelimiter[0] : '\u00fe';
-        bool hasQuote = !string.IsNullOrEmpty(request.QuoteDelimiter);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+        var eolString = GetEolString(request.Delimiters.EndOfLine);
+        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
+        char quote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
 
         using var memStream = new MemoryStream();
 
@@ -31,16 +31,16 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
         var headerBytes = encoding.GetBytes(header + eolString);
         await memStream.WriteAsync(headerBytes);
 
-        var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+        var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
 #pragma warning disable S2245
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + 1) : new Random();
 #pragma warning restore S2245
 
         var builder = new MetadataRowBuilder(request, random, now);
         var buffer = new StringBuilder();
 
-        for (long i = 1; i <= request.FileCount; i++)
+        for (long i = 1; i <= request.Output.FileCount; i++)
         {
             long lineNumber = i + 1;
             string recordId = builder.GetControlNumber(i);
@@ -53,7 +53,7 @@ internal class LoadfileOnlyDatWriter : LoadFileWriterBase
             buffer.Append(eolString);
 
             // Handle encoding anomalies between lines
-            if (chaosEngine != null && i < request.FileCount)
+            if (chaosEngine != null && i < request.Output.FileCount)
             {
                 // Flush current buffer first
                 var bufferedBytes = encoding.GetBytes(buffer.ToString());

--- a/src/LoadFiles/LoadfileOnlyOptWriter.cs
+++ b/src/LoadFiles/LoadfileOnlyOptWriter.cs
@@ -14,18 +14,18 @@ internal class LoadfileOnlyOptWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
-        var eolString = GetEolString(request.EndOfLine);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+        var eolString = GetEolString(request.Delimiters.EndOfLine);
 
         using var memStream = new MemoryStream();
 
 #pragma warning disable S2245
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value + 1) : new Random();
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + 1) : new Random();
 #pragma warning restore S2245
 
         var buffer = new StringBuilder();
 
-        for (long i = 1; i <= request.FileCount; i++)
+        for (long i = 1; i <= request.Output.FileCount; i++)
         {
             long lineNumber = i;
             string batesId = $"IMG{i:D8}";

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -19,7 +19,7 @@ internal class OptWriter : LoadFileWriterBase
         ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
-        await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.Encoding), leaveOpen: true);
+        await using var writer = new StreamWriter(stream, Zipper.EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding), leaveOpen: true);
 
         await WriteRowsAsync(writer, request, processedFiles);
 
@@ -42,12 +42,12 @@ internal class OptWriter : LoadFileWriterBase
             Console.Error.WriteLine("Warning: Email metadata columns are not supported in Opticon format. The OPT file uses the standard 7-column layout.");
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             Console.Error.WriteLine("Warning: --with-text is not supported in Opticon format. The OPT file uses the standard 7-column layout.");
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             Console.Error.WriteLine("Warning: The Bates number column is part of the standard Opticon 7-column format (column 1). Other Bates configuration is ignored.");
         }
@@ -60,7 +60,7 @@ internal class OptWriter : LoadFileWriterBase
             var workItem = fileData.WorkItem;
 
             // Opticon 7-column format: BatesNumber,Volume,ImagePath,DocBreak,FolderBreak,BoxBreak,PageCount
-            string batesNumber = request.BatesConfig != null
+            string batesNumber = request.Bates != null
                 ? GenerateBatesNumber(request, workItem)
                 : GenerateDocumentId(workItem);
             string volume = "VOL001";

--- a/src/LoadFiles/ProductionSetDatWriter.cs
+++ b/src/LoadFiles/ProductionSetDatWriter.cs
@@ -12,9 +12,9 @@ internal class ProductionSetDatWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        var col = string.IsNullOrEmpty(request.ColumnDelimiter) ? "\u0014" : request.ColumnDelimiter;
-        var quote = string.IsNullOrEmpty(request.QuoteDelimiter) ? "\u00fe" : request.QuoteDelimiter;
-        var eol = GetEolString(request.EndOfLine);
+        var col = string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? "\u0014" : request.Delimiters.ColumnDelimiter;
+        var quote = string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? "\u00fe" : request.Delimiters.QuoteDelimiter;
+        var eol = GetEolString(request.Delimiters.EndOfLine);
 
         await using var writer = CreateWriter(stream, request);
 
@@ -26,18 +26,18 @@ internal class ProductionSetDatWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var workItem = fileData.WorkItem;
-            var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig!, workItem.Index - 1);
+            var batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
             var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
                 .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif");
 
             var nativePath = workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
-            var textPath = nativePath.Replace($".{request.FileType}", ".txt");
+            var textPath = nativePath.Replace($".{request.Output.FileType}", ".txt");
             var imagesPath = imagePath.Replace(Path.DirectorySeparatorChar, '\\');
 
 #pragma warning disable S2245
-            var random = request.Seed.HasValue ? new Random(request.Seed.Value + (int)workItem.Index) : Random.Shared;
+            var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + (int)workItem.Index) : Random.Shared;
 #pragma warning restore S2245
-            var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+            var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
             var builder = new MetadataRowBuilder(request, random, now);
 
             var fields = new[]
@@ -51,7 +51,7 @@ internal class ProductionSetDatWriter : LoadFileWriterBase
                 builder.GetCustodian(),
                 builder.GetDateCreated(),
                 fileData.DataLength.ToString(),
-                request.FileType.ToUpperInvariant(),
+                request.Output.FileType.ToUpperInvariant(),
             };
             await writer.WriteAsync(string.Join(col, fields.Select(f => $"{quote}{f}{quote}")) + eol);
         }

--- a/src/LoadFiles/ProductionSetOptWriter.cs
+++ b/src/LoadFiles/ProductionSetOptWriter.cs
@@ -12,12 +12,12 @@ internal class ProductionSetOptWriter : LoadFileWriterBase
         List<FileData> processedFiles,
         ChaosEngine? chaosEngine = null)
     {
-        var eol = GetEolString(request.EndOfLine);
+        var eol = GetEolString(request.Delimiters.EndOfLine);
         await using var writer = CreateWriter(stream, request);
 
         foreach (var workItem in processedFiles.OrderBy(f => f.WorkItem.Index).Select(f => f.WorkItem))
         {
-            var batesNumber = BatesNumberGenerator.Generate(request.BatesConfig!, workItem.Index - 1);
+            var batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
             var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
                 .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
                 .Replace(Path.DirectorySeparatorChar, '\\');

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -36,9 +36,9 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
             await writer.WriteStartElementAsync(null, "documents", null);
 
 #pragma warning disable S2245
-            var random = request.Seed.HasValue ? new Random(request.Seed.Value) : Random.Shared;
+            var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
-            var now = request.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+            var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
@@ -98,7 +98,7 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
                 new XElement("attachment", eml.Attachment)));
         }
 
-        if (request.BatesConfig != null)
+        if (request.Bates != null)
         {
             docElement.Add(new XElement("batesNumber", GenerateBatesNumber(request, workItem)));
         }
@@ -108,7 +108,7 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
             docElement.Add(new XElement("pageCount", fileData.PageCount));
         }
 
-        if (request.WithText)
+        if (request.Output.WithText)
         {
             docElement.Add(new XElement("extractedTextPath", GenerateTextPath(request, workItem)));
         }

--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -31,7 +31,7 @@ internal static class LoadfileAuditWriter
     {
         var propertiesPath = Path.ChangeExtension(outputPath, null) + "_properties.json";
 
-        var formatName = request.LoadFileFormat == LoadFileFormat.Opt
+        var formatName = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt
             ? "OPT (Image)"
             : "DAT (Metadata)";
 
@@ -42,21 +42,21 @@ internal static class LoadfileAuditWriter
             TotalRecords = totalRecords,
             Properties = new AuditProperties
             {
-                Encoding = request.Encoding,
-                LineEnding = request.EndOfLine,
+                Encoding = request.LoadFile.Encoding,
+                LineEnding = request.Delimiters.EndOfLine,
                 Delimiters = new AuditDelimiters
                 {
-                    Column = FormatDelimiter(request.ColumnDelimiter),
-                    Quote = string.IsNullOrEmpty(request.QuoteDelimiter) ? "none" : FormatDelimiter(request.QuoteDelimiter),
-                    Newline = FormatDelimiter(request.NewlineDelimiter),
-                    MultiValue = FormatDelimiter(request.MultiValueDelimiter),
-                    NestedValue = FormatDelimiter(request.NestedValueDelimiter),
+                    Column = FormatDelimiter(request.Delimiters.ColumnDelimiter),
+                    Quote = string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? "none" : FormatDelimiter(request.Delimiters.QuoteDelimiter),
+                    Newline = FormatDelimiter(request.Delimiters.NewlineDelimiter),
+                    MultiValue = FormatDelimiter(request.Delimiters.MultiValueDelimiter),
+                    NestedValue = FormatDelimiter(request.Delimiters.NestedValueDelimiter),
                 },
             },
             ChaosMode = new AuditChaosMode
             {
-                Enabled = request.ChaosMode,
-                TargetAmount = request.ChaosAmount,
+                Enabled = request.Chaos.ChaosMode,
+                TargetAmount = request.Chaos.ChaosAmount,
                 TotalAnomalies = anomalies?.Count ?? 0,
                 InjectedAnomalies = anomalies != null && anomalies.Count > 0
                     ? anomalies.Select(a => new AuditAnomalyEntry

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -20,26 +20,26 @@ internal static class LoadfileOnlyGenerator
 
         var stopwatch = Stopwatch.StartNew();
 
-        Directory.CreateDirectory(request.OutputPath);
+        Directory.CreateDirectory(request.Output.OutputPath);
 
         var baseFileName = $"loadfile_{DateTime.Now:yyyyMMdd_HHmmss}";
-        var extension = request.LoadFileFormat == LoadFileFormat.Opt ? ".opt" : ".dat";
-        var loadFilePath = Path.Combine(request.OutputPath, $"{baseFileName}{extension}");
+        var extension = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? ".opt" : ".dat";
+        var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
 
-        var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.EndOfLine);
-        long totalLines = request.LoadFileFormat == LoadFileFormat.Opt
-            ? request.FileCount
-            : request.FileCount + 1;
+        var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.Delimiters.EndOfLine);
+        long totalLines = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt
+            ? request.Output.FileCount
+            : request.Output.FileCount + 1;
 
         ChaosEngine? chaosEngine = null;
-        if (request.ChaosMode)
+        if (request.Chaos.ChaosMode)
         {
-            string? resolvedTypes = request.ChaosTypes;
-            string? resolvedAmount = request.ChaosAmount;
+            string? resolvedTypes = request.Chaos.ChaosTypes;
+            string? resolvedAmount = request.Chaos.ChaosAmount;
 
-            if (!string.IsNullOrEmpty(request.ChaosScenario))
+            if (!string.IsNullOrEmpty(request.Chaos.ChaosScenario))
             {
-                var scenario = ChaosScenarios.GetByName(request.ChaosScenario);
+                var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
                 if (scenario != null)
                 {
                     resolvedTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes;
@@ -48,28 +48,28 @@ internal static class LoadfileOnlyGenerator
                         resolvedAmount = scenario.DefaultAmount;
                     }
 
-                    request.ChaosAmount = resolvedAmount;
-                    request.ChaosTypes = resolvedTypes;
+                    request.Chaos = request.Chaos with { ChaosAmount = resolvedAmount };
+                    request.Chaos = request.Chaos with { ChaosTypes = resolvedTypes };
 
                     Console.WriteLine(string.Format("  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
                 }
             }
 
-            string chaosColDelim = request.LoadFileFormat == LoadFileFormat.Opt ? "," : request.ColumnDelimiter;
-            string chaosQuoteDelim = request.LoadFileFormat == LoadFileFormat.Opt ? string.Empty : request.QuoteDelimiter;
+            string chaosColDelim = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? "," : request.Delimiters.ColumnDelimiter;
+            string chaosQuoteDelim = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? string.Empty : request.Delimiters.QuoteDelimiter;
 
             chaosEngine = new ChaosEngine(
                 totalLines,
                 resolvedAmount,
                 resolvedTypes,
-                request.LoadFileFormat,
+                request.LoadFile.LoadFileFormat,
                 chaosColDelim,
                 chaosQuoteDelim,
                 eolString,
-                request.Seed);
+                request.Metadata.Seed);
         }
 
-        ILoadFileWriter writer = request.LoadFileFormat == LoadFileFormat.Opt
+        ILoadFileWriter writer = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt
             ? new LoadfileOnlyOptWriter()
             : new LoadfileOnlyDatWriter();
 
@@ -84,7 +84,7 @@ internal static class LoadfileOnlyGenerator
             propertiesPath = await LoadfileAuditWriter.WriteAsync(
                 loadFilePath,
                 request,
-                request.FileCount,
+                request.Output.FileCount,
                 chaosEngine?.Anomalies);
         }
         catch
@@ -103,7 +103,7 @@ internal static class LoadfileOnlyGenerator
         {
             LoadFilePath = loadFilePath,
             PropertiesFilePath = propertiesPath,
-            TotalRecords = request.FileCount,
+            TotalRecords = request.Output.FileCount,
             GenerationTime = stopwatch.Elapsed,
         };
     }

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -8,18 +8,18 @@ namespace Zipper
         public async Task RunAsync(FileGenerationRequest request)
         {
             Console.WriteLine("Starting loadfile-only generation...");
-            Console.WriteLine(string.Format("  Format: {0}", request.LoadFileFormat));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
-            Console.WriteLine(string.Format("  EOL: {0}", request.EndOfLine));
+            Console.WriteLine(string.Format("  Format: {0}", request.LoadFile.LoadFileFormat));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.Output.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.Output.OutputPath));
+            Console.WriteLine(string.Format("  Encoding: {0}", request.LoadFile.Encoding));
+            Console.WriteLine(string.Format("  EOL: {0}", request.Delimiters.EndOfLine));
 
-            if (request.ChaosMode)
+            if (request.Chaos.ChaosMode)
             {
-                Console.WriteLine(string.Format("  Chaos Mode: Enabled (amount: {0})", request.ChaosAmount ?? "1%"));
-                if (!string.IsNullOrEmpty(request.ChaosTypes))
+                Console.WriteLine(string.Format("  Chaos Mode: Enabled (amount: {0})", request.Chaos.ChaosAmount ?? "1%"));
+                if (!string.IsNullOrEmpty(request.Chaos.ChaosTypes))
                 {
-                    Console.WriteLine(string.Format("  Chaos Types: {0}", request.ChaosTypes));
+                    Console.WriteLine(string.Format("  Chaos Types: {0}", request.Chaos.ChaosTypes));
                 }
             }
 

--- a/src/MetadataRowBuilder.cs
+++ b/src/MetadataRowBuilder.cs
@@ -34,7 +34,7 @@ internal class MetadataRowBuilder
 
     public string GetCustodian()
     {
-        var maxCustodians = Math.Max(2, this.request.CustodianCountOverride ?? 10);
+        var maxCustodians = Math.Max(2, this.request.Metadata.CustodianCountOverride ?? 10);
         return $"Custodian {this.random.Next(1, maxCustodians + 1)}";
     }
 
@@ -102,7 +102,7 @@ internal class MetadataRowBuilder
 
     public string GetTextPath(FileWorkItem workItem)
     {
-        var sourceSuffix = $".{this.request.FileType}";
+        var sourceSuffix = $".{this.request.Output.FileType}";
         return workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
             ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
             : workItem.FilePathInZip;
@@ -110,7 +110,7 @@ internal class MetadataRowBuilder
 
     public string GetBatesNumber(FileWorkItem workItem)
     {
-        return this.request.BatesConfig != null ? BatesNumberGenerator.Generate(this.request.BatesConfig, workItem.Index - 1) : string.Empty;
+        return this.request.Bates != null ? BatesNumberGenerator.Generate(this.request.Bates, workItem.Index - 1) : string.Empty;
     }
 
     public static string SanitizeField(string value, string newlineDelimiter)

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -19,51 +19,51 @@ namespace Zipper
             // Clone to avoid mutating the caller's request object
             request = request.Clone();
 
-            this.performanceMonitor.Start(request.FileCount);
+            this.performanceMonitor.Start(request.Output.FileCount);
 
             try
             {
                 // Validate inputs
-                if (request.FileCount <= 0)
+                if (request.Output.FileCount <= 0)
                 {
-                    throw new ArgumentException("File count must be positive", nameof(request.FileCount));
+                    throw new ArgumentException("File count must be positive", nameof(request.Output.FileCount));
                 }
 
-                if (request.Concurrency <= 0)
+                if (request.Output.Concurrency <= 0)
                 {
-                    request.Concurrency = PerformanceConstants.DefaultConcurrency;
+                    request.Output = request.Output with { Concurrency = PerformanceConstants.DefaultConcurrency };
                 }
 
-                var fileGenerator = FileGeneratorFactory.Create(request.FileType, request)
-                    ?? throw new InvalidOperationException($"Unknown file type: {request.FileType}");
+                var fileGenerator = FileGeneratorFactory.Create(request.Output.FileType, request)
+                    ?? throw new InvalidOperationException($"Unknown file type: {request.Output.FileType}");
 
                 // For EML files, use sequential processing to avoid ZIP entry creation conflicts
                 if (fileGenerator.RequiresSequentialProcessing(request))
                 {
-                    request.Concurrency = 1; // Force sequential processing
+                    request.Output = request.Output with { Concurrency = 1 }; // Force sequential processing
                 }
 
-                Directory.CreateDirectory(request.OutputPath);
+                Directory.CreateDirectory(request.Output.OutputPath);
 
                 var baseFileName = $"archive_{DateTime.Now:yyyyMMdd_HHmmss}";
-                var zipFilePath = Path.Combine(request.OutputPath, $"{baseFileName}.zip");
+                var zipFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}.zip");
                 var loadFileName = $"{baseFileName}.dat";
-                var loadFilePath = Path.Combine(request.OutputPath, loadFileName);
+                var loadFilePath = Path.Combine(request.Output.OutputPath, loadFileName);
 
                 var placeholderContent = fileGenerator.IsPlaceholderBased
-                    ? PlaceholderFiles.GetContent(request.FileType.ToLowerInvariant())
+                    ? PlaceholderFiles.GetContent(request.Output.FileTypeLower)
                     : Array.Empty<byte>();
 
                 long paddingPerFile = 0;
-                if (request.TargetZipSize.HasValue)
+                if (request.Output.TargetZipSize.HasValue)
                 {
                     var baseSize = placeholderContent.Length > 0 ? placeholderContent.Length : 1024;
-                    paddingPerFile = this.CalculatePaddingPerFile(request.TargetZipSize.Value, baseSize, request.FileCount, request.WithText);
+                    paddingPerFile = this.CalculatePaddingPerFile(request.Output.TargetZipSize.Value, baseSize, request.Output.FileCount, request.Output.WithText);
                 }
 
                 // Create channels for work distribution
-                var workChannelReader = CreateWorkChannel(request.FileCount, request.Folders, request.Distribution, request.FileType, request.Concurrency);
-                var resultChannel = Channel.CreateBounded<FileData>(new BoundedChannelOptions(request.Concurrency * 2)
+                var workChannelReader = CreateWorkChannel(request.Output.FileCount, request.Output.Folders, request.LoadFile.Distribution, request.Output.FileType, request.Output.Concurrency);
+                var resultChannel = Channel.CreateBounded<FileData>(new BoundedChannelOptions(request.Output.Concurrency * 2)
                 {
                     FullMode = BoundedChannelFullMode.Wait,
                 });
@@ -72,8 +72,8 @@ namespace Zipper
                 var consumerTask = this.WriteArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader);
 
                 // Generate files in parallel (producers)
-                using var semaphore = new SemaphoreSlim(request.Concurrency);
-                var producerTasks = Enumerable.Range(0, request.Concurrency)
+                using var semaphore = new SemaphoreSlim(request.Output.Concurrency);
+                var producerTasks = Enumerable.Range(0, request.Output.Concurrency)
                     .Select(i => this.ProcessFileWorkAsync(semaphore, workChannelReader, paddingPerFile, resultChannel.Writer, request, fileGenerator))
                     .ToList();
 
@@ -108,7 +108,7 @@ namespace Zipper
                 {
                     ZipFilePath = zipFilePath,
                     LoadFilePath = actualLoadFilePath,
-                    FilesGenerated = request.FileCount,
+                    FilesGenerated = request.Output.FileCount,
                     GenerationTime = TimeSpan.FromMilliseconds(performanceMetrics.ElapsedMilliseconds),
                     FilesPerSecond = performanceMetrics.FilesPerSecond,
                 };

--- a/src/ProductionManifestWriter.cs
+++ b/src/ProductionManifestWriter.cs
@@ -35,13 +35,13 @@ internal static class ProductionManifestWriter
             {
                 Start = batesStart,
                 End = batesEnd,
-                Prefix = request.BatesConfig?.Prefix ?? string.Empty,
-                Digits = request.BatesConfig?.Digits ?? 8,
+                Prefix = request.Bates?.Prefix ?? string.Empty,
+                Digits = request.Bates?.Digits ?? 8,
             },
-            DocumentCount = request.FileCount,
-            FileType = request.FileType,
+            DocumentCount = request.Output.FileCount,
+            FileType = request.Output.FileType,
             VolumeCount = volumeCount,
-            VolumeSize = request.VolumeSize,
+            VolumeSize = request.Production.VolumeSize,
             Directories = new ProductionDirectories
             {
                 Data = "DATA",
@@ -56,11 +56,11 @@ internal static class ProductionManifestWriter
             },
             Settings = new ProductionSettings
             {
-                Encoding = request.Encoding,
-                ColumnDelimiter = FormatDelimiter(request.ColumnDelimiter),
-                QuoteDelimiter = FormatDelimiter(request.QuoteDelimiter),
-                ColumnProfile = request.ColumnProfile?.Name,
-                Seed = request.Seed,
+                Encoding = request.LoadFile.Encoding,
+                ColumnDelimiter = FormatDelimiter(request.Delimiters.ColumnDelimiter),
+                QuoteDelimiter = FormatDelimiter(request.Delimiters.QuoteDelimiter),
+                ColumnProfile = request.Metadata.ColumnProfile?.Name,
+                Seed = request.Metadata.Seed,
             },
             GenerationTime = $"{generationTime.TotalSeconds:F1}s",
         };

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -19,7 +19,7 @@ internal static class ProductionSetGenerator
         var stopwatch = Stopwatch.StartNew();
 
         var productionName = $"PRODUCTION_{DateTime.Now:yyyyMMdd_HHmmss}";
-        var productionPath = Path.Combine(request.OutputPath, productionName);
+        var productionPath = Path.Combine(request.Output.OutputPath, productionName);
 
         // Create directory structure
         var dataDir = Path.Combine(productionPath, "DATA");
@@ -33,13 +33,13 @@ internal static class ProductionSetGenerator
         Directory.CreateDirectory(imagesDir);
 
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
-        var random = request.Seed.HasValue ? new Random(request.Seed.Value) : new Random();
+        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : new Random();
 #pragma warning restore S2245
-        var batesConfig = request.BatesConfig
+        var batesConfig = request.Bates
             ?? throw new InvalidOperationException("Production set requires Bates configuration. Specify --bates-prefix.");
 
         // Calculate volume distribution
-        int volumeCount = (int)Math.Ceiling((double)request.FileCount / request.VolumeSize);
+        int volumeCount = (int)Math.Ceiling((double)request.Output.FileCount / request.Production.VolumeSize);
 
         // Pre-create volume subdirectories
         for (int v = 1; v <= volumeCount; v++)
@@ -50,21 +50,21 @@ internal static class ProductionSetGenerator
             Directory.CreateDirectory(Path.Combine(imagesDir, volName));
         }
 
-        var encoding = EncodingHelper.GetEncodingOrDefault(request.Encoding);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
-        var fileGenerator = FileGeneratorFactory.Create(request.FileType, request)
-            ?? throw new InvalidOperationException($"Unknown file type: {request.FileType}");
+        var fileGenerator = FileGeneratorFactory.Create(request.Output.FileType, request)
+            ?? throw new InvalidOperationException($"Unknown file type: {request.Output.FileType}");
 
         // Generate files and collect records for load files
         var fileDataList = new List<FileData>();
 
-        for (long i = 0; i < request.FileCount; i++)
+        for (long i = 0; i < request.Output.FileCount; i++)
         {
-            int volumeIndex = (int)(i / request.VolumeSize) + 1;
+            int volumeIndex = (int)(i / request.Production.VolumeSize) + 1;
             var volName = $"VOL{volumeIndex:D3}";
             var batesNumber = BatesNumberGenerator.Generate(batesConfig, i);
 
-            var nativeExt = request.FileType.ToLowerInvariant();
+            var nativeExt = request.Output.FileTypeLower;
             var nativeRelPath = Path.Combine("NATIVES", volName, $"{batesNumber}.{nativeExt}");
             var textRelPath = Path.Combine("TEXT", volName, $"{batesNumber}.txt");
             var imageRelPath = Path.Combine("IMAGES", volName, $"{batesNumber}.tif");
@@ -101,9 +101,9 @@ internal static class ProductionSetGenerator
             });
 
             // Progress reporting
-            if ((i + 1) % 1000 == 0 || i == request.FileCount - 1)
+            if ((i + 1) % 1000 == 0 || i == request.Output.FileCount - 1)
             {
-                Console.Write($"\r  Progress: {i + 1:N0} / {request.FileCount:N0} documents");
+                Console.Write($"\r  Progress: {i + 1:N0} / {request.Output.FileCount:N0} documents");
             }
         }
 
@@ -127,15 +127,15 @@ internal static class ProductionSetGenerator
 
         // Write manifest
         var batesStart = BatesNumberGenerator.Generate(batesConfig, 0);
-        var batesEnd = BatesNumberGenerator.Generate(batesConfig, request.FileCount - 1);
+        var batesEnd = BatesNumberGenerator.Generate(batesConfig, request.Output.FileCount - 1);
         var manifestPath = await ProductionManifestWriter.WriteAsync(
             productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed);
 
         // Optionally wrap in ZIP
         string? zipPath = null;
-        if (request.ProductionZip)
+        if (request.Production.ProductionZip)
         {
-            zipPath = Path.Combine(request.OutputPath, $"{productionName}.zip");
+            zipPath = Path.Combine(request.Output.OutputPath, $"{productionName}.zip");
             Console.Write("  Creating ZIP archive...");
             ZipFile.CreateFromDirectory(productionPath, zipPath, CompressionLevel.Optimal, true);
             Console.WriteLine(" done.");
@@ -150,7 +150,7 @@ internal static class ProductionSetGenerator
             DatFilePath = datPath,
             OptFilePath = optPath,
             ManifestPath = manifestPath,
-            TotalDocuments = request.FileCount,
+            TotalDocuments = request.Output.FileCount,
             BatesRange = $"{batesStart} - {batesEnd}",
             VolumeCount = volumeCount,
             GenerationTime = stopwatch.Elapsed,

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -8,15 +8,15 @@ namespace Zipper
         public async Task RunAsync(FileGenerationRequest request)
         {
             Console.WriteLine("Starting production set generation...");
-            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Volume Size: {0:N0} files/volume", request.VolumeSize));
-            var batesPrefix = request.BatesConfig?.Prefix ?? string.Empty;
-            var batesStart = request.BatesConfig?.Start ?? 1;
-            var batesDigits = request.BatesConfig?.Digits ?? 8;
+            Console.WriteLine(string.Format("  File Type: {0}", request.Output.FileType));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.Output.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.Output.OutputPath));
+            Console.WriteLine(string.Format("  Volume Size: {0:N0} files/volume", request.Production.VolumeSize));
+            var batesPrefix = request.Bates?.Prefix ?? string.Empty;
+            var batesStart = request.Bates?.Start ?? 1;
+            var batesDigits = request.Bates?.Digits ?? 8;
             Console.WriteLine(string.Format("  Bates: {0}{1}", batesPrefix, batesStart.ToString($"D{batesDigits}")));
-            if (request.ProductionZip)
+            if (request.Production.ProductionZip)
             {
                 Console.WriteLine("  ZIP Output: Enabled");
             }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -55,7 +55,7 @@ namespace Zipper
                 return new LoadfileOnlyMode();
             }
 
-            if (request.ProductionSet)
+            if (request.Production.ProductionSet)
             {
                 return new ProductionSetMode();
             }

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -8,28 +8,28 @@ namespace Zipper
         public async Task RunAsync(FileGenerationRequest request)
         {
             Console.WriteLine("Starting parallel file generation...");
-            Console.WriteLine(string.Format("  File Type: {0}", request.FileType));
-            Console.WriteLine(string.Format("  Count: {0:N0}", request.FileCount));
-            Console.WriteLine(string.Format("  Output Path: {0}", request.OutputPath));
-            Console.WriteLine(string.Format("  Folders: {0}", request.Folders));
-            Console.WriteLine(string.Format("  Encoding: {0}", request.Encoding));
-            Console.WriteLine(string.Format("  Distribution: {0}", request.Distribution));
-            if (request.WithMetadata)
+            Console.WriteLine(string.Format("  File Type: {0}", request.Output.FileType));
+            Console.WriteLine(string.Format("  Count: {0:N0}", request.Output.FileCount));
+            Console.WriteLine(string.Format("  Output Path: {0}", request.Output.OutputPath));
+            Console.WriteLine(string.Format("  Folders: {0}", request.Output.Folders));
+            Console.WriteLine(string.Format("  Encoding: {0}", request.LoadFile.Encoding));
+            Console.WriteLine(string.Format("  Distribution: {0}", request.LoadFile.Distribution));
+            if (request.Metadata.WithMetadata)
             {
                 Console.WriteLine("  Metadata: Enabled");
             }
 
-            if (request.WithText)
+            if (request.Output.WithText)
             {
                 Console.WriteLine("  Extracted Text: Enabled");
             }
 
-            if (request.TargetZipSize.HasValue)
+            if (request.Output.TargetZipSize.HasValue)
             {
-                Console.WriteLine(string.Format("  Target ZIP Size: {0} MB", request.TargetZipSize.Value / (1024 * 1024)));
+                Console.WriteLine(string.Format("  Target ZIP Size: {0} MB", request.Output.TargetZipSize.Value / (1024 * 1024)));
             }
 
-            if (request.IncludeLoadFile)
+            if (request.Output.IncludeLoadFile)
             {
                 Console.WriteLine("  Load File: Will be included in zip archive.");
             }
@@ -42,7 +42,7 @@ namespace Zipper
             Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format("  Archive created: {0}", result.ZipFilePath));
             Console.WriteLine(string.Format("  Performance: {0:F1} files/second", result.FilesPerSecond));
-            if (!request.IncludeLoadFile)
+            if (!request.Output.IncludeLoadFile)
             {
                 Console.WriteLine(string.Format("  Load file created: {0}", result.LoadFilePath));
             }

--- a/src/TiffFileGenerator.cs
+++ b/src/TiffFileGenerator.cs
@@ -13,7 +13,7 @@ internal sealed class TiffFileGenerator : IFileGenerator
 
     public TiffFileGenerator(FileGenerationRequest request)
     {
-        this.hasPageRange = request.TiffPageRange.HasValue;
+        this.hasPageRange = request.Tiff.PageRange.HasValue;
     }
 
     public bool RequiresSequentialProcessing(FileGenerationRequest request) => false;
@@ -29,7 +29,7 @@ internal sealed class TiffFileGenerator : IFileGenerator
         }
 
         var pageCount = TiffMultiPageGenerator.GetPageCount(
-            request.TiffPageRange!.Value, request.Seed, workItem.Index);
+            request.Tiff.PageRange!.Value, request.Metadata.Seed, workItem.Index);
 
         return new GeneratedFileContent
         {

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -33,8 +33,8 @@ namespace Zipper
             var usedEntryPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Pre-compute the extracted text content selection once, outside the loop
-            var extractedTextContent = request.WithText
-                ? (string.Equals(request.FileType, "eml", StringComparison.OrdinalIgnoreCase)
+            var extractedTextContent = request.Output.WithText
+                ? (string.Equals(request.Output.FileType, "eml", StringComparison.OrdinalIgnoreCase)
                     ? PlaceholderFiles.EmlExtractedText
                     : PlaceholderFiles.ExtractedText)
                 : null;
@@ -52,7 +52,7 @@ namespace Zipper
                 // 4. Attachment's extracted text (if it exists and text is requested)
                 WriteFileToArchive(archive, fileData, usedEntryPaths);
 
-                if (request.WithText)
+                if (request.Output.WithText)
                 {
                     WriteExtractedTextToArchive(archive, fileData, request, extractedTextContent!, usedEntryPaths);
                 }
@@ -62,7 +62,7 @@ namespace Zipper
                     WriteAttachmentToArchive(archive, fileData, usedEntryPaths);
                 }
 
-                if (fileData.Attachment.HasValue && request.WithText)
+                if (fileData.Attachment.HasValue && request.Output.WithText)
                 {
                     WriteAttachmentTextToArchive(archive, fileData, usedEntryPaths);
                 }
@@ -73,9 +73,9 @@ namespace Zipper
                 fileData.MemoryOwner?.Dispose();
             }
 
-            var formatsToGenerate = request.LoadFileFormats?.Any() == true
-                ? request.LoadFileFormats
-                : new List<LoadFileFormat> { request.LoadFileFormat };
+            var formatsToGenerate = request.LoadFile.LoadFileFormats?.Any() == true
+                ? request.LoadFile.LoadFileFormats
+                : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
 
             string actualLoadFilePath = loadFilePath;
             var baseFileName = Path.GetFileNameWithoutExtension(loadFileName);
@@ -86,7 +86,7 @@ namespace Zipper
                 var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
                 var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
 
-                if (request.IncludeLoadFile)
+                if (request.Output.IncludeLoadFile)
                 {
                     var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
                     using var loadFileStream = loadFileEntry.Open();
@@ -173,9 +173,9 @@ namespace Zipper
         /// </summary>
         private static void WriteExtractedTextToArchive(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[] textContent, HashSet<string> usedEntryPaths)
         {
-            System.Diagnostics.Debug.Assert(request.WithText, "Should only be called when WithText is true");
+            System.Diagnostics.Debug.Assert(request.Output.WithText, "Should only be called when WithText is true");
 
-            var textFileName = fileData.WorkItem.FileName.Replace($".{request.FileType}", ".txt");
+            var textFileName = fileData.WorkItem.FileName.Replace($".{request.Output.FileType}", ".txt");
             var entryPath = $"{fileData.WorkItem.FolderName}/{textFileName}";
 
             if (!usedEntryPaths.Add(entryPath))

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -21,7 +21,7 @@ namespace Zipper
         public async Task WriteAsync_WithMetadata_IncludesMetadataColumns()
         {
             var request = DefaultRequest();
-            request.WithMetadata = true;
+            request.Metadata = request.Metadata with { WithMetadata = true };
             var output = await WriteAndCaptureOutput(request, []);
             Assert.Contains("Custodian", output);
             Assert.Contains("Date Sent", output);
@@ -33,7 +33,7 @@ namespace Zipper
         public async Task WriteAsync_WithEmailType_IncludesEmlColumns()
         {
             var request = DefaultRequest();
-            request.FileType = "eml";
+            request.Output = request.Output with { FileType = "eml" };
             var output = await WriteAndCaptureOutput(request, []);
             Assert.Contains("To", output);
             Assert.Contains("From", output);
@@ -46,7 +46,7 @@ namespace Zipper
         public async Task WriteAsync_WithBatesConfig_IncludesBatesNumberColumn()
         {
             var request = DefaultRequest();
-            request.BatesConfig = new BatesNumberConfig
+            request.Bates = new BatesNumberConfig
             {
                 Prefix = "TEST",
                 Start = 1,
@@ -61,8 +61,8 @@ namespace Zipper
         public async Task WriteAsync_WithTiffPageRange_IncludesPageCountColumn()
         {
             var request = DefaultRequest();
-            request.FileType = "tiff";
-            request.TiffPageRange = (1, 10);
+            request.Output = request.Output with { FileType = "tiff" };
+            request.Tiff = request.Tiff with { PageRange = (1, 10) };
             var output = await WriteAndCaptureOutput(request, []);
             Assert.Contains("Page Count", output);
         }
@@ -71,7 +71,7 @@ namespace Zipper
         public async Task WriteAsync_WithText_IncludesExtractedTextColumn()
         {
             var request = DefaultRequest();
-            request.WithText = true;
+            request.Output = request.Output with { WithText = true };
             var output = await WriteAndCaptureOutput(request, []);
             Assert.Contains("Extracted Text", output);
         }
@@ -102,7 +102,7 @@ namespace Zipper
         public async Task WriteAsync_WithMetadata_WritesMetadataValues()
         {
             var request = DefaultRequest();
-            request.WithMetadata = true;
+            request.Metadata = request.Metadata with { WithMetadata = true };
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
@@ -114,7 +114,7 @@ namespace Zipper
         public async Task WriteAsync_WithEmailData_WritesEmlColumns()
         {
             var request = DefaultRequest();
-            request.FileType = "eml";
+            request.Output = request.Output with { FileType = "eml" };
             var template = new EmailTemplate
             {
                 To = "test@example.com",
@@ -151,7 +151,7 @@ namespace Zipper
         public async Task WriteAsync_WithBates_WritesBatesNumber()
         {
             var request = DefaultRequest();
-            request.BatesConfig = new BatesNumberConfig
+            request.Bates = new BatesNumberConfig
             {
                 Prefix = "DOC",
                 Start = 100,
@@ -168,8 +168,8 @@ namespace Zipper
         public async Task WriteAsync_WithTiff_WritesPageCount()
         {
             var request = DefaultRequest();
-            request.FileType = "tiff";
-            request.TiffPageRange = (1, 5);
+            request.Output = request.Output with { FileType = "tiff" };
+            request.Tiff = request.Tiff with { PageRange = (1, 5) };
             var files = new List<FileData>
             {
                 new()
@@ -197,8 +197,8 @@ namespace Zipper
         public async Task WriteAsync_WithText_WritesTextFileReference()
         {
             var request = DefaultRequest();
-            request.WithText = true;
-            request.FileType = "pdf";
+            request.Output = request.Output with { WithText = true };
+            request.Output = request.Output with { FileType = "pdf" };
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
@@ -231,7 +231,7 @@ namespace Zipper
         public async Task WriteAsync_WithEmlWithoutTemplate_WritesFallbackEmlValues()
         {
             var request = DefaultRequest();
-            request.FileType = "eml";
+            request.Output = request.Output with { FileType = "eml" };
             var files = new List<FileData>
             {
                 new()
@@ -259,8 +259,8 @@ namespace Zipper
         public async Task WriteAsync_DefaultDelimiters_UseNonPrintingChars()
         {
             var request = DefaultRequest();
-            request.ColumnDelimiter = null!;
-            request.QuoteDelimiter = null!;
+            request.Delimiters = request.Delimiters with { ColumnDelimiter = null! };
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = null! };
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
@@ -271,7 +271,7 @@ namespace Zipper
         public async Task WriteAsync_SanitizeField_ReplacesWindowsNewline()
         {
             var request = DefaultRequest();
-            request.WithMetadata = true;
+            request.Metadata = request.Metadata with { WithMetadata = true };
             var files = new List<FileData>
             {
                 new()

--- a/src/Zipper.Tests/FileGenerationRequestTests.cs
+++ b/src/Zipper.Tests/FileGenerationRequestTests.cs
@@ -47,8 +47,8 @@ namespace Zipper.Tests
         {
             var request = new FileGenerationRequest();
             var profile = new ColumnProfile { Name = "test", Description = "standard" };
-            request.ColumnProfile = profile;
-            Assert.Same(profile, request.ColumnProfile);
+            request.Metadata = request.Metadata with { ColumnProfile = profile };
+            Assert.Same(profile, request.Metadata.ColumnProfile);
             Assert.Same(profile, request.Metadata.ColumnProfile);
         }
 
@@ -56,8 +56,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_DateFormatOverride_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.DateFormatOverride = "yyyy-MM-dd";
-            Assert.Equal("yyyy-MM-dd", request.DateFormatOverride);
+            request.Metadata = request.Metadata with { DateFormatOverride = "yyyy-MM-dd" };
+            Assert.Equal("yyyy-MM-dd", request.Metadata.DateFormatOverride);
             Assert.Equal("yyyy-MM-dd", request.Metadata.DateFormatOverride);
         }
 
@@ -65,8 +65,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_EmptyPercentageOverride_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.EmptyPercentageOverride = 25;
-            Assert.Equal(25, request.EmptyPercentageOverride);
+            request.Metadata = request.Metadata with { EmptyPercentageOverride = 25 };
+            Assert.Equal(25, request.Metadata.EmptyPercentageOverride);
             Assert.Equal(25, request.Metadata.EmptyPercentageOverride);
         }
 
@@ -74,8 +74,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_WithFamilies_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.WithFamilies = true;
-            Assert.True(request.WithFamilies);
+            request.Metadata = request.Metadata with { WithFamilies = true };
+            Assert.True(request.Metadata.WithFamilies);
             Assert.True(request.Metadata.WithFamilies);
         }
 
@@ -83,8 +83,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_AttachmentRate_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.AttachmentRate = 50;
-            Assert.Equal(50, request.AttachmentRate);
+            request.LoadFile = request.LoadFile with { AttachmentRate = 50 };
+            Assert.Equal(50, request.LoadFile.AttachmentRate);
             Assert.Equal(50, request.LoadFile.AttachmentRate);
         }
 
@@ -92,8 +92,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_NewlineDelimiter_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.NewlineDelimiter = " ";
-            Assert.Equal(" ", request.NewlineDelimiter);
+            request.Delimiters = request.Delimiters with { NewlineDelimiter = " " };
+            Assert.Equal(" ", request.Delimiters.NewlineDelimiter);
             Assert.Equal(" ", request.Delimiters.NewlineDelimiter);
         }
 
@@ -101,8 +101,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_MultiValueDelimiter_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.MultiValueDelimiter = ",";
-            Assert.Equal(",", request.MultiValueDelimiter);
+            request.Delimiters = request.Delimiters with { MultiValueDelimiter = "," };
+            Assert.Equal(",", request.Delimiters.MultiValueDelimiter);
             Assert.Equal(",", request.Delimiters.MultiValueDelimiter);
         }
 
@@ -110,8 +110,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_NestedValueDelimiter_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.NestedValueDelimiter = "/";
-            Assert.Equal("/", request.NestedValueDelimiter);
+            request.Delimiters = request.Delimiters with { NestedValueDelimiter = "/" };
+            Assert.Equal("/", request.Delimiters.NestedValueDelimiter);
             Assert.Equal("/", request.Delimiters.NestedValueDelimiter);
         }
 
@@ -119,8 +119,8 @@ namespace Zipper.Tests
         public void FileGenerationRequest_ChaosScenario_Roundtrips()
         {
             var request = new FileGenerationRequest();
-            request.ChaosScenario = "encoding-nightmare";
-            Assert.Equal("encoding-nightmare", request.ChaosScenario);
+            request.Chaos = request.Chaos with { ChaosScenario = "encoding-nightmare" };
+            Assert.Equal("encoding-nightmare", request.Chaos.ChaosScenario);
             Assert.Equal("encoding-nightmare", request.Chaos.ChaosScenario);
         }
 

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -62,7 +62,7 @@ namespace Zipper
         public void Program_SelectMode_ProductionSet_ReturnsProductionSetMode()
         {
             var request = DefaultRequest();
-            request.ProductionSet = true;
+            request.Production = request.Production with { ProductionSet = true };
             Assert.IsType<ProductionSetMode>(Program.SelectMode(request));
         }
 
@@ -78,7 +78,7 @@ namespace Zipper
         {
             var request = DefaultRequest();
             request.LoadfileOnly = true;
-            request.ProductionSet = true;
+            request.Production = request.Production with { ProductionSet = true };
             Assert.IsType<LoadfileOnlyMode>(Program.SelectMode(request));
         }
 

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -127,7 +127,7 @@ namespace Zipper
 
             // Arrange - Test that OPT writer respects the requested encoding
             var request = this.CreateTestRequest();
-            request.Encoding = encoding;
+            request.LoadFile = request.LoadFile with { Encoding = encoding };
             var fileData = this.CreateTestFileData();
             var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt);
             var outputPath = Path.Combine(this.tempDir, "test.opt");
@@ -334,7 +334,7 @@ namespace Zipper
         {
             // Arrange
             var request = this.CreateTestRequest();
-            request.BatesConfig = new BatesNumberConfig
+            request.Bates = new BatesNumberConfig
             {
                 Prefix = "TEST",
                 Start = 1,
@@ -368,7 +368,7 @@ namespace Zipper
         {
             // Arrange
             var request = this.CreateTestRequest("tiff");
-            request.TiffPageRange = (1, 10);
+            request.Tiff = request.Tiff with { PageRange = (1, 10) };
             var fileData = this.CreateTestFileData();
             fileData[0] = fileData[0] with { PageCount = 5 };
             fileData[1] = fileData[1] with { PageCount = 7 };
@@ -407,7 +407,7 @@ namespace Zipper
 
             // Arrange - Test encoding path with non-UTF8 encoding to verify proper encoding handling
             var request = this.CreateTestRequest();
-            request.Encoding = encoding;
+            request.LoadFile = request.LoadFile with { Encoding = encoding };
             var fileData = this.CreateTestFileData();
             var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat);
             var outputPath = Path.Combine(this.tempDir, "test.dat");
@@ -448,7 +448,7 @@ namespace Zipper
         public async Task CsvWriter_WithText_WritesTextPath()
         {
             var request = this.CreateTestRequest();
-            request.WithText = true;
+            request.Output = request.Output with { WithText = true };
             var files = this.CreateTestFileData(1);
             files[0] = files[0] with { WorkItem = files[0].WorkItem with { FilePathInZip = "folder_001/file_00000001.pdf" } };
             var content = await this.CaptureCsvOutput(request, files);
@@ -459,12 +459,12 @@ namespace Zipper
         public async Task CsvWriter_MetadataHeader_ReflectsRequestConfiguration()
         {
             var request = this.CreateTestRequest();
-            request.WithMetadata = true;
+            request.Metadata = request.Metadata with { WithMetadata = true };
             var files = this.CreateTestFileData(1);
             var contentWith = await this.CaptureCsvOutput(request, files);
             Assert.Contains("Custodian", contentWith);
 
-            request.WithMetadata = false;
+            request.Metadata = request.Metadata with { WithMetadata = false };
             var contentWithout = await this.CaptureCsvOutput(request, files);
             Assert.DoesNotContain("Custodian", contentWithout);
 
@@ -492,13 +492,13 @@ namespace Zipper
         public async Task CsvWriter_PageCount_OnlyForTiffWithPageRange()
         {
             var request = this.CreateTestRequest("tiff");
-            request.TiffPageRange = (1, 10);
+            request.Tiff = request.Tiff with { PageRange = (1, 10) };
             var files = this.CreateTestFileData(1);
             files[0] = files[0] with { PageCount = 5 };
             var contentWith = await this.CaptureCsvOutput(request, files);
             Assert.Contains("Page Count", contentWith);
 
-            request.TiffPageRange = null;
+            request.Tiff = request.Tiff with { PageRange = null };
             var contentWithout = await this.CaptureCsvOutput(request, files);
             Assert.DoesNotContain("Page Count", contentWithout);
 
@@ -512,7 +512,7 @@ namespace Zipper
         public async Task CsvWriter_WithBatesConfig_WritesCorrectBatesNumber()
         {
             var request = this.CreateTestRequest();
-            request.BatesConfig = new BatesNumberConfig
+            request.Bates = new BatesNumberConfig
             {
                 Prefix = "TEST",
                 Start = 1000,
@@ -529,7 +529,7 @@ namespace Zipper
         public async Task CsvWriter_WithMetadata_ContainsCustodianAndFileSizeInDataRow()
         {
             var request = this.CreateTestRequest();
-            request.WithMetadata = true;
+            request.Metadata = request.Metadata with { WithMetadata = true };
             var files = this.CreateTestFileData(1);
             files[0] = files[0] with { DataLength = 1024, WorkItem = files[0].WorkItem with { FolderNumber = 5 } };
             var content = await this.CaptureCsvOutput(request, files);
@@ -608,7 +608,7 @@ namespace Zipper
             };
 
             var eol = "\r\n";
-            long totalLines = request.FileCount + 1;
+            long totalLines = request.Output.FileCount + 1;
             var chaos = new ChaosEngine(totalLines, "5", null, LoadFileFormat.Dat, "\u0014", "\u00fe", eol, 42);
 
             var writer = new LoadfileOnlyDatWriter();

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -68,8 +68,8 @@ namespace Zipper
         public async Task GenerateAsync_Dat_UsesConfiguredDelimiters()
         {
             var request = this.CreateRequest();
-            request.ColumnDelimiter = "\u0014";
-            request.QuoteDelimiter = "\u00fe";
+            request.Delimiters = request.Delimiters with { ColumnDelimiter = "\u0014" };
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = "\u00fe" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var content = await File.ReadAllTextAsync(result.LoadFilePath);
@@ -82,8 +82,8 @@ namespace Zipper
         public async Task GenerateAsync_Dat_WithQuoteDelimNone_OmitsQuotes()
         {
             var request = this.CreateRequest();
-            request.QuoteDelimiter = string.Empty;
-            request.ColumnDelimiter = "|";
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            request.Delimiters = request.Delimiters with { ColumnDelimiter = "|" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var firstLine = (await File.ReadAllLinesAsync(result.LoadFilePath))[0];
@@ -147,9 +147,9 @@ namespace Zipper
         public async Task GenerateAsync_WithChaos_PropertiesJsonContainsAnomalies()
         {
             var request = this.CreateRequest(count: 100);
-            request.ChaosMode = true;
-            request.ChaosAmount = "5";
-            request.Seed = 42;
+            request.Chaos = request.Chaos with { ChaosMode = true };
+            request.Chaos = request.Chaos with { ChaosAmount = "5" };
+            request.Metadata = request.Metadata with { Seed = 42 };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
 
@@ -164,7 +164,7 @@ namespace Zipper
         public async Task GenerateAsync_Dat_WithLfEol_UsesCorrectLineEndings()
         {
             var request = this.CreateRequest(count: 5);
-            request.EndOfLine = "LF";
+            request.Delimiters = request.Delimiters with { EndOfLine = "LF" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
@@ -179,7 +179,7 @@ namespace Zipper
         public async Task GenerateAsync_WithSeed_ProducesDeterministicOutput()
         {
             var request1 = this.CreateRequest(count: 10);
-            request1.Seed = 123;
+            request1.Metadata = request1.Metadata with { Seed = 123 };
             var result1 = await LoadfileOnlyGenerator.GenerateAsync(request1);
             var content1 = await File.ReadAllTextAsync(result1.LoadFilePath);
 
@@ -189,8 +189,8 @@ namespace Zipper
             try
             {
                 var request2 = this.CreateRequest(count: 10);
-                request2.Seed = 123;
-                request2.OutputPath = tempDir2;
+                request2.Metadata = request2.Metadata with { Seed = 123 };
+                request2.Output = request2.Output with { OutputPath = tempDir2 };
                 var result2 = await LoadfileOnlyGenerator.GenerateAsync(request2);
                 var content2 = await File.ReadAllTextAsync(result2.LoadFilePath);
 
@@ -247,7 +247,7 @@ namespace Zipper
         public async Task GenerateAsync_Dat_WithCrEol_UsesCorrectLineEndings()
         {
             var request = this.CreateRequest(count: 5);
-            request.EndOfLine = "CR";
+            request.Delimiters = request.Delimiters with { EndOfLine = "CR" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
@@ -261,7 +261,7 @@ namespace Zipper
         public async Task GenerateAsync_Dat_WithCrlfEol_Explicitly_UsesCrlf()
         {
             var request = this.CreateRequest(count: 5);
-            request.EndOfLine = "CRLF";
+            request.Delimiters = request.Delimiters with { EndOfLine = "CRLF" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
@@ -274,7 +274,7 @@ namespace Zipper
         public async Task GenerateAsync_Opt_WithLfEol_UsesCorrectLineEndings()
         {
             var request = this.CreateRequest(format: LoadFileFormat.Opt, count: 5);
-            request.EndOfLine = "LF";
+            request.Delimiters = request.Delimiters with { EndOfLine = "LF" };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
@@ -288,9 +288,9 @@ namespace Zipper
         public async Task GenerateAsync_WithChaos_HundredPercent_AllLinesCorrupted()
         {
             var request = this.CreateRequest(count: 20);
-            request.ChaosMode = true;
-            request.ChaosAmount = "100%";
-            request.Seed = 42;
+            request.Chaos = request.Chaos with { ChaosMode = true };
+            request.Chaos = request.Chaos with { ChaosAmount = "100%" };
+            request.Metadata = request.Metadata with { Seed = 42 };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
 
@@ -299,14 +299,14 @@ namespace Zipper
 
             // With 100% chaos, every line should have an anomaly (header + 20 data rows = 21 lines)
             var totalAnomalies = doc.RootElement.GetProperty("chaosMode").GetProperty("totalAnomalies").GetInt32();
-            Assert.Equal(1 + request.FileCount, totalAnomalies);
+            Assert.Equal(1 + request.Output.FileCount, totalAnomalies);
         }
 
         [Fact]
         public async Task GenerateAsync_WithNullEol_FallsBackToCrlf()
         {
             var request = this.CreateRequest(count: 3);
-            request.EndOfLine = string.Empty;
+            request.Delimiters = request.Delimiters with { EndOfLine = string.Empty };
 
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
@@ -332,12 +332,12 @@ namespace Zipper
         public async Task GenerateAsync_WithSeed_LoadfileOnly_DatAndOpt_BothDeterministic()
         {
             var request1 = this.CreateRequest(format: LoadFileFormat.Dat, count: 5);
-            request1.Seed = 42;
+            request1.Metadata = request1.Metadata with { Seed = 42 };
             var result1 = await LoadfileOnlyGenerator.GenerateAsync(request1);
             var content1 = await File.ReadAllTextAsync(result1.LoadFilePath);
 
             var request2 = this.CreateRequest(format: LoadFileFormat.Opt, count: 5);
-            request2.Seed = 42;
+            request2.Metadata = request2.Metadata with { Seed = 42 };
             var result2 = await LoadfileOnlyGenerator.GenerateAsync(request2);
             var content2 = await File.ReadAllTextAsync(result2.LoadFilePath);
 

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -67,11 +67,11 @@ public class ProductionSetTests : IDisposable
         var request = CommandLineValidator.ValidateAndParseArguments(args);
 
         Assert.NotNull(request);
-        Assert.True(request.ProductionSet);
-        Assert.Equal(50L, request.FileCount);
-        Assert.Equal("PROD", request.BatesConfig!.Prefix);
-        Assert.Equal(6, request.BatesConfig.Digits);
-        Assert.Equal(25, request.VolumeSize);
+        Assert.True(request.Production.ProductionSet);
+        Assert.Equal(50L, request.Output.FileCount);
+        Assert.Equal("PROD", request.Bates!.Prefix);
+        Assert.Equal(6, request.Bates.Digits);
+        Assert.Equal(25, request.Production.VolumeSize);
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class ProductionSetTests : IDisposable
         var request = CommandLineValidator.ValidateAndParseArguments(args);
 
         Assert.NotNull(request);
-        Assert.Equal(5000, request.VolumeSize);
+        Assert.Equal(5000, request.Production.VolumeSize);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class ProductionSetTests : IDisposable
         var request = CommandLineValidator.ValidateAndParseArguments(args);
 
         Assert.NotNull(request);
-        Assert.Equal("pdf", request.FileType);
+        Assert.Equal("pdf", request.Output.FileType);
     }
 
     // === End-to-End Generation Tests ===
@@ -217,7 +217,7 @@ public class ProductionSetTests : IDisposable
     public async Task ProductionSet_WithZip_CreatesArchive()
     {
         var request = this.CreateTestRequest(count: 3);
-        request.ProductionZip = true;
+        request.Production = request.Production with { ProductionZip = true };
         var result = await ProductionSetGenerator.GenerateAsync(request);
 
         Assert.NotNull(result.ZipFilePath);
@@ -229,7 +229,7 @@ public class ProductionSetTests : IDisposable
     public async Task ProductionSet_WithoutZip_NoArchive()
     {
         var request = this.CreateTestRequest(count: 3);
-        request.ProductionZip = false;
+        request.Production = request.Production with { ProductionZip = false };
         var result = await ProductionSetGenerator.GenerateAsync(request);
 
         Assert.Null(result.ZipFilePath);
@@ -415,7 +415,7 @@ public class ProductionSetTests : IDisposable
     public async Task ProductionSet_WithTiff_CreatesNativeFiles()
     {
         var request = this.CreateTestRequest(count: 3, fileType: "tiff");
-        request.TiffPageRange = (1, 5);
+        request.Tiff = request.Tiff with { PageRange = (1, 5) };
         var result = await ProductionSetGenerator.GenerateAsync(request);
 
         var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.tiff", SearchOption.AllDirectories);
@@ -432,7 +432,7 @@ public class ProductionSetTests : IDisposable
     public async Task ProductionSet_WithCustomEncoding_ProducesValidDat()
     {
         var request = this.CreateTestRequest(count: 3);
-        request.Encoding = "UTF-16";
+        request.LoadFile = request.LoadFile with { Encoding = "UTF-16" };
         var result = await ProductionSetGenerator.GenerateAsync(request);
 
         var datContent = await File.ReadAllTextAsync(result.DatFilePath, System.Text.Encoding.Unicode);


### PR DESCRIPTION
Rewrite all 106 call sites that access flat pass-through properties on `FileGenerationRequest` to go directly to the appropriate sub-config (`Output`, `Metadata`, `LoadFile`, `Delimiters`, `Bates`, `Tiff`, `Chaos`, `Production`).

Closes #212

## Summary

Phase F3 of the FGR refactor series. F1 (#210) added computed properties on sub-configs. F2 (#211) added the `FGR_FLAT_ACCESS` Roslyn analyzer (non-fatal). This PR rewrites every call site the analyzer flags — making `dotnet build` emit zero `FGR_FLAT_ACCESS` diagnostics. F4 (#213) will then delete the 35 flat pass-throughs and their backing helpers.

No semantic change — purely a form change.

## Changes

- **23 source files** across `src/` rewritten: all generators, modes, writers, load file writers, and supporting services
- **6 test files** updated: same sub-config access patterns applied to test code
- **Special cases handled correctly:**
  - `request.FileType.ToLowerInvariant()` → `request.Output.FileTypeLower` (computed property from F1)
  - `request.BatesConfig` → `request.Bates` (sub-config accessor rename)
  - `request.TiffPageRange` → `request.Tiff.PageRange` (property renamed on sub-config)
  - Setter assignments use record `with` expression syntax: `request.X = val` → `request.Sub = request.Sub with { X = val }`

## Verification

- All existing unit tests pass (unchanged semantics, just form change)
- `dotnet build` → 0 `FGR_FLAT_ACCESS` diagnostics
- Golden CI job (byte-diff all 15 scenarios pre/post) must pass green
- `dotnet format --verify-no-changes` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal configuration handling by consolidating related settings into nested, logically-grouped objects (encoding, delimiters, metadata, output controls, production parameters, and Bates numbering) to improve code organization and maintainability throughout the generation pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->