### PR TITLE
Email scaffold: create src/Emails/ with EmailTemplate, EmailAttachment, EmailCategory

### DIFF
--- a/src/EmailBuilder.cs
+++ b/src/EmailBuilder.cs
@@ -4,48 +4,6 @@ using System.Text;
 namespace Zipper
 {
     /// <summary>
-    /// Represents email metadata and content for building EML files.
-    /// </summary>
-    public record EmailTemplate
-    {
-        public string To { get; init; } = string.Empty;
-
-        public string From { get; init; } = string.Empty;
-
-        public string Subject { get; init; } = string.Empty;
-
-        public DateTime SentDate { get; init; } = DateTime.Now;
-
-        public string Body { get; init; } = string.Empty;
-
-        public string? Cc { get; init; }
-
-        public string? Bcc { get; init; }
-
-        public string? ReplyTo { get; init; }
-
-        public bool IsHighPriority { get; init; } = false;
-
-        public bool RequestReadReceipt { get; init; } = false;
-    }
-
-    /// <summary>
-    /// Represents attachment information for emails.
-    /// </summary>
-    public record AttachmentInfo
-    {
-        public string FileName { get; init; } = string.Empty;
-
-        public byte[] Content { get; init; } = Array.Empty<byte>();
-
-        public string? ContentType { get; init; }
-
-        public string? ContentId { get; init; }
-
-        public bool IsInline { get; init; } = false;
-    }
-
-    /// <summary>
     /// Builds EML email content with proper MIME formatting.
     /// </summary>
     public static class EmailBuilder

--- a/src/EmailTemplateSystem.cs
+++ b/src/EmailTemplateSystem.cs
@@ -6,25 +6,6 @@ namespace Zipper
     public static class EmailTemplateSystem
     {
         /// <summary>
-        /// Email template categories for variety.
-        /// </summary>
-        public enum EmailCategory
-        {
-            Business,
-            Personal,
-            Technical,
-            Marketing,
-            Legal,
-            Financial,
-            Notification,
-            Support,
-            Healthcare,
-            Education,
-            Ecommerce,
-            Travel,
-        }
-
-        /// <summary>
         /// Gets a random email template from the available categories.
         /// </summary>
         /// <param name="recipientIndex">Index used to generate recipient email.</param>
@@ -466,7 +447,7 @@ namespace Zipper
 
         public int SenderIndex { get; init; }
 
-        public EmailTemplateSystem.EmailCategory Category { get; init; }
+        public EmailCategory Category { get; init; }
 
         public int TemplateIndex { get; init; }
 

--- a/src/Emails/EmailAttachment.cs
+++ b/src/Emails/EmailAttachment.cs
@@ -1,0 +1,18 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Represents attachment information for emails.
+    /// </summary>
+    public record AttachmentInfo
+    {
+        public string FileName { get; init; } = string.Empty;
+
+        public byte[] Content { get; init; } = Array.Empty<byte>();
+
+        public string? ContentType { get; init; }
+
+        public string? ContentId { get; init; }
+
+        public bool IsInline { get; init; } = false;
+    }
+}

--- a/src/Emails/EmailCategory.cs
+++ b/src/Emails/EmailCategory.cs
@@ -1,0 +1,21 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Email template categories for variety.
+    /// </summary>
+    public enum EmailCategory
+    {
+        Business,
+        Personal,
+        Technical,
+        Marketing,
+        Legal,
+        Financial,
+        Notification,
+        Support,
+        Healthcare,
+        Education,
+        Ecommerce,
+        Travel,
+    }
+}

--- a/src/Emails/EmailTemplate.cs
+++ b/src/Emails/EmailTemplate.cs
@@ -1,0 +1,28 @@
+namespace Zipper
+{
+    /// <summary>
+    /// Represents email metadata and content for building EML files.
+    /// </summary>
+    public record EmailTemplate
+    {
+        public string To { get; init; } = string.Empty;
+
+        public string From { get; init; } = string.Empty;
+
+        public string Subject { get; init; } = string.Empty;
+
+        public DateTime SentDate { get; init; } = DateTime.Now;
+
+        public string Body { get; init; } = string.Empty;
+
+        public string? Cc { get; init; }
+
+        public string? Bcc { get; init; }
+
+        public string? ReplyTo { get; init; }
+
+        public bool IsHighPriority { get; init; } = false;
+
+        public bool RequestReadReceipt { get; init; } = false;
+    }
+}

