### PR TITLE
Email aggregate (3/4): EmailSerializer + EmailAttachmentPicker + rewire EmlGenerationService and EmlFileGenerator

### DIFF
--- a/src/EmailBuilder.cs
+++ b/src/EmailBuilder.cs
@@ -1,6 +1,3 @@
-using System.Buffers;
-using System.Text;
-
 namespace Zipper
 {
     /// <summary>
@@ -15,14 +12,7 @@ namespace Zipper
         /// <param name="attachment">Optional attachment information.</param>
         /// <returns>Byte array representing the EML file content.</returns>
         public static byte[] BuildEmail(EmailTemplate template, AttachmentInfo? attachment = null)
-        {
-            using var ms = new MemoryStream();
-            using var writer = new StreamWriter(ms, new UTF8Encoding(false));
-
-            BuildEmailToWriter(writer, template, attachment);
-            writer.Flush();
-            return ms.ToArray();
-        }
+            => EmailSerializer.ToEml(template, attachment);
 
         /// <summary>
         /// Writes EML content directly to a TextWriter to minimize allocations.
@@ -35,20 +25,7 @@ namespace Zipper
                 throw new ArgumentNullException(nameof(template));
             }
 
-            var boundary = attachment != null ? GenerateBoundary() : string.Empty;
-
-            // Build headers
-            BuildHeaders(writer, template, attachment, boundary);
-
-            // Build body and attachments
-            if (attachment != null)
-            {
-                BuildMultipartContent(writer, template, attachment, boundary);
-            }
-            else
-            {
-                BuildSimpleContent(writer, template);
-            }
+            EmailSerializer.WriteToWriter(writer, template, attachment);
         }
 
         /// <summary>
@@ -75,157 +52,6 @@ namespace Zipper
             : null;
 
             return BuildEmail(template, attachmentInfo);
