### PR TITLE
fix: shell test script hygiene with set -euo pipefail and fixed find usage

### DIFF
--- a/tests/run-e2e-basic.sh
+++ b/tests/run-e2e-basic.sh
@@ -6,7 +6,7 @@
 # Covers: PDF, EML, TIFF, Bates numbering, load-file-in-zip
 # Full suite: run-tests.sh (17 cases + 8 standalone suites)
 
-set -e
+set -euo pipefail
 
 # --- Configuration ---
 
@@ -51,7 +51,7 @@ function verify_output() {
   print_info "Verifying output in $test_dir"
 
   local zip_file
-  zip_file=$(find "$test_dir" -name "*.zip")
+  zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
   local dat_file
   dat_file=$(find "$test_dir" -name "*.dat")
 
@@ -114,7 +114,7 @@ function verify_load_file_included() {
     local file_type="$4"
 
     local zip_file
-    zip_file=$(find "$test_dir" -name "*.zip")
+    zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     [[ -z "$zip_file" ]] && print_error "No .zip file found in $test_dir"
 
     # No separate .dat should exist
@@ -183,7 +183,7 @@ run_test "EML with attachments" --type eml --count 10 --output-path "$TEST_OUTPU
 verify_output "$TEST_OUTPUT_DIR/eml_attach" 10 "Control Number,File Path,To,From,Subject" "eml" "false"
 
 # Explicitly verify attachments are in the zip
-zip_file=$(find "$TEST_OUTPUT_DIR/eml_attach" -name "*.zip")
+zip_file=$(find "$TEST_OUTPUT_DIR/eml_attach" -name "*.zip" -print -quit)
 zip_listing=$(unzip -l "$zip_file")
 attachment_count=$(echo "$zip_listing" | grep -c "attachment\.") || true
 [[ "$attachment_count" -eq 0 ]] && print_error "Expected attachments in zip but found none"

--- a/tests/run-e2e-loadfile.sh
+++ b/tests/run-e2e-loadfile.sh
@@ -6,7 +6,7 @@
 # Covers: DAT loadfile-only, OPT loadfile-only, custom delimiters, EOL,
 #         chaos mode, properties JSON, dependency rejection.
 
-set -e
+set -euo pipefail
 
 # --- Configuration ---
 
@@ -81,7 +81,7 @@ line_count=$(wc -l < "$dat_file" | tr -d ' ')
 print_info "DAT line count OK ($line_count)"
 
 # Verify no ZIP was created
-zip_count=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*.zip" | wc -l)
+zip_count=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*.zip" -print -quit | wc -l)
 [[ "$zip_count" -ne 0 ]] && print_error "Expected no .zip file in loadfile-only mode"
 print_info "No ZIP file created (correct)"
 

--- a/tests/run-tests-manual-verify.sh
+++ b/tests/run-tests-manual-verify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # --- Test Configuration ---
 
@@ -47,8 +47,8 @@ function verify_output() {
 
   print_info "Verifying output in $test_dir (Encoding: $encoding)"
 
-  local zip_file=$(find "$test_dir" -name "*.zip")
-  local dat_file=$(find "$test_dir" -name "*.dat")
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
 
   if [ -z "$zip_file" ]; then
     print_error "No .zip file found in $test_dir"
@@ -125,7 +125,7 @@ function verify_eml_output() {
 
   verify_output "$@"
 
-  local dat_file=$(find "$test_dir" -name "*.dat")
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
   local dat_content_cmd="cat"
   if [ "$encoding" = "UTF-16" ]; then
     dat_content_cmd="iconv -f UTF-16LE -t UTF-8"
@@ -134,7 +134,7 @@ function verify_eml_output() {
   fi
 
   # Verify that attachment files are actually present in the ZIP archive
-  local zip_file=$(find "$test_dir" -name "*.zip")
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
   local attachment_files=$(unzip -l "$zip_file" | grep "attachment.*\.\(pdf\|jpg\|tiff\)$" | wc -l)
 
   # Count EML files to calculate expected attachments (50% attachment rate)
@@ -174,7 +174,7 @@ function verify_zip_size() {
     local target_size_bytes=$((target_size_mb * 1024 * 1024))
     local tolerance_bytes=$((target_size_bytes / 10)) # 10%
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [ -z "$zip_file" ]; then
         print_error "No .zip file found in $test_dir"
     fi
@@ -206,13 +206,13 @@ function verify_load_file_included() {
 
     print_info "Verifying load file included in zip archive (Encoding: $encoding)"
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [ -z "$zip_file" ]; then
         print_error "No .zip file found in $test_dir"
     fi
 
     # Verify no separate .dat file in output directory
-    local dat_file=$(find "$test_dir" -name "*.dat")
+    local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
     if [ -n "$dat_file" ]; then
         print_error "Found separate .dat file in output directory, but --include-load-file was specified"
     fi

--- a/tests/run-tests-optimized.sh
+++ b/tests/run-tests-optimized.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # --- Optimized Test Configuration ---
 # This version optimizes performance by reducing process spawning and caching operations
@@ -59,8 +59,8 @@ function verify_output() {
 
   print_info "Verifying output in $test_dir (Encoding: $encoding)"
 
-  local zip_file=$(find "$test_dir" -name "*.zip")
-  local dat_file=$(find "$test_dir" -name "*.dat")
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
 
   if [[ -z "$zip_file" ]]; then
     print_error "No .zip file found in $test_dir"
@@ -144,8 +144,8 @@ function verify_eml_output() {
 
   verify_output "$@"
 
-  local dat_file=$(find "$test_dir" -name "*.dat")
-  local zip_file=$(find "$test_dir" -name "*.zip")
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
 
   # Get zip listing once (already cached in verify_output, but we need it here too)
   local zip_listing
@@ -200,7 +200,7 @@ function verify_zip_size() {
     local target_size_bytes=$((target_size_mb * 1024 * 1024))
     local tolerance_bytes=$((target_size_bytes / 10)) # 10%
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [[ -z "$zip_file" ]]; then
         print_error "No .zip file found in $test_dir"
     fi
@@ -232,13 +232,13 @@ function verify_load_file_included() {
 
     print_info "Verifying load file included in zip archive (Encoding: $encoding)"
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [[ -z "$zip_file" ]]; then
         print_error "No .zip file found in $test_dir"
     fi
 
     # Verify no separate .dat file in output directory
-    local dat_file=$(find "$test_dir" -name "*.dat")
+    local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
     if [[ -n "$dat_file" ]]; then
         print_error "Found separate .dat file in output directory, but --include-load-file was specified"
     fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # --- Test Configuration ---
 
@@ -58,8 +58,8 @@ function verify_output() {
 
   print_info "Verifying output in $test_dir (Encoding: $encoding)"
 
-  local zip_file=$(find "$test_dir" -name "*.zip")
-  local dat_file=$(find "$test_dir" -name "*.dat")
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
 
   if [[ -z "$zip_file" ]]; then
     print_error "No .zip file found in $test_dir"
@@ -143,8 +143,8 @@ function verify_eml_output() {
 
   verify_output "$@"
 
-  local dat_file=$(find "$test_dir" -name "*.dat")
-  local zip_file=$(find "$test_dir" -name "*.zip")
+  local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
+  local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
 
   # Get zip listing once (already cached in verify_output, but we need it here too)
   local zip_listing
@@ -199,7 +199,7 @@ function verify_zip_size() {
     local target_size_bytes=$((target_size_mb * 1024 * 1024))
     local tolerance_bytes=$((target_size_bytes / 10)) # 10%
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [[ -z "$zip_file" ]]; then
         print_error "No .zip file found in $test_dir"
     fi
@@ -236,13 +236,13 @@ function verify_load_file_included() {
 
     print_info "Verifying load file included in zip archive (Encoding: $encoding)"
 
-    local zip_file=$(find "$test_dir" -name "*.zip")
+    local zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
     if [[ -z "$zip_file" ]]; then
         print_error "No .zip file found in $test_dir"
     fi
 
     # Verify no separate .dat file in output directory
-    local dat_file=$(find "$test_dir" -name "*.dat")
+    local dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
     if [[ -n "$dat_file" ]]; then
         print_error "Found separate .dat file in output directory, but --include-load-file was specified"
     fi
@@ -416,8 +416,8 @@ print_success "Test Case 17 passed."
 # Test Case 18: CSV load file format (non-DAT format inline validation)
 run_test_case "Test Case 18: CSV load file format" --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/pdf_csv" --load-file-format csv
 csv_dir="$TEST_OUTPUT_DIR/pdf_csv"
-csv_zip=$(find "$csv_dir" -name "*.zip")
-csv_file=$(find "$csv_dir" -name "*.csv")
+csv_zip=$(find "$csv_dir" -name "*.zip" -print -quit)
+csv_file=$(find "$csv_dir" -name "*.csv" -print -quit)
 if [[ -z "$csv_zip" ]]; then
   print_error "Test 18: No .zip file found"
 fi
@@ -432,8 +432,8 @@ print_success "Test Case 18 passed."
 # Test Case 19: OPT load file format (non-DAT format inline validation)
 run_test_case "Test Case 19: OPT load file format" --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/pdf_opt" --load-file-format opt
 opt_dir="$TEST_OUTPUT_DIR/pdf_opt"
-opt_zip=$(find "$opt_dir" -name "*.zip")
-opt_file=$(find "$opt_dir" -name "*.opt")
+opt_zip=$(find "$opt_dir" -name "*.zip" -print -quit)
+opt_file=$(find "$opt_dir" -name "*.opt" -print -quit)
 if [[ -z "$opt_zip" ]]; then
   print_error "Test 19: No .zip file found"
 fi

--- a/tests/stress/run-stress-tests.sh
+++ b/tests/stress/run-stress-tests.sh
@@ -13,7 +13,7 @@
 #
 # =============================================================================
 
-set -e
+set -euo pipefail
 
 # --- Configuration ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/stress/stress-10gb-filecount.sh
+++ b/tests/stress/stress-10gb-filecount.sh
@@ -25,7 +25,7 @@
 # - Provides clear runtime expectations
 # =============================================================================
 
-set -e  # Exit on any error
+set -euo pipefail  # Exit on any error, use unset variable as error, and fail on pipe failures
 
 # --- Check Required Utilities ---
 check_required_utilities() {

--- a/tests/stress/stress-30gb-attachments.sh
+++ b/tests/stress/stress-30gb-attachments.sh
@@ -33,7 +33,7 @@
 # - Provides clear runtime expectations
 # =============================================================================
 
-set -e  # Exit on any error
+set -euo pipefail  # Exit on any error, use unset variable as error, and fail on pipe failures
 
 # --- Check Required Utilities ---
 check_required_utilities() {

--- a/tests/stress/stress-large-loadfile.sh
+++ b/tests/stress/stress-large-loadfile.sh
@@ -24,7 +24,7 @@
 # - Focuses on load file performance bottlenecks
 # =============================================================================
 
-set -e  # Exit on any error
+set -euo pipefail  # Exit on any error, use unset variable as error, and fail on pipe failures
 
 # --- Check Required Utilities ---
 check_required_utilities() {

--- a/tests/test-bates-numbering.sh
+++ b/tests/test-bates-numbering.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"
@@ -47,8 +47,8 @@ zipper \
   --bates-digits 8
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 1: No .zip file found"
@@ -87,7 +87,7 @@ zipper \
   --bates-digits 6
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat" -print -quit)
 
 if ! grep -q "CLIENT001000100" "$dat_file"; then
   print_error "Test 2: Bates number 'CLIENT001000100' not found in .dat file"
@@ -112,7 +112,7 @@ zipper \
   --bates-digits 8
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat" -print -quit)
 
 if ! grep -q "IMG00000001" "$dat_file"; then
   print_error "Test 3: Bates number 'IMG00000001' not found in .dat file"
@@ -133,7 +133,7 @@ zipper \
   --bates-digits 10
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat" -print -quit)
 
 if ! grep -q "DOCX0000000500" "$dat_file"; then
   print_error "Test 4: Bates number 'DOCX0000000500' not found in .dat file"

--- a/tests/test-cross-platform.sh
+++ b/tests/test-cross-platform.sh
@@ -3,7 +3,7 @@
 # Cross-platform compatibility test script for Zipper
 # This script tests core functionality across different platforms
 
-set -e
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -3,7 +3,7 @@
 # Constitutional Requirement: Must test ALL EML functionality scenarios
 # Tests both Windows and Unix compatibility for EML feature implementation
 
-# set -e # Exit on any error - disabled for better debugging
+set -euo pipefail
 
 echo "========================================"
 echo "Comprehensive EML Test Suite - Unix"
@@ -120,7 +120,7 @@ verify_attachments() {
 
 # Main test function
 run_test() {
-    ((TEST_COUNT++))
+    TEST_COUNT=$((TEST_COUNT + 1))
     local test_name="$1"
     local command_args="$2"
     local expected_headers=("${@:3}") # All args from 3rd onwards are headers
@@ -160,9 +160,9 @@ run_test() {
         echo "  ✓ Command executed successfully."
         
         local archive_file
-        archive_file=$(find "$test_path" -name "archive_*.zip")
+        archive_file=$(find "$test_path" -name "archive_*.zip" -print -quit) || true
         local dat_file
-        dat_file=$(find "$test_path" -name "archive_*.dat")
+        dat_file=$(find "$test_path" -name "archive_*.dat" -print -quit) || true
 
         if [[ -z "$archive_file" ]]; then
             echo "  ✗ Test FAILED. Archive file not created."
@@ -209,7 +209,7 @@ run_test() {
 
             if [[ "$all_checks_passed" = true ]]; then
                 echo "✓ Test $TEST_COUNT PASSED"
-                ((PASSED_COUNT++))
+                PASSED_COUNT=$((PASSED_COUNT + 1))
             else
                 echo "✗ Test $TEST_COUNT FAILED due to verification errors."
             fi

--- a/tests/test-load-file-formats.sh
+++ b/tests/test-load-file-formats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"
@@ -45,8 +45,8 @@ zipper \
   --load-file-format opt
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip")
-opt_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.opt")
+zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip" -print -quit)
+opt_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.opt" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 1: No .zip file found"
@@ -86,8 +86,8 @@ zipper \
   --load-file-format csv
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip")
-csv_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.csv")
+zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" -print -quit)
+csv_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.csv" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 2: No .zip file found"
@@ -128,8 +128,8 @@ zipper \
   --load-file-format xml
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.zip")
-xml_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.xml")
+zip_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.zip" -print -quit)
+xml_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.xml" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 3: No .zip file found"
@@ -175,8 +175,8 @@ zipper \
   --load-file-format concordance
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.zip")
-concordance_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.zip" -print -quit)
+concordance_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 4: No .zip file found"
@@ -210,8 +210,8 @@ zipper \
   --load-file-format dat
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test5" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test5" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test5" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test5" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 5: No .zip file found"
@@ -285,8 +285,8 @@ zipper \
   --delimiter-quote "^"
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test7" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test7" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test7" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test7" -name "*.dat" -print -quit)
 
 if [[ -z "$dat_file" ]]; then
   print_error "Test 7: No .dat file found"
@@ -317,7 +317,7 @@ zipper \
   --delimiter-quote "254"
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test8" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test8" -name "*.dat" -print -quit)
 
 if [[ -z "$dat_file" ]]; then
   print_error "Test 8: No .dat file found"
@@ -349,7 +349,7 @@ zipper \
   --delimiter-column "|"
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test9" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test9" -name "*.dat" -print -quit)
 
 if [[ -z "$dat_file" ]]; then
   print_error "Test 9: No .dat file found"

--- a/tests/test-multipage-tiff.sh
+++ b/tests/test-multipage-tiff.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"
@@ -50,8 +50,8 @@ zipper \
   --output-path "$TEST_OUTPUT_DIR/test1"
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 1: No .zip file found"
@@ -79,8 +79,8 @@ zipper \
   --tiff-pages "1-20"
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 2: No .zip file found"
@@ -122,8 +122,8 @@ zipper \
   --tiff-pages "5-10"
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 3: No .zip file found"
@@ -162,8 +162,8 @@ zipper \
   --bates-digits 8
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 4: No .zip file found"
@@ -221,8 +221,8 @@ zipper \
   --tiff-pages "1-50"
 
 # Extract page counts from both runs
-dat_file_a=$(find "$TEST_OUTPUT_DIR/test5a" -name "*.dat")
-dat_file_b=$(find "$TEST_OUTPUT_DIR/test5b" -name "*.dat")
+dat_file_a=$(find "$TEST_OUTPUT_DIR/test5a" -name "*.dat" -print -quit)
+dat_file_b=$(find "$TEST_OUTPUT_DIR/test5b" -name "*.dat" -print -quit)
 
 # Extract page counts using the helper function (handles DAT format delimiter correctly)
 page_counts_a=$(tail -n +2 "$dat_file_a" | while IFS= read -r line; do extract_page_count "$line"; done)

--- a/tests/test-office-formats.sh
+++ b/tests/test-office-formats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"
@@ -45,8 +45,8 @@ zipper \
   --folders 3
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test1" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 1: No .zip file found"
@@ -79,8 +79,8 @@ zipper \
   --folders 2
 
 # Verify output
-zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip")
-dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat")
+zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.dat" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 2: No .zip file found"
@@ -113,7 +113,7 @@ zipper \
   --with-metadata
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test3" -name "*.dat" -print -quit)
 
 # Check for metadata columns
 first_line=$(head -n 1 "$dat_file")
@@ -148,7 +148,7 @@ zipper \
   --bates-digits 10
 
 # Verify output
-dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/test4" -name "*.dat" -print -quit)
 
 # Check for Bates Number column
 first_line=$(head -n 1 "$dat_file")
@@ -212,7 +212,7 @@ zipper \
   --output-path "$TEST_OUTPUT_DIR/test6"
 
 # Extract one DOCX file and verify it's a valid ZIP
-zip_file=$(find "$TEST_OUTPUT_DIR/test6" -name "*.zip")
+zip_file=$(find "$TEST_OUTPUT_DIR/test6" -name "*.zip" -print -quit)
 
 # Get the first DOCX file from the archive
 docx_filename=$(unzip -l "$zip_file" | grep "\.docx" | head -n 1 | awk '{print $4}')

--- a/tests/test-path-traversal-security.sh
+++ b/tests/test-path-traversal-security.sh
@@ -2,6 +2,11 @@
 # Path Traversal Security Test Script
 # Tests that path traversal attempts are properly blocked
 
+set -euo pipefail
+
+# shellcheck source=./_zipper-cli.sh
+source "$(dirname "$0")/_zipper-cli.sh"
+
 echo "🔒 Path Traversal Security Test"
 echo "================================="
 
@@ -9,30 +14,18 @@ echo "================================="
 TEST_DIR="$(mktemp -d)"
 echo "Created test directory: $TEST_DIR"
 
-# Build the application
-echo "Building Zipper..."
-dotnet build src/Zipper.csproj --configuration Release > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    echo "❌ Build failed"
-    rm -rf "$TEST_DIR"
-    exit 1
-fi
-
 # Test 1: Normal path should work
 echo ""
 echo "Test 1: Normal path should work"
-ZIPPER_DLL="src/bin/Release/net8.0/Zipper.dll"
-if [ ! -f "$ZIPPER_DLL" ]; then
-    echo "❌ Could not find Zipper DLL at $ZIPPER_DLL"
-    rm -rf "$TEST_DIR"
-    exit 1
-fi
 
 # Run with normal path
-dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "$TEST_DIR/normal" > /dev/null 2>&1
-if [ $? -eq 0 ] && [ -f "$TEST_DIR/normal/archive_"*.zip ]; then
-    echo "✅ Normal path works correctly"
-    rm -f "$TEST_DIR/normal/"*
+if zipper --type pdf --count 5 --output-path "$TEST_DIR/normal" > /dev/null 2>&1; then
+    if compgen -G "$TEST_DIR/normal/archive_*.zip" > /dev/null 2>&1; then
+        echo "✅ Normal path works correctly"
+        rm -f "$TEST_DIR/normal/"*
+    else
+        echo "❌ Normal path failed - no archive created"
+    fi
 else
     echo "❌ Normal path failed"
 fi
@@ -41,10 +34,9 @@ fi
 echo ""
 echo "Test 2: Path traversal with ../ should be blocked"
 
-SECURITY_OUTPUT=$(dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "$TEST_DIR/../security_test" 2>&1)
-SECURITY_EXIT_CODE=$?
+SECURITY_OUTPUT=$(zipper --type pdf --count 5 --output-path "$TEST_DIR/../security_test" 2>&1) && SECURITY_EXIT_CODE=0 || SECURITY_EXIT_CODE=$?
 
-if [ $SECURITY_EXIT_CODE -ne 0 ] && echo "$SECURITY_OUTPUT" | grep -q "Path traversal detected"; then
+if [[ $SECURITY_EXIT_CODE -ne 0 ]] && echo "$SECURITY_OUTPUT" | grep -q "Path traversal detected"; then
     echo "✅ Path traversal with ../ was properly blocked"
     echo "   Error message: $(echo "$SECURITY_OUTPUT" | grep "Path traversal detected" | head -1)"
 else
@@ -57,10 +49,9 @@ fi
 echo ""
 echo "Test 3: Absolute path traversal attempt should be blocked"
 
-SYSTEM_OUTPUT=$(dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "/tmp/../etc/security_test" 2>&1)
-SYSTEM_EXIT_CODE=$?
+SYSTEM_OUTPUT=$(zipper --type pdf --count 5 --output-path "/tmp/../etc/security_test" 2>&1) && SYSTEM_EXIT_CODE=0 || SYSTEM_EXIT_CODE=$?
 
-if [ $SYSTEM_EXIT_CODE -ne 0 ] && (echo "$SYSTEM_OUTPUT" | grep -q "Path traversal detected\|Error: Invalid path"); then
+if [[ $SYSTEM_EXIT_CODE -ne 0 ]] && (echo "$SYSTEM_OUTPUT" | grep -q "Path traversal detected\|Error: Invalid path"); then
     echo "✅ Absolute path traversal was properly blocked"
     echo "   Error message: $(echo "$SYSTEM_OUTPUT" | grep -E "Path traversal detected|Error: Invalid path" | head -1)"
 else
@@ -73,10 +64,9 @@ fi
 echo ""
 echo "Test 4: Path with invalid characters should be blocked"
 
-INVALID_OUTPUT=$(dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "$TEST_DIR/invalid<name" 2>&1)
-INVALID_EXIT_CODE=$?
+INVALID_OUTPUT=$(zipper --type pdf --count 5 --output-path "$TEST_DIR/invalid<name" 2>&1) && INVALID_EXIT_CODE=0 || INVALID_EXIT_CODE=$?
 
-if [ $INVALID_EXIT_CODE -ne 0 ] && echo "$INVALID_OUTPUT" | grep -q "Invalid character"; then
+if [[ $INVALID_EXIT_CODE -ne 0 ]] && echo "$INVALID_OUTPUT" | grep -q "Invalid character"; then
     echo "✅ Path with invalid characters was properly blocked"
     echo "   Error message: $(echo "$INVALID_OUTPUT" | grep "Invalid character" | head -1)"
 else
@@ -89,10 +79,9 @@ fi
 echo ""
 echo "Test 5: Empty path should be blocked"
 
-EMPTY_OUTPUT=$(dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "" 2>&1)
-EMPTY_EXIT_CODE=$?
+EMPTY_OUTPUT=$(zipper --type pdf --count 5 --output-path "" 2>&1) && EMPTY_EXIT_CODE=0 || EMPTY_EXIT_CODE=$?
 
-if [ $EMPTY_EXIT_CODE -ne 0 ] && echo "$EMPTY_OUTPUT" | grep -q "Output path cannot be null or empty"; then
+if [[ $EMPTY_EXIT_CODE -ne 0 ]] && echo "$EMPTY_OUTPUT" | grep -q "Output path cannot be null or empty"; then
     echo "✅ Empty path was properly handled"
     echo "   Error message: $(echo "$EMPTY_OUTPUT" | grep "Output path cannot be null or empty" | head -1)"
 else
@@ -105,10 +94,9 @@ fi
 echo ""
 echo "Test 6: Path with mixed separators and traversal should be blocked"
 
-MIXED_OUTPUT=$(dotnet "$ZIPPER_DLL" --type pdf --count 5 --output-path "folder/../..\\mixed\\path" 2>&1)
-MIXED_EXIT_CODE=$?
+MIXED_OUTPUT=$(zipper --type pdf --count 5 --output-path "folder/../..\\mixed\\path" 2>&1) && MIXED_EXIT_CODE=0 || MIXED_EXIT_CODE=$?
 
-if [ $MIXED_EXIT_CODE -ne 0 ] && (echo "$MIXED_OUTPUT" | grep -q "Path traversal detected\|Invalid character"); then
+if [[ $MIXED_EXIT_CODE -ne 0 ]] && (echo "$MIXED_OUTPUT" | grep -q "Path traversal detected\|Invalid character"); then
     echo "✅ Mixed separators with traversal was properly blocked"
     echo "   Error message: $(echo "$MIXED_OUTPUT" | grep -E "Path traversal detected|Invalid character" | head -1)"
 else

--- a/tests/test-production-sets.sh
+++ b/tests/test-production-sets.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
-set -e
+# Exit immediately if a command exits with a non-zero status, use unset variable as error, and fail on pipe failures.
+set -euo pipefail
 
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"


### PR DESCRIPTION
## Summary
Fixes #294

This PR adds proper shell script hygiene to all test scripts in the repository.

## Changes

### `set -euo pipefail` Added
All scripts in `tests/` and `tests/stress/` now use `set -euo pipefail` at the top:
- `set -e` - Exit immediately if a command exits with a non-zero status
- `set -u` - Treat unset variables as an error
- `set -o pipefail` - Return value of a pipeline is the status of the last command to exit with a non-zero status

### Fixed Fragile `find` Usage
All single-variable `find` assignments now add `-print -quit` or `| head -1`:
- Prevents multi-path concatenation if more than one match exists
- Ensures deterministic behavior

### Scripts Updated
- `tests/run-tests.sh`
- `tests/run-e2e-basic.sh`
- `tests/run-e2e-loadfile.sh`
- `tests/run-tests-manual-verify.sh`
- `tests/run-tests-optimized.sh`
- `tests/test-multipage-tiff.sh`
- `tests/test-bates-numbering.sh`
- `tests/test-load-file-formats.sh`
- `tests/test-office-formats.sh`
- `tests/test-cross-platform.sh`
- `tests/test-eml-comprehensive.sh` (re-enabled `set -e`, was disabled)
- `tests/test-path-traversal-security.sh` (added `set -euo pipefail` + sources `_zipper-cli.sh`)
- `tests/test-production-sets.sh`
- `tests/stress/stress-10gb-filecount.sh`
- `tests/stress/stress-30gb-attachments.sh`
- `tests/stress/stress-large-loadfile.sh`
- `tests/stress/run-stress-tests.sh`

## Testing
- Unit tests: 890 passed
- E2E basic smoke tests: 5/5 passed
- E2E loadfile tests: 7/7 passed
- Golden regression suite: 13/13 passed

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with stricter error handling across all test scripts for improved reliability and failure detection.
  * Made test output verification more deterministic by selecting specific artifacts when multiple matches exist.
  * Refactored path-traversal security tests to use the CLI tool for consistent validation.

* **Chores**
  * Updated test runner scripts to use enhanced bash safety settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/298)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->