--- a/src/EmlGenerationService.cs
+++ b/src/EmlGenerationService.cs
@@ -18,7 +18,7 @@ namespace Zipper
         /// <summary>
         /// Gets optional email category constraint.
         /// </summary>
-        public EmailTemplateSystem.EmailCategory? Category { get; init; }
+        public EmailCategory? Category { get; init; }
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ namespace Zipper
         public static EmlGenerationResult GenerateEmlContent(
             int fileIndex,
             int attachmentRate,
-            EmailTemplateSystem.EmailCategory? category = null)
+            EmailCategory? category = null)
         {
             var config = new EmlGenerationConfig
             {

--- a/src/Zipper.Tests/EmailTemplateSystemTests.cs
+++ b/src/Zipper.Tests/EmailTemplateSystemTests.cs
@@ -32,19 +32,19 @@ namespace Zipper
         }
 
         [Theory]
-        [InlineData(EmailTemplateSystem.EmailCategory.Business)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Personal)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Technical)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Marketing)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Legal)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Financial)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Notification)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Support)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Healthcare)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Education)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Ecommerce)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Travel)]
-        public void GetRandomTemplate_WithSpecificCategory_ReturnsCategorySpecificTemplates(EmailTemplateSystem.EmailCategory category)
+        [InlineData(EmailCategory.Business)]
+        [InlineData(EmailCategory.Personal)]
+        [InlineData(EmailCategory.Technical)]
+        [InlineData(EmailCategory.Marketing)]
+        [InlineData(EmailCategory.Legal)]
+        [InlineData(EmailCategory.Financial)]
+        [InlineData(EmailCategory.Notification)]
+        [InlineData(EmailCategory.Support)]
+        [InlineData(EmailCategory.Healthcare)]
+        [InlineData(EmailCategory.Education)]
+        [InlineData(EmailCategory.Ecommerce)]
+        [InlineData(EmailCategory.Travel)]
+        public void GetRandomTemplate_WithSpecificCategory_ReturnsCategorySpecificTemplates(EmailCategory category)
         {
             // Arrange
             const int recipientIndex = 10;
@@ -112,7 +112,7 @@ namespace Zipper
             {
                 RecipientIndex = 5,
                 SenderIndex = 10,
-                Category = EmailTemplateSystem.EmailCategory.Business,
+                Category = EmailCategory.Business,
                 TemplateIndex = 0,
                 SentDate = new DateTime(2023, 6, 15),
                 IsHighPriority = true,
@@ -168,7 +168,7 @@ namespace Zipper
             const int senderIndex = 2;
 
             // Act
-            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailTemplateSystem.EmailCategory.Business);
+            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailCategory.Business);
 
             // Assert
             Assert.NotNull(template);
@@ -191,7 +191,7 @@ namespace Zipper
             const int senderIndex = 2;
 
             // Act
-            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailTemplateSystem.EmailCategory.Healthcare);
+            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailCategory.Healthcare);
 
             // Assert
             Assert.NotNull(template);
@@ -213,7 +213,7 @@ namespace Zipper
             const int senderIndex = 2;
 
             // Act
-            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailTemplateSystem.EmailCategory.Education);
+            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailCategory.Education);
 
             // Assert
             Assert.NotNull(template);
@@ -234,7 +234,7 @@ namespace Zipper
             const int senderIndex = 2;
 
             // Act
-            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailTemplateSystem.EmailCategory.Ecommerce);
+            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailCategory.Ecommerce);
 
             // Assert
             Assert.NotNull(template);
@@ -255,7 +255,7 @@ namespace Zipper
             const int senderIndex = 2;
 
             // Act
-            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailTemplateSystem.EmailCategory.Travel);
+            var template = EmailTemplateSystem.GetRandomTemplate(recipientIndex, senderIndex, EmailCategory.Travel);
 
             // Assert
             Assert.NotNull(template);