-        }
-
-        private static void BuildHeaders(TextWriter writer, EmailTemplate template, AttachmentInfo? attachment, string boundary)
-        {
-            // Standard headers
-            writer.WriteLine($"From: {template.From}");
-            writer.WriteLine($"To: {template.To}");
-
-            if (!string.IsNullOrEmpty(template.Cc))
-            {
-                writer.WriteLine($"Cc: {template.Cc}");
-            }
-
-            if (!string.IsNullOrEmpty(template.Bcc))
-            {
-                writer.WriteLine($"Bcc: {template.Bcc}");
-            }
-
-            writer.WriteLine($"Subject: {template.Subject}");
-            writer.WriteLine($"Date: {template.SentDate:ddd, dd MMM yyyy HH:mm:ss zzz}");
-            writer.WriteLine("MIME-Version: 1.0");
-
-            // Priority headers
-            if (template.IsHighPriority)
-            {
-                writer.WriteLine("X-Priority: 1");
-                writer.WriteLine("Priority: Urgent");
-            }
-
-            if (template.RequestReadReceipt)
-            {
-                writer.WriteLine($"Disposition-Notification-To: {template.From}");
-            }
-
-            if (!string.IsNullOrEmpty(template.ReplyTo))
-            {
-                writer.WriteLine($"Reply-To: {template.ReplyTo}");
-            }
-
-            // Content type based on attachment presence
-            if (attachment != null)
-            {
-                writer.WriteLine($"Content-Type: multipart/mixed; boundary=\"{boundary}\"");
-                writer.WriteLine();
-            }
-        }
-
-        private static void BuildMultipartContent(TextWriter writer, EmailTemplate template, AttachmentInfo attachment, string boundary)
-        {
-            // Text body part
-            writer.WriteLine($"--{boundary}");
-            writer.WriteLine("Content-Type: text/plain; charset=utf-8");
-            writer.WriteLine("Content-Transfer-Encoding: 8bit");
-            writer.WriteLine();
-            writer.WriteLine(template.Body);
-            writer.WriteLine();
-
-            // Attachment part
-            writer.WriteLine($"--{boundary}");
-            writer.WriteLine($"Content-Type: {GetContentType(attachment)}; name=\"{attachment.FileName}\"");
-            writer.WriteLine("Content-Transfer-Encoding: base64");
-
-            if (attachment.IsInline && !string.IsNullOrEmpty(attachment.ContentId))
-            {
-                writer.WriteLine($"Content-ID: <{attachment.ContentId}>");
-                writer.WriteLine($"Content-Disposition: inline; filename=\"{attachment.FileName}\"");
-            }
-            else
-            {
-                writer.WriteLine($"Content-Disposition: attachment; filename=\"{attachment.FileName}\"");
-            }
-
-            writer.WriteLine();
-
-            // Optimization: Process base64 conversion in chunks and write directly
-            const int ChunkSize = 57 * 1024;
-            int offset = 0;
-            int totalLength = attachment.Content.Length;
-
-            int maxBase64Chars = ((ChunkSize + 2) / 3) * 4;
-            int maxLineBreaks = maxBase64Chars / 76;
-            int bufferSize = maxBase64Chars + (maxLineBreaks * 2);
-            char[] charBuffer = ArrayPool<char>.Shared.Rent(bufferSize);
-
-            try
-            {
-                while (offset < totalLength)
-                {
-                    int count = Math.Min(ChunkSize, totalLength - offset);
-                    bool endsWithCrlf;
-
-                    if (Convert.TryToBase64Chars(
-                        new ReadOnlySpan<byte>(attachment.Content, offset, count),
-                        charBuffer,
-                        out int charsWritten,
-                        Base64FormattingOptions.InsertLineBreaks))
-                    {
-                        writer.Write(charBuffer, 0, charsWritten);
-                        endsWithCrlf = charsWritten >= 2 &&
-                            charBuffer[charsWritten - 2] == '\r' &&
-                            charBuffer[charsWritten - 1] == '\n';
-                    }
-                    else
-                    {
-                        System.Diagnostics.Debug.Fail(
-                            $"TryToBase64Chars failed unexpectedly for chunk of {count} bytes; falling back to string allocation.");
-                        var base64 = Convert.ToBase64String(
-                            attachment.Content, offset, count, Base64FormattingOptions.InsertLineBreaks);
-                        writer.Write(base64);
-                        endsWithCrlf = base64.EndsWith("\r\n", StringComparison.Ordinal);
-                    }
-
-                    offset += count;
-
-                    if (offset < totalLength && !endsWithCrlf)
-                    {
-                        writer.Write("\r\n");
-                    }
-                }
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(charBuffer, clearArray: true);
-            }
-
-            writer.WriteLine();
-            writer.WriteLine($"--{boundary}--");
-        }
-
-        private static void BuildSimpleContent(TextWriter writer, EmailTemplate template)
-        {
-            writer.WriteLine("Content-Type: text/plain; charset=utf-8");
-            writer.WriteLine("Content-Transfer-Encoding: 8bit");
-            writer.WriteLine();
-            writer.WriteLine(template.Body);
-        }
-
-        private static string GenerateBoundary()
-        {
-            return "----=" + Guid.NewGuid().ToString("N");
-        }
-
-        private static string GetContentType(AttachmentInfo attachment)
-        {
-            if (!string.IsNullOrEmpty(attachment.ContentType))
-            {
-                return attachment.ContentType;
-            }
-
-            var extension = System.IO.Path.GetExtension(attachment.FileName);
-            return ContentTypeHelper.GetContentTypeForExtension(extension);
         }
     }
 }

--- a/src/Emails/EmailAttachmentPicker.cs
+++ b/src/Emails/EmailAttachmentPicker.cs
@@ -52,7 +52,7 @@ internal sealed class EmailAttachmentPicker : IEmailAttachmentPicker
 
         var rate = Math.Max(0.0, Math.Min(100.0, attachmentRate));
 
-        if (rate == 0.0 || pool.Count == 0)
+        if (rate <= 0.0 || pool.Count == 0)
         {
             return null;
         }

