### PR TITLE
Delete LoadFileFormat.Xml alias; map xml CLI token to EdrmXml

### DIFF
--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -215,7 +215,7 @@ public static class RequestBuilder
             "DAT" => LoadFileFormat.Dat,
             "OPT" => LoadFileFormat.Opt,
             "CSV" => LoadFileFormat.Csv,
-            "XML" => LoadFileFormat.Xml,
+            "XML" => LoadFileFormat.EdrmXml,
             "EDRMXML" => LoadFileFormat.EdrmXml,
             "CONCORDANCE" => LoadFileFormat.Concordance,
             _ => null,

--- a/src/LoadFileFormat.cs
+++ b/src/LoadFileFormat.cs
@@ -21,11 +21,6 @@ public enum LoadFileFormat
     Csv,
 
     /// <summary>
-    /// XML format - structured markup (legacy alias, generates the exact same format as <see cref="EdrmXml"/>).
-    /// </summary>
-    Xml,
-
-    /// <summary>
     /// EDRM XML format - Electronic Discovery Reference Model schema v1.2.
     /// </summary>
     EdrmXml,

--- a/src/LoadFiles/LoadFileWriterFactory.cs
+++ b/src/LoadFiles/LoadFileWriterFactory.cs
@@ -17,7 +17,6 @@ internal static class LoadFileWriterFactory
             LoadFileFormat.Dat => new DatWriter(),
             LoadFileFormat.Opt => new OptWriter(),
             LoadFileFormat.Csv => new CsvWriter(),
-            LoadFileFormat.Xml => new XmlLoadFileWriter(),
             LoadFileFormat.EdrmXml => new XmlLoadFileWriter(), // EDRM XML uses same writer
             LoadFileFormat.Concordance => new ConcordanceWriter(),
             _ => new DatWriter(),

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -392,7 +392,7 @@ namespace Zipper
         [InlineData("dat", LoadFileFormat.Dat)]
         [InlineData("opt", LoadFileFormat.Opt)]
         [InlineData("csv", LoadFileFormat.Csv)]
-        [InlineData("xml", LoadFileFormat.Xml)]
+        [InlineData("xml", LoadFileFormat.EdrmXml)]
         [InlineData("concordance", LoadFileFormat.Concordance)]
         public void ValidateAndParseArguments_WithLoadFileFormat_ShouldParseCorrectly(string format, LoadFileFormat expected)
         {

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -226,7 +226,7 @@ namespace Zipper
             // Arrange
             var request = this.CreateTestRequest();
             var fileData = this.CreateTestFileData();
-            var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Xml);
+            var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.EdrmXml);
             var outputPath = Path.Combine(this.tempDir, "test.xml");
 
             // Act
@@ -327,7 +327,7 @@ namespace Zipper
             Assert.Equal("CSV", csvWriter.FormatName);
             Assert.Equal(".csv", csvWriter.FileExtension);
 
-            var xmlWriter = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Xml);
+            var xmlWriter = LoadFileWriterFactory.CreateWriter(LoadFileFormat.EdrmXml);
             Assert.IsType<XmlLoadFileWriter>(xmlWriter);
             Assert.Equal("XML", xmlWriter.FormatName);
             Assert.Equal(".xml", xmlWriter.FileExtension);

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -212,7 +212,7 @@ namespace Zipper.Tests
             Assert.Equal(LoadFileFormat.Dat, RequestBuilder.GetLoadFileFormat("dat"));
             Assert.Equal(LoadFileFormat.Opt, RequestBuilder.GetLoadFileFormat("opt"));
             Assert.Equal(LoadFileFormat.Csv, RequestBuilder.GetLoadFileFormat("csv"));
-            Assert.Equal(LoadFileFormat.Xml, RequestBuilder.GetLoadFileFormat("xml"));
+            Assert.Equal(LoadFileFormat.EdrmXml, RequestBuilder.GetLoadFileFormat("xml"));
             Assert.Equal(LoadFileFormat.EdrmXml, RequestBuilder.GetLoadFileFormat("edrm-xml"));
             Assert.Equal(LoadFileFormat.Concordance, RequestBuilder.GetLoadFileFormat("concordance"));
         }


### PR DESCRIPTION
Delete `LoadFileFormat.Xml` enum member; map `xml` CLI token to `EdrmXml`

Closes #223

## Summary

`LoadFileFormat.Xml` was a documented legacy alias for `EdrmXml` — both values produced identical EDRM XML output via `XmlLoadFileWriter`. This PR removes the enum member while preserving the `xml` CLI alias at parse time (per the scope correction comment on #223). Callers who pass `--load-file-format xml` still get EDRM XML output — the alias is now resolved in `RequestBuilder.GetLoadFileFormat` rather than carried forward as a distinct enum value.

## Changes

- `src/LoadFileFormat.cs` — removed `Xml` enum member
- `src/Cli/RequestBuilder.cs` — changed `"XML" => LoadFileFormat.Xml` to `"XML" => LoadFileFormat.EdrmXml`
- `src/LoadFiles/LoadFileWriterFactory.cs` — removed redundant `LoadFileFormat.Xml => new XmlLoadFileWriter()` switch arm
- `src/Zipper.Tests/RequestBuilderTests.cs` — updated assertion: `GetLoadFileFormat("xml")` now expected to return `EdrmXml`
- `src/Zipper.Tests/CliPipelineTests.cs` — updated `InlineData`: `"xml"` now expected to parse to `LoadFileFormat.EdrmXml`
- `src/Zipper.Tests/LoadFileWriterTests.cs` — replaced two `LoadFileFormat.Xml` references with `LoadFileFormat.EdrmXml`

## Verification

- `build` — project must compile without `CS0117` errors referencing `LoadFileFormat.Xml`
- `test` — all unit tests must pass; updated assertions verify the `xml` alias still resolves correctly
- `lint` — no SA1507 (no consecutive blank lines) or IDE0005 violations introduced
- `goldens` — byte-identical (load file output unchanged; only routing logic modified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal XML file format handling by consolidating format representations and unifying processing logic.

* **Tests**
  * Updated test suites to validate XML format handling changes across CLI pipeline, writer factory, and format builder tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->