@@ -274,10 +274,10 @@ namespace Zipper
             // Arrange
             var categories = new[]
             {
-                EmailTemplateSystem.EmailCategory.Healthcare,
-                EmailTemplateSystem.EmailCategory.Education,
-                EmailTemplateSystem.EmailCategory.Ecommerce,
-                EmailTemplateSystem.EmailCategory.Travel,
+                EmailCategory.Healthcare,
+                EmailCategory.Education,
+                EmailCategory.Ecommerce,
+                EmailCategory.Travel,
             };
 
             // Placeholders that SHOULD be replaced in body
@@ -311,9 +311,9 @@ namespace Zipper
         public void GetRandomTemplate_AllCategories_VarySentDateAppropriately()
         {
             // Arrange
-            var categories = Enum.GetValues<EmailTemplateSystem.EmailCategory>();
+            var categories = Enum.GetValues<EmailCategory>();
             var now = DateTime.Now;
-            var categoryDates = new System.Collections.Generic.Dictionary<EmailTemplateSystem.EmailCategory, TimeSpan>();
+            var categoryDates = new System.Collections.Generic.Dictionary<EmailCategory, TimeSpan>();
 
             // Act
             foreach (var category in categories)
@@ -327,19 +327,19 @@ namespace Zipper
             Assert.True(categoryDates.Count > 0);
 
             // Travel emails should potentially have a wider range (older dates possible)
-            var travelTime = categoryDates[EmailTemplateSystem.EmailCategory.Travel];
-            var supportTime = categoryDates[EmailTemplateSystem.EmailCategory.Support];
+            var travelTime = categoryDates[EmailCategory.Travel];
+            var supportTime = categoryDates[EmailCategory.Support];
 
             this.output.WriteLine($"Travel time difference: {travelTime.TotalDays:F1} days");
             this.output.WriteLine($"Support time difference: {supportTime.TotalDays:F1} days");
         }
 
         [Theory]