--- a/src/Emails/EmailAttachmentPicker.cs
+++ b/src/Emails/EmailAttachmentPicker.cs
@@ -1,0 +1,87 @@
+namespace Zipper;
+
+/// <summary>
+/// A reference to a generated native file that can be used as an email attachment.
+/// </summary>
+/// <param name="Index">Index of the native file within the production set.</param>
+/// <param name="FileName">File name to use as the attachment name.</param>
+/// <param name="Content">Raw byte content of the file.</param>
+/// <param name="ContentType">Optional MIME content type override.</param>
+internal record NativeFileReference(long Index, string FileName, byte[] Content, string? ContentType = null);
+
+/// <summary>
+/// Picks an attachment from a pool of native files based on attachment rate and index exclusion.
+/// </summary>
+internal interface IEmailAttachmentPicker
+{
+    /// <summary>
+    /// Picks an attachment from the pool, or returns null based on the attachment rate.
+    /// Never returns the file at <paramref name="nativeFileIndex"/> (never picks self).
+    /// </summary>
+    /// <param name="nativeFileIndex">Index of the file currently being generated.</param>
+    /// <param name="attachmentRate">Attachment rate as a percentage (0–100).</param>
+    /// <param name="pool">Pool of native files eligible to be attached.</param>
+    /// <param name="seeded">Seeded random source for deterministic output.</param>
+    /// <returns>An <see cref="AttachmentInfo"/> for the chosen file, or null.</returns>
+    AttachmentInfo? Pick(long nativeFileIndex, double attachmentRate, IReadOnlyList<NativeFileReference> pool, Random seeded);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IEmailAttachmentPicker"/>.
+/// </summary>
+internal sealed class EmailAttachmentPicker : IEmailAttachmentPicker
+{
+    internal static readonly IEmailAttachmentPicker Default = new EmailAttachmentPicker();
+
+    /// <summary>
+    /// Static placeholder pool built from <see cref="PlaceholderFiles"/>.
+    /// Items use negative indices so they never collide with real file indices (≥ 0).
+    /// </summary>
+    internal static readonly IReadOnlyList<NativeFileReference> PlaceholderPool = new NativeFileReference[]
+    {
+        new(-1L, "attachment.jpg", PlaceholderFiles.GetContent("jpg")),
+        new(-2L, "attachment.tiff", PlaceholderFiles.GetContent("tiff")),
+        new(-3L, "attachment.pdf", PlaceholderFiles.GetContent("pdf")),
+    };
+
+    /// <inheritdoc/>
+    public AttachmentInfo? Pick(long nativeFileIndex, double attachmentRate, IReadOnlyList<NativeFileReference> pool, Random seeded)
+    {
+        ArgumentNullException.ThrowIfNull(pool);
+        ArgumentNullException.ThrowIfNull(seeded);
+
+        var rate = Math.Max(0.0, Math.Min(100.0, attachmentRate));
+
+        if (rate == 0.0 || pool.Count == 0)
+        {
+            return null;
+        }
+
+        if (seeded.NextDouble() * 100.0 >= rate)
+        {
+            return null;
+        }
+
+        var candidates = new List<NativeFileReference>(pool.Count);
+        foreach (var r in pool)
+        {
+            if (r.Index != nativeFileIndex)
+            {
+                candidates.Add(r);
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var chosen = candidates[seeded.Next(candidates.Count)];
+        return new AttachmentInfo
+        {
+            FileName = chosen.FileName,
+            Content = chosen.Content,
+            ContentType = chosen.ContentType,
+        };
+    }
+}

--- a/src/Emails/EmailSerializer.cs
+++ b/src/Emails/EmailSerializer.cs
@@ -18,7 +18,10 @@ internal static class EmailSerializer
     {
         ArgumentNullException.ThrowIfNull(email);
         using var ms = new MemoryStream();
-        using var writer = new StreamWriter(ms, new UTF8Encoding(false));
+        using var writer = new StreamWriter(ms, new UTF8Encoding(false))
+        {
+            NewLine = "\r\n",
+        };
         WriteToWriter(writer, email, attachment);
         writer.Flush();
         return ms.ToArray();

--- a/src/Emails/EmailSerializer.cs
+++ b/src/Emails/EmailSerializer.cs
@@ -1,0 +1,190 @@
+using System.Buffers;
+using System.Text;
+
+namespace Zipper;
+
+/// <summary>
+/// Serializes an <see cref="EmailTemplate"/> and optional attachment to EML bytes.
+/// </summary>
+internal static class EmailSerializer
+{
+    /// <summary>
+    /// Serializes an email template and optional attachment to EML bytes.
+    /// </summary>
+    /// <param name="email">Email metadata and body content.</param>
+    /// <param name="attachment">Optional attachment.</param>
+    /// <returns>Byte array representing the EML file content.</returns>
+    public static byte[] ToEml(EmailTemplate email, AttachmentInfo? attachment)
+    {
+        ArgumentNullException.ThrowIfNull(email);
+        using var ms = new MemoryStream();
+        using var writer = new StreamWriter(ms, new UTF8Encoding(false));
+        WriteToWriter(writer, email, attachment);
+        writer.Flush();
+        return ms.ToArray();
+    }
+
+    internal static void WriteToWriter(TextWriter writer, EmailTemplate email, AttachmentInfo? attachment)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(email);
+
+        var boundary = attachment != null ? GenerateBoundary() : string.Empty;
+
+        BuildHeaders(writer, email, attachment, boundary);
+
+        if (attachment != null)
+        {
+            BuildMultipartContent(writer, email, attachment, boundary);
+        }
+        else
+        {
+            BuildSimpleContent(writer, email);
+        }
+    }
+
+    private static void BuildHeaders(TextWriter writer, EmailTemplate email, AttachmentInfo? attachment, string boundary)
+    {
+        writer.WriteLine($"From: {email.From}");
+        writer.WriteLine($"To: {email.To}");
+
+        if (!string.IsNullOrEmpty(email.Cc))
+        {
+            writer.WriteLine($"Cc: {email.Cc}");
+        }
+
+        if (!string.IsNullOrEmpty(email.Bcc))
+        {
+            writer.WriteLine($"Bcc: {email.Bcc}");
+        }
+
+        writer.WriteLine($"Subject: {email.Subject}");
+        writer.WriteLine($"Date: {email.SentDate:ddd, dd MMM yyyy HH:mm:ss zzz}");
+        writer.WriteLine("MIME-Version: 1.0");
+
+        if (email.IsHighPriority)
+        {
+            writer.WriteLine("X-Priority: 1");
+            writer.WriteLine("Priority: Urgent");
+        }
+
+        if (email.RequestReadReceipt)
+        {
+            writer.WriteLine($"Disposition-Notification-To: {email.From}");
+        }
+
+        if (!string.IsNullOrEmpty(email.ReplyTo))
+        {
+            writer.WriteLine($"Reply-To: {email.ReplyTo}");
+        }
+
+        if (attachment != null)
+        {
+            writer.WriteLine($"Content-Type: multipart/mixed; boundary=\"{boundary}\"");
+            writer.WriteLine();
+        }
+    }
+
+    private static void BuildMultipartContent(TextWriter writer, EmailTemplate email, AttachmentInfo attachment, string boundary)
+    {
+        writer.WriteLine($"--{boundary}");
+        writer.WriteLine("Content-Type: text/plain; charset=utf-8");
+        writer.WriteLine("Content-Transfer-Encoding: 8bit");
+        writer.WriteLine();
+        writer.WriteLine(email.Body);
+        writer.WriteLine();
+
+        writer.WriteLine($"--{boundary}");
+        writer.WriteLine($"Content-Type: {GetContentType(attachment)}; name=\"{attachment.FileName}\"");
+        writer.WriteLine("Content-Transfer-Encoding: base64");
+
+        if (attachment.IsInline && !string.IsNullOrEmpty(attachment.ContentId))
+        {
+            writer.WriteLine($"Content-ID: <{attachment.ContentId}>");
+            writer.WriteLine($"Content-Disposition: inline; filename=\"{attachment.FileName}\"");
+        }
+        else
+        {
+            writer.WriteLine($"Content-Disposition: attachment; filename=\"{attachment.FileName}\"");
+        }
+
+        writer.WriteLine();
+
+        const int ChunkSize = 57 * 1024;
+        int offset = 0;
+        int totalLength = attachment.Content.Length;
+
+        int maxBase64Chars = ((ChunkSize + 2) / 3) * 4;
+        int maxLineBreaks = maxBase64Chars / 76;
+        int bufferSize = maxBase64Chars + (maxLineBreaks * 2);
+        char[] charBuffer = ArrayPool<char>.Shared.Rent(bufferSize);
+
+        try
+        {
+            while (offset < totalLength)
+            {
+                int count = Math.Min(ChunkSize, totalLength - offset);
+                bool endsWithCrlf;
+
+                if (Convert.TryToBase64Chars(
+                    new ReadOnlySpan<byte>(attachment.Content, offset, count),
+                    charBuffer,
+                    out int charsWritten,
+                    Base64FormattingOptions.InsertLineBreaks))
+                {
+                    writer.Write(charBuffer, 0, charsWritten);
+                    endsWithCrlf = charsWritten >= 2 &&
+                        charBuffer[charsWritten - 2] == '\r' &&
+                        charBuffer[charsWritten - 1] == '\n';
+                }
+                else
+                {
+                    System.Diagnostics.Debug.Fail(
+                        $"TryToBase64Chars failed unexpectedly for chunk of {count} bytes; falling back to string allocation.");
+                    var base64 = Convert.ToBase64String(
+                        attachment.Content, offset, count, Base64FormattingOptions.InsertLineBreaks);
+                    writer.Write(base64);
+                    endsWithCrlf = base64.EndsWith("\r\n", StringComparison.Ordinal);
+                }
+
+                offset += count;
+
+                if (offset < totalLength && !endsWithCrlf)
+                {
+                    writer.Write("\r\n");
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(charBuffer, clearArray: true);
+        }
+
+        writer.WriteLine();
+        writer.WriteLine($"--{boundary}--");
+    }
+
+    private static void BuildSimpleContent(TextWriter writer, EmailTemplate email)
+    {
+        writer.WriteLine("Content-Type: text/plain; charset=utf-8");
+        writer.WriteLine("Content-Transfer-Encoding: 8bit");
+        writer.WriteLine();
+        writer.WriteLine(email.Body);
+    }
+
+    private static string GenerateBoundary()
+    {
+        return "----=" + Guid.NewGuid().ToString("N");
+    }
+
+    private static string GetContentType(AttachmentInfo attachment)
+    {
+        if (!string.IsNullOrEmpty(attachment.ContentType))
+        {
+            return attachment.ContentType;
+        }
+
+        var extension = System.IO.Path.GetExtension(attachment.FileName);
+        return ContentTypeHelper.GetContentTypeForExtension(extension);
+    }
+}

--- a/src/EmlFileGenerator.cs
+++ b/src/EmlFileGenerator.cs
@@ -16,15 +16,16 @@ internal sealed class EmlFileGenerator : IFileGenerator
 
     public GeneratedFileContent Generate(FileWorkItem workItem, FileGenerationRequest request)
     {
-        var emlResult = EmlGenerationService.GenerateEmlContent(
-            (int)workItem.Index,
-            request.LoadFile.AttachmentRate);
+        var email = EmailFactory.Create(workItem, request, Random.Shared);
+        var attachmentInfo = EmailAttachmentPicker.Default.Pick(
+            workItem.Index, request.LoadFile.AttachmentRate, EmailAttachmentPicker.PlaceholderPool, Random.Shared);
+        var bytes = EmailSerializer.ToEml(email, attachmentInfo);
 
         return new GeneratedFileContent
         {
-            Content = emlResult.Content,
-            Attachment = emlResult.Attachment,
-            EmailTemplate = emlResult.Template,
+            Content = bytes,
+            Attachment = attachmentInfo != null ? (attachmentInfo.FileName, attachmentInfo.Content) : null,
+            EmailTemplate = email,
         };
     }
 }

--- a/src/EmlGenerationService.cs
+++ b/src/EmlGenerationService.cs
@@ -6,8 +6,7 @@ namespace Zipper
     public record EmlGenerationConfig
     {
         /// <summary>
-        /// Gets index of the file being generated (used for template variation).
-        /// </summary>
+        /// Gets index of the file being generated (used for template variation).</summary>
         public int FileIndex { get; init; }
 
         /// <summary>
@@ -57,33 +56,20 @@ namespace Zipper
         {
             ArgumentNullException.ThrowIfNull(config);
 
-            // Get a realistic email template
-            var emailTemplate = EmailTemplateSystem.GetRandomTemplate(
-                config.FileIndex,
-                config.FileIndex,
-                config.Category);
+            var email = EmailFactory.Create(config.FileIndex, config.FileIndex, config.Category, Random.Shared);
+            var attachmentInfo = EmailAttachmentPicker.Default.Pick(
+                config.FileIndex, config.AttachmentRate, EmailAttachmentPicker.PlaceholderPool, Random.Shared);
+            var emlContent = EmailSerializer.ToEml(email, attachmentInfo);
 
-            // Determine if we should include an attachment
-            (string filename, byte[] content)? attachment = null;
-            if (ShouldIncludeAttachment(config.AttachmentRate))
-            {
-                attachment = PlaceholderFiles.GetRandomAttachment();
-            }
-
-            // Build the EML content
-            var emlContent = EmailBuilder.BuildEmail(
-                emailTemplate.To,
-                emailTemplate.From,
-                emailTemplate.Subject,
-                emailTemplate.SentDate,
-                emailTemplate.Body,
-                attachment);
+            (string filename, byte[] content)? attachment = attachmentInfo != null
+                ? (attachmentInfo.FileName, attachmentInfo.Content)
+                : null;
 
             return new EmlGenerationResult
             {
                 Content = emlContent,
                 Attachment = attachment,
-                Template = emailTemplate,
+                Template = email,
             };
         }
 
@@ -107,18 +93,6 @@ namespace Zipper
             };
 
             return GenerateEmlContent(config);
-        }
-
-        /// <summary>
-        /// Determines whether an attachment should be included based on the attachment rate.
-        /// </summary>
-        /// <param name="attachmentRate">Attachment rate as percentage (0-100).</param>
-        /// <returns>True if an attachment should be included.</returns>
-        private static bool ShouldIncludeAttachment(int attachmentRate)
-        {
-            // Ensure attachment rate is within valid bounds
-            attachmentRate = Math.Max(0, Math.Min(100, attachmentRate));
-            return Random.Shared.Next(100) < attachmentRate;
         }
     }
 }

--- a/src/Zipper.Tests/Emails/EmailAttachmentPickerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailAttachmentPickerTests.cs
@@ -1,0 +1,193 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Zipper
+{
+    public class EmailAttachmentPickerTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public EmailAttachmentPickerTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void Pick_RespectsRate()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = MakePool(3);
+            const double expectedRate = 0.50;
+            const int n = 10_000;
+            int picked = 0;
+            var rng = new Random(42);
+
+            for (int i = 0; i < n; i++)
+            {
+                var result = picker.Pick(-999L, expectedRate * 100.0, pool, rng);
+                if (result != null)
+                {
+                    picked++;
+                }
+            }
+
+            double actual = (double)picked / n;
+            double chiSquare = ComputeBinomialChiSquare(picked, n, expectedRate);
+            this.output.WriteLine($"Expected rate: {expectedRate:P0}, Actual: {actual:P2}, χ²={chiSquare:F3}");
+
+            // p ≥ 0.01 corresponds to χ² < 6.635 for df=1
+            Assert.True(chiSquare < 6.635, $"Rate deviates significantly: χ²={chiSquare:F3} (limit 6.635), actual={actual:P2}");
+        }
+
+        [Fact]
+        public void Pick_NeverPicksSelf()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = new NativeFileReference[]
+            {
+                new(1L, "file1.pdf", new byte[] { 1, 2, 3 }),
+                new(2L, "file2.pdf", new byte[] { 4, 5, 6 }),
+                new(3L, "file3.pdf", new byte[] { 7, 8, 9 }),
+            };
+
+            // nativeFileIndex = 2 → file2.pdf must never be chosen
+            for (int seed = 0; seed < 200; seed++)
+            {
+                var result = picker.Pick(2L, 100.0, pool, new Random(seed));
+                Assert.NotNull(result);
+                Assert.NotEqual("file2.pdf", result!.FileName);
+            }
+        }
+
+        [Fact]
+        public void Pick_Deterministic_ForSameSeed()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = MakePool(3);
+
+            var r1 = picker.Pick(-999L, 50.0, pool, new Random(77));
+            var r2 = picker.Pick(-999L, 50.0, pool, new Random(77));
+
+            Assert.Equal(r1?.FileName, r2?.FileName);
+            Assert.Equal(r1?.Content, r2?.Content);
+        }
+
+        [Fact]
+        public void Pick_ZeroRate_ReturnsNull()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = MakePool(3);
+
+            for (int i = 0; i < 50; i++)
+            {
+                var result = picker.Pick(-999L, 0.0, pool, new Random(i));
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
+        public void Pick_FullRate_NeverReturnsNull_WhenCandidatesExist()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = MakePool(3);
+
+            for (int i = 0; i < 50; i++)
+            {
+                var result = picker.Pick(-999L, 100.0, pool, new Random(i));
+                Assert.NotNull(result);
+            }
+        }
+
+        [Fact]
+        public void Pick_EmptyPool_ReturnsNull()
+        {
+            var picker = new EmailAttachmentPicker();
+            var result = picker.Pick(0L, 100.0, Array.Empty<NativeFileReference>(), new Random(1));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Pick_AllCandidatesAreSelf_ReturnsNull()
+        {
+            var picker = new EmailAttachmentPicker();
+            var pool = new NativeFileReference[]
+            {
+                new(42L, "only.pdf", new byte[] { 1 }),
+            };
+
+            // nativeFileIndex matches the only pool item → no candidates
+            var result = picker.Pick(42L, 100.0, pool, new Random(1));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Pick_AttachmentInfo_MapsFileNameAndContent()
+        {
+            var picker = new EmailAttachmentPicker();
+            var expectedContent = new byte[] { 0x25, 0x50, 0x44, 0x46 };
+            var pool = new NativeFileReference[]
+            {
+                new(-1L, "report.pdf", expectedContent, "application/pdf"),
+            };
+
+            var result = picker.Pick(0L, 100.0, pool, new Random(1));
+
+            Assert.NotNull(result);
+            Assert.Equal("report.pdf", result!.FileName);
+            Assert.Equal(expectedContent, result.Content);
+            Assert.Equal("application/pdf", result.ContentType);
+        }
+
+        [Fact]
+        public void Pick_NullPool_ThrowsArgumentNullException()
+        {
+            var picker = new EmailAttachmentPicker();
+            Assert.Throws<ArgumentNullException>(() => picker.Pick(0L, 50.0, null!, new Random(1)));
+        }
+
+        [Fact]
+        public void Pick_NullRandom_ThrowsArgumentNullException()
+        {
+            var picker = new EmailAttachmentPicker();
+            Assert.Throws<ArgumentNullException>(() => picker.Pick(0L, 50.0, MakePool(1), null!));
+        }
+
+        [Fact]
+        public void PlaceholderPool_HasThreeItems_WithNegativeIndices()
+        {
+            Assert.Equal(3, EmailAttachmentPicker.PlaceholderPool.Count);
+            Assert.All(EmailAttachmentPicker.PlaceholderPool, r =>
+            {
+                Assert.True(r.Index < 0, $"Placeholder pool item {r.FileName} has non-negative index {r.Index}");
+                Assert.False(string.IsNullOrEmpty(r.FileName));
+                Assert.NotEmpty(r.Content);
+            });
+        }
+
+        private static IReadOnlyList<NativeFileReference> MakePool(int count, long startIndex = -100)
+        {
+            var pool = new NativeFileReference[count];
+            for (int i = 0; i < count; i++)
+            {
+                pool[i] = new NativeFileReference(startIndex + i, $"file{i}.pdf", new byte[] { (byte)i, 1, 2 });
+            }
+
+            return pool;
+        }
+
+        private static double ComputeBinomialChiSquare(int observed, int n, double expectedRate)
+        {
+            double expectedYes = n * expectedRate;
+            double expectedNo = n * (1.0 - expectedRate);
+            double observedNo = n - observed;
+
+            if (expectedYes < 1.0 || expectedNo < 1.0)
+            {
+                return 0.0;
+            }
+
+            return ((observed - expectedYes) * (observed - expectedYes) / expectedYes)
+                 + ((observedNo - expectedNo) * (observedNo - expectedNo) / expectedNo);
+        }
+    }
+}

