### PR TITLE
Remove EmlGenerationService legacy params overload

### DIFF
--- a/src/EmlGenerationService.cs
+++ b/src/EmlGenerationService.cs
@@ -74,27 +74,5 @@ namespace Zipper
                 Template = email,
             };
         }
-
-        /// <summary>
-        /// Generates EML content using explicit parameters for backward compatibility.
-        /// </summary>
-        /// <param name="fileIndex">Index of the file being generated.</param>
-        /// <param name="attachmentRate">Attachment rate as percentage (0-100).</param>
-        /// <param name="category">Optional email category constraint.</param>
-        /// <returns>EML generation result with content and optional attachment.</returns>
-        public static EmlGenerationResult GenerateEmlContent(
-            int fileIndex,
-            int attachmentRate,
-            EmailCategory? category = null)
-        {
-            var config = new EmlGenerationConfig
-            {
-                FileIndex = fileIndex,
-                AttachmentRate = attachmentRate,
-                Category = category,
-            };
-
-            return GenerateEmlContent(config);
-        }
     }
 }

--- a/src/Zipper.Tests/EmlGenerationServiceTests.cs
+++ b/src/Zipper.Tests/EmlGenerationServiceTests.cs
@@ -192,42 +192,26 @@ namespace Zipper
         }
 
         [Fact]
-        public void GenerateEmlContent_BackwardCompatibilityMethod_WorksSameAsConfigMethod()
+        public void GenerateEmlContent_WithAllParameters_ProducesValidResult()
         {
             // Arrange
-            var fileIndex = 42;
-            var attachmentRate = 75;
-            var category = EmailCategory.Technical;
+            var config = new EmlGenerationConfig
+            {
+                FileIndex = 42,
+                AttachmentRate = 75,
+                Category = EmailCategory.Technical,
+            };
 
-            // Act - The two methods should behave similarly, though content may differ due to randomness
-            var configResult = EmlGenerationService.GenerateEmlContent(
-                new EmlGenerationConfig
-                {
-                    FileIndex = fileIndex,
-                    AttachmentRate = attachmentRate,
-                    Category = category,
-                });
+            // Act
+            var result = EmlGenerationService.GenerateEmlContent(config);
 
-            var directResult = EmlGenerationService.GenerateEmlContent(
-                fileIndex,
-                attachmentRate,
-                category);
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Content.Length > 0);
 
-            // Assert - Both should produce valid EML content (not necessarily identical due to randomness)
-            Assert.NotNull(configResult);
-            Assert.NotNull(directResult);
-            Assert.True(configResult.Content.Length > 0);
-            Assert.True(directResult.Content.Length > 0);
-
-            // Both methods should use the same config parameters
-            var configContent = Encoding.UTF8.GetString(configResult.Content);
-            var directContent = Encoding.UTF8.GetString(directResult.Content);
-
-            // Both should contain valid email structure
-            Assert.Contains("From:", configContent);
-            Assert.Contains("To:", configContent);
-            Assert.Contains("From:", directContent);
-            Assert.Contains("To:", directContent);
+            var content = Encoding.UTF8.GetString(result.Content);
+            Assert.Contains("From:", content);
+            Assert.Contains("To:", content);
         }
 
         [Fact]


### PR DESCRIPTION
Remove `EmlGenerationService` legacy params overload and migrate the backward-compat test.

Closes #222

## Summary

`EmailBuilder` was already removed by prior G-series work (#216). The remaining legacy surface was a single convenience overload on `EmlGenerationService` that forwarded to the config-based method. This PR deletes it and updates the one test that exercised it.

## Changes

- **`src/EmlGenerationService.cs`** — deleted `GenerateEmlContent(int fileIndex, int attachmentRate, EmailCategory? category)` overload (21 lines). Only the `EmlGenerationConfig`-based method remains.
- **`src/Zipper.Tests/EmlGenerationServiceTests.cs`** — replaced `GenerateEmlContent_BackwardCompatibilityMethod_WorksSameAsConfigMethod` (which called the deleted overload) with `GenerateEmlContent_WithAllParameters_ProducesValidResult` that constructs `EmlGenerationConfig` directly.

## Verification

CI must pass:
- `build` — solution compiles with no reference to the deleted overload
- `test` — all unit tests green (migrated test calls config-based path)
- `lint` — no StyleCop/IDE0005 regressions
- `goldens` — no load-file or archive output touched; byte-identical fixtures expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified configuration parameters for EML generation service, consolidating multiple input parameters into a single configuration object for cleaner API usage.
  * Updated test coverage to validate the refactored EML generation functionality with various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->