-        [InlineData(EmailTemplateSystem.EmailCategory.Healthcare)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Education)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Ecommerce)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Travel)]
-        public void GetRandomTemplate_NewCategories_HaveAppropriateCcAndReplyToRates(EmailTemplateSystem.EmailCategory category)
+        [InlineData(EmailCategory.Healthcare)]
+        [InlineData(EmailCategory.Education)]
+        [InlineData(EmailCategory.Ecommerce)]
+        [InlineData(EmailCategory.Travel)]
+        public void GetRandomTemplate_NewCategories_HaveAppropriateCcAndReplyToRates(EmailCategory category)
         {
             // Arrange
             const int iterations = 100;
@@ -383,8 +383,8 @@ namespace Zipper
             // Act
             for (int i = 0; i < iterations; i++)
             {
-                var businessTemplate = EmailTemplateSystem.GetRandomTemplate(i + 1, i + 2, EmailTemplateSystem.EmailCategory.Business);
-                var marketingTemplate = EmailTemplateSystem.GetRandomTemplate(i + 1, i + 2, EmailTemplateSystem.EmailCategory.Marketing);
+                var businessTemplate = EmailTemplateSystem.GetRandomTemplate(i + 1, i + 2, EmailCategory.Business);
+                var marketingTemplate = EmailTemplateSystem.GetRandomTemplate(i + 1, i + 2, EmailCategory.Marketing);
 
                 if (!string.IsNullOrEmpty(businessTemplate.Cc))
                 {
@@ -411,7 +411,7 @@ namespace Zipper
             {
                 RecipientIndex = 1,
                 SenderIndex = 2,
-                Category = EmailTemplateSystem.EmailCategory.Business,
+                Category = EmailCategory.Business,
                 TemplateIndex = 0,
             };
 

--- a/src/Zipper.Tests/EmlGenerationServiceTests.cs
+++ b/src/Zipper.Tests/EmlGenerationServiceTests.cs
@@ -21,7 +21,7 @@ namespace Zipper
             {
                 FileIndex = 1,
                 AttachmentRate = 0,
-                Category = EmailTemplateSystem.EmailCategory.Business,
+                Category = EmailCategory.Business,
             };
 
             // Act
@@ -102,15 +102,15 @@ namespace Zipper
         }
 
         [Theory]
-        [InlineData(EmailTemplateSystem.EmailCategory.Business)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Personal)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Technical)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Marketing)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Legal)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Financial)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Notification)]
-        [InlineData(EmailTemplateSystem.EmailCategory.Support)]
-        public void GenerateEmlContent_WithDifferentCategories_ReturnsCategorySpecificContent(EmailTemplateSystem.EmailCategory category)
+        [InlineData(EmailCategory.Business)]
+        [InlineData(EmailCategory.Personal)]
+        [InlineData(EmailCategory.Technical)]
+        [InlineData(EmailCategory.Marketing)]
+        [InlineData(EmailCategory.Legal)]
+        [InlineData(EmailCategory.Financial)]
+        [InlineData(EmailCategory.Notification)]
+        [InlineData(EmailCategory.Support)]
+        public void GenerateEmlContent_WithDifferentCategories_ReturnsCategorySpecificContent(EmailCategory category)
         {
             // Arrange
             var config = new EmlGenerationConfig
@@ -196,7 +196,7 @@ namespace Zipper
             // Arrange
             var fileIndex = 42;
             var attachmentRate = 75;
-            var category = EmailTemplateSystem.EmailCategory.Technical;
+            var category = EmailCategory.Technical;
 
             // Act - The two methods should behave similarly, though content may differ due to randomness
             var configResult = EmlGenerationService.GenerateEmlContent(
@@ -282,7 +282,7 @@ namespace Zipper
                 {
                     FileIndex = i,
                     AttachmentRate = 50,
-                    Category = (EmailTemplateSystem.EmailCategory)(i % 8),
+                    Category = (EmailCategory)(i % 8),
                 })
                 .ToList();
 
@@ -389,7 +389,7 @@ namespace Zipper
             {
                 FileIndex = 42,
                 AttachmentRate = 75,
-                Category = EmailTemplateSystem.EmailCategory.Business,
+                Category = EmailCategory.Business,
             };
 
             var config2 = config1 with { };


### PR DESCRIPTION
## Summary

Creates the `src/Emails/` scaffold by moving three types out of their current homes into the new namespace directory. No behaviour change — all types keep their existing names and the `Zipper` namespace.

## Changes

- **New** `src/Emails/EmailTemplate.cs` — `EmailTemplate` record extracted from `EmailBuilder.cs`
- **New** `src/Emails/EmailAttachment.cs` — `AttachmentInfo` record extracted from `EmailBuilder.cs`
- **New** `src/Emails/EmailCategory.cs` — `EmailCategory` enum promoted from nested inside `EmailTemplateSystem` to top-level
- **Modified** `src/EmailBuilder.cs` — `EmailTemplate` and `AttachmentInfo` records removed (now live in `src/Emails/`)
- **Modified** `src/EmailTemplateSystem.cs` — nested `EmailCategory` enum removed; `EmailContext.Category` type updated to top-level `EmailCategory`
- **Modified** `src/EmlGenerationService.cs` — `EmailTemplateSystem.EmailCategory` references updated to `EmailCategory`
- **Modified** `src/Zipper.Tests/EmailTemplateSystemTests.cs` — `EmailTemplateSystem.EmailCategory` references updated to `EmailCategory`
- **Modified** `src/Zipper.Tests/EmlGenerationServiceTests.cs` — `EmailTemplateSystem.EmailCategory` references updated to `EmailCategory`

## Verification

CI must pass:
- `build` — solution compiles with zero warnings (Warnings as Errors)
- `test` — all unit tests green
- `goldens` — E2E golden fixtures byte-identical

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized email-related type definitions into dedicated modules for improved code organization.
  * Moved `EmailTemplate` and `AttachmentInfo` records to separate files for better maintainability.
  * Introduced a top-level `EmailCategory` enum with support for multiple categories: Business, Personal, Technical, Marketing, Legal, Financial, Notification, Support, Healthcare, Education, Ecommerce, and Travel.
  * Updated service references to use the reorganized type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->