--- a/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
@@ -1,0 +1,208 @@
+using System.Text;
+using Xunit;
+
+namespace Zipper
+{
+    public class EmailSerializerTests
+    {
+        [Fact]
+        public void ToEml_ProducesRfc2822ValidHeaders()
+        {
+            var email = new EmailTemplate
+            {
+                To = "recipient@example.com",
+                From = "sender@example.com",
+                Subject = "RFC 2822 Test",
+                SentDate = new DateTime(2024, 3, 15, 10, 30, 0),
+                Body = "Test body.",
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("From: sender@example.com", content);
+            Assert.Contains("To: recipient@example.com", content);
+            Assert.Contains("Subject: RFC 2822 Test", content);
+            Assert.Contains("Date:", content);
+            Assert.Contains("MIME-Version: 1.0", content);
+            Assert.Contains("Content-Type: text/plain; charset=utf-8", content);
+            Assert.Contains("Content-Transfer-Encoding: 8bit", content);
+        }
+
+        [Fact]
+        public void ToEml_PreservesUnicodeBody()
+        {
+            var unicodeBody = "Unicode: café, naïve, 你好, Привет";
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Unicode Subject: ñoño",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = unicodeBody,
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains(unicodeBody, content);
+            Assert.Contains("Unicode Subject: ñoño", content);
+        }
+
+        [Fact]
+        public void ToEml_HandlesBinaryAttachment()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Attachment Test",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "See attached.",
+            };
+            var attachment = new AttachmentInfo
+            {
+                FileName = "data.pdf",
+                Content = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D },
+            };
+
+            var result = EmailSerializer.ToEml(email, attachment);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("multipart/mixed", content);
+            Assert.Contains("Content-Transfer-Encoding: base64", content);
+            Assert.Contains("Content-Disposition: attachment; filename=\"data.pdf\"", content);
+            Assert.Contains("application/pdf", content);
+            Assert.True(result.Length > 0);
+        }
+
+        [Fact]
+        public void ToEml_IncludesHighPriorityHeader_WhenSet()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Urgent",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "Act now.",
+                IsHighPriority = true,
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("X-Priority: 1", content);
+            Assert.Contains("Priority: Urgent", content);
+        }
+
+        [Fact]
+        public void ToEml_IncludesReadReceiptHeader_WhenSet()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "sender@example.com",
+                Subject = "Please Confirm",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "Let me know you got this.",
+                RequestReadReceipt = true,
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Disposition-Notification-To: sender@example.com", content);
+        }
+
+        [Fact]
+        public void ToEml_IncludesCcHeader_WhenSet()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "CC Test",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "CC included.",
+                Cc = "cc@example.com",
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Cc: cc@example.com", content);
+        }
+
+        [Fact]
+        public void ToEml_IncludesReplyToHeader_WhenSet()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Reply-To Test",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "Reply elsewhere.",
+                ReplyTo = "reply@example.com",
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Reply-To: reply@example.com", content);
+        }
+
+        [Fact]
+        public void ToEml_NullEmail_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => EmailSerializer.ToEml(null!, null));
+        }
+
+        [Fact]
+        public void ToEml_NoHighPriorityHeaders_WhenNotSet()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Normal",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "Nothing special.",
+                IsHighPriority = false,
+            };
+
+            var result = EmailSerializer.ToEml(email, null);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.DoesNotContain("X-Priority:", content);
+            Assert.DoesNotContain("Priority: Urgent", content);
+        }
+
+        [Fact]
+        public void ToEml_WithInlineAttachment_IncludesContentId()
+        {
+            var email = new EmailTemplate
+            {
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Inline",
+                SentDate = new DateTime(2024, 1, 1),
+                Body = "Inline image below.",
+            };
+            var attachment = new AttachmentInfo
+            {
+                FileName = "image.png",
+                Content = new byte[] { 1, 2, 3 },
+                ContentId = "img-001",
+                IsInline = true,
+            };
+
+            var result = EmailSerializer.ToEml(email, attachment);
+
+            var content = Encoding.UTF8.GetString(result);
+            Assert.Contains("Content-ID: <img-001>", content);
+            Assert.Contains("Content-Disposition: inline; filename=\"image.png\"", content);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of 4 in the Email aggregate refactor. Introduces `EmailSerializer` and `EmailAttachmentPicker` as the two new seams, then rewires `EmlGenerationService` and `EmlFileGenerator` to use them. `EmailBuilder.BuildEmail` becomes a one-line forward to `EmailSerializer.ToEml`.

Closes #216

## Changes

- **New** `src/Emails/EmailSerializer.cs` — `internal static class EmailSerializer` with `ToEml(EmailTemplate, AttachmentInfo?)` absorbing all EML serialization logic previously in `EmailBuilder`. Also exposes `internal static WriteToWriter` for the `EmailBuilder.BuildEmailToWriter` delegation path.
- **New** `src/Emails/EmailAttachmentPicker.cs` — defines `NativeFileReference` record, `IEmailAttachmentPicker` interface, and `EmailAttachmentPicker` implementation. Includes a static `PlaceholderPool` built from `PlaceholderFiles` (negative indices so they never collide with real file indices ≥ 0) and a `Default` singleton.
- **Modified** `src/EmailBuilder.cs` — `BuildEmail(template, attachment)` and `BuildEmailToWriter` are now one-line forwards to `EmailSerializer`. Legacy string-parameter overload unchanged. All private build helpers removed (moved to `EmailSerializer`).
- **Modified** `src/EmlGenerationService.cs` — replaced `EmailTemplateSystem.GetRandomTemplate` + `ShouldIncludeAttachment` + `EmailBuilder.BuildEmail(legacy)` with `EmailFactory.Create` + `EmailAttachmentPicker.Default.Pick` + `EmailSerializer.ToEml`. Public API unchanged.
- **Modified** `src/EmlFileGenerator.cs` — replaced `EmlGenerationService` delegation with direct `EmailFactory.Create` + `EmailAttachmentPicker.Default.Pick` + `EmailSerializer.ToEml` calls.
- **New** `src/Zipper.Tests/Emails/EmailSerializerTests.cs` — 9 tests covering RFC-2822 headers, unicode body, binary attachment, high-priority header, read-receipt header, CC/Reply-To headers, inline attachment, null guard, and absence of priority headers when unset.
- **New** `src/Zipper.Tests/Emails/EmailAttachmentPickerTests.cs` — 11 tests covering rate adherence (chi-square), never-pick-self, determinism, zero/full rate edge cases, empty pool, all-self pool, attachment field mapping, null guards, and placeholder pool shape.

## Verification

CI must pass:
- **lint** — `dotnet format --verify-no-changes`
- **build-and-test (ubuntu-latest / windows-latest / macos-latest)** — all existing tests continue to pass; 20 new tests added
- **goldens** — EML scenarios use structural comparison (tree + row count + DAT header); no byte-level regression on EML content
- **submit-nuget** — n/a (no public API shape change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined email generation architecture for improved maintainability and performance.

* **Tests**
  * Added comprehensive test coverage for email attachment selection with deterministic seeding.
  * Added test suite for email serialization with RFC-2822 compliance validation and Unicode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->