### PR TITLE
🧪 Add test coverage for InverseNormalCDF edge cases

### DIFF
--- a/src/Zipper.Tests/DistributionAlgorithmTests.cs
+++ b/src/Zipper.Tests/DistributionAlgorithmTests.cs
@@ -115,8 +115,12 @@ namespace Zipper.Tests
 
         [Theory]
         [InlineData(0.5, 0.0)] // Middle probability
-        [InlineData(0.025, -1.96)] // Low probability
-        [InlineData(0.975, 1.96)] // High probability
+        [InlineData(0.025, -1.96)] // Low probability (central region)
+        [InlineData(0.975, 1.96)] // High probability (central region)
+        [InlineData(0.01, -2.326)] // Lower region (p < pLow)
+        [InlineData(0.001, -3.090)] // Lower region edge (clamped min)
+        [InlineData(0.99, 2.326)] // Upper region (p > pHigh)
+        [InlineData(0.999, 3.090)] // Upper region edge (clamped max)
         public void InverseNormalCDF_KnownProbabilities_ReturnsExpectedValues(double probability, double expectedApprox)
         {
             // Act


### PR DESCRIPTION
🎯 **What:** The testing gap where `p < pLow` (0.02425) in `InverseNormalCDF` was not being hit by the unit tests was addressed.
📊 **Coverage:** The tests now explicitly check boundary and extreme values such as `p = 0.01`, `p = 0.001`, `p = 0.99`, and `p = 0.999`. 
✨ **Result:** Test coverage improved by guaranteeing all regions of the mathematical approximation (lower, central, and upper) are traversed during standard automated tests.

---
*PR created automatically by Jules for task [13119784019977834211](https://jules.google.com/task/13119784019977834211) started by @dwojtaszek*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for inverse normal CDF calculations to include additional edge cases and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->