### PR TITLE
docs: correct FileGenerationRequest description in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Issues ordered: `BLOCKER` → `MAJOR` → `MINOR` → `INFO`.
 |------|---------|
 | `src/Program.cs` | Entry point, CLI orchestration, mode dispatch |
 | `src/Cli/` | CLI parsing, validation, help text, request assembly |
-| `src/FileGenerationRequest.cs` | Configuration object (40+ properties) shared across pipeline |
+| `src/FileGenerationRequest.cs` | Configuration root — 8 sub-configs (`Output`, `Metadata`, `LoadFile`, `Delimiters`, `Bates`, `Tiff`, `Chaos`, `Production`) + `LoadfileOnly` flag. Flat access guarded by `FGR_FLAT_ACCESS` analyzer |
 | `src/IGenerationMode.cs` / `GenerationRunner.cs` | Mode interface + dispatcher (errors → exit codes) |
 | `src/StandardMode.cs` / `LoadfileOnlyMode.cs` / `ProductionSetMode.cs` | Three generation mode adapters |
 | `src/IFileGenerator.cs` / `FileGeneratorFactory.cs` | File generator interface + factory |


### PR DESCRIPTION
## Summary

Corrects a stale project-structure entry in `AGENTS.md` that described `src/FileGenerationRequest.cs` as a "Configuration object (40+ properties) shared across pipeline".

That description contradicts both the current class shape and the `FgrFlatAccessAnalyzer` docstring, which states:

> Severity escalated to Error in F4 (#213); flat pass-throughs have been deleted.
> This rule now acts as a forever-guard preventing re-introduction.

The class today exposes 8 structured sub-configs (`Output`, `Metadata`, `LoadFile`, `Delimiters`, `Bates`, `Tiff`, `Chaos`, `Production`) plus the `LoadfileOnly` flag.

## Change

```diff
- | `src/FileGenerationRequest.cs` | Configuration object (40+ properties) shared across pipeline |
+ | `src/FileGenerationRequest.cs` | Configuration root — 8 sub-configs (`Output`, `Metadata`, `LoadFile`, `Delimiters`, `Bates`, `Tiff`, `Chaos`, `Production`) + `LoadfileOnly` flag. Flat access guarded by `FGR_FLAT_ACCESS` analyzer |
```

## Verification

Docs-only change. Pre-push hook still ran the full check suite:

- 885/885 unit tests passed
- 5/5 basic E2E smoke tests passed
- 13/13 golden regression scenarios passed

## Not Included

No requirement (`Requirements.md`) or user-facing (`README.md`) updates needed — both already describe the sub-config layout correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to reflect current configuration organization and access control mechanisms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->