### PR TITLE
fix: guard grep -c with || true and replace find|head with -print -quit

### DIFF
--- a/tests/_zipper-cli.sh
+++ b/tests/_zipper-cli.sh
@@ -27,7 +27,7 @@ _zipper_resolve_bin() {
     # Resolve to an absolute path so the caller can cd elsewhere between
     # helper-init and command invocation without breaking the binary path.
     local build_dir
-    build_dir=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" 2>/dev/null | head -n 1)
+    build_dir=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" -print -quit 2>/dev/null)
     [[ -z "$build_dir" ]] && build_dir="src/bin/Release/net8.0"
     if [[ -d "$build_dir" ]]; then
         build_dir=$(cd "$build_dir" && pwd)

--- a/tests/run-e2e-basic.sh
+++ b/tests/run-e2e-basic.sh
@@ -14,7 +14,7 @@ TEST_OUTPUT_DIR="./results/e2e-basic"
 PROJECT="src/Zipper.csproj"
 
 # Dynamically locate the built framework directory
-BUILD_DIR=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" | head -n 1)
+BUILD_DIR=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" -print -quit)
 [[ -z "$BUILD_DIR" ]] && BUILD_DIR="src/bin/Release/net8.0" # Fallback
 
 # --- Helper Functions ---
@@ -53,7 +53,7 @@ function verify_output() {
   local zip_file
   zip_file=$(find "$test_dir" -name "*.zip" -print -quit)
   local dat_file
-  dat_file=$(find "$test_dir" -name "*.dat")
+  dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
 
   [[ -z "$zip_file" ]] && print_error "No .zip file found in $test_dir"
   [[ -z "$dat_file" ]] && print_error "No .dat file found in $test_dir"
@@ -99,7 +99,7 @@ function verify_output() {
     if [[ "$file_type" = "eml" ]]; then
       txt_count=$(echo "$zip_listing" | grep "\.txt$" | grep -v "attachment" | wc -l)
     else
-      txt_count=$(echo "$zip_listing" | grep -c "\.txt")
+      txt_count=$(echo "$zip_listing" | grep -c "\.txt" || true)
     fi
     [[ "$txt_count" -ne "$expected_count" ]] && \
       print_error "Zip .txt count: expected $expected_count, got $txt_count"
@@ -119,7 +119,7 @@ function verify_load_file_included() {
 
     # No separate .dat should exist
     local dat_file
-    dat_file=$(find "$test_dir" -name "*.dat")
+    dat_file=$(find "$test_dir" -name "*.dat" -print -quit)
     [[ -n "$dat_file" ]] && print_error "Found separate .dat file — should be inside zip"
 
     local zip_listing
@@ -203,7 +203,7 @@ print_success "Test 4: Load file in zip — PASSED"
 
 # 5. Bates numbering (feature-specific)
 run_test "Bates numbering" --type pdf --count 10 --output-path "$TEST_OUTPUT_DIR/pdf_bates" --bates-prefix "SMOKE" --bates-start 1 --bates-digits 8
-dat_file=$(find "$TEST_OUTPUT_DIR/pdf_bates" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/pdf_bates" -name "*.dat" -print -quit)
 [[ -z "$dat_file" ]] && print_error "No .dat file found for Bates test"
 grep -q "SMOKE00000001" "$dat_file" || print_error "Bates number SMOKE00000001 not found"
 grep -q "SMOKE00000010" "$dat_file" || print_error "Bates number SMOKE00000010 not found"

--- a/tests/run-e2e-loadfile.sh
+++ b/tests/run-e2e-loadfile.sh
@@ -14,7 +14,7 @@ TEST_OUTPUT_DIR="./results/e2e-loadfile"
 PROJECT="src/Zipper.csproj"
 
 # Dynamically locate the built framework directory
-BUILD_DIR=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" 2>/dev/null | head -n 1)
+BUILD_DIR=$(find src/bin/Release -mindepth 1 -maxdepth 1 -type d -name "net*" -print -quit 2>/dev/null)
 [[ -z "$BUILD_DIR" ]] && BUILD_DIR="src/bin/Release/net8.0" # Fallback
 
 # --- Helper Functions ---
@@ -72,7 +72,7 @@ TOTAL=$((TOTAL + 1))
 run_test "DAT loadfile-only" \
     --loadfile-only --count 100 --output-path "$TEST_OUTPUT_DIR/dat_basic"
 
-dat_file=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*.dat" -print -quit)
 [[ -z "$dat_file" ]] && print_error "No .dat file found"
 
 # Verify line count (header + 100 data rows)
@@ -86,7 +86,7 @@ zip_count=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*.zip" -print -quit | wc -l
 print_info "No ZIP file created (correct)"
 
 # Verify properties JSON
-props_file=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*_properties.json")
+props_file=$(find "$TEST_OUTPUT_DIR/dat_basic" -name "*_properties.json" -print -quit)
 [[ -z "$props_file" ]] && print_error "No _properties.json file found"
 grep -q '"format"' "$props_file" || print_error "Properties JSON missing Format field"
 grep -q '"totalRecords"' "$props_file" || print_error "Properties JSON missing TotalRecords field"
@@ -103,7 +103,7 @@ TOTAL=$((TOTAL + 1))
 run_test "OPT loadfile-only" \
     --loadfile-only --loadfile-format opt --count 50 --output-path "$TEST_OUTPUT_DIR/opt_basic"
 
-opt_file=$(find "$TEST_OUTPUT_DIR/opt_basic" -name "*.opt")
+opt_file=$(find "$TEST_OUTPUT_DIR/opt_basic" -name "*.opt" -print -quit)
 [[ -z "$opt_file" ]] && print_error "No .opt file found"
 
 # Verify no header (OPT has no header row)
@@ -135,7 +135,7 @@ run_test "Custom delimiters" \
     --loadfile-only --count 20 --output-path "$TEST_OUTPUT_DIR/dat_custom_delim" \
     --col-delim "char:|" --quote-delim "char:\"" --eol LF
 
-dat_file=$(find "$TEST_OUTPUT_DIR/dat_custom_delim" -name "*.dat")
+dat_file=$(find "$TEST_OUTPUT_DIR/dat_custom_delim" -name "*.dat" -print -quit)
 [[ -z "$dat_file" ]] && print_error "No .dat file found"
 
 # Verify pipe delimiter is present
@@ -159,7 +159,7 @@ run_test "Chaos mode" \
     --loadfile-only --count 200 --output-path "$TEST_OUTPUT_DIR/dat_chaos" \
     --chaos-mode --chaos-amount "5%" --seed 42
 
-props_file=$(find "$TEST_OUTPUT_DIR/dat_chaos" -name "*_properties.json")
+props_file=$(find "$TEST_OUTPUT_DIR/dat_chaos" -name "*_properties.json" -print -quit)
 [[ -z "$props_file" ]] && print_error "No _properties.json file found for chaos test"
 
 # Verify chaos section in properties JSON
@@ -185,7 +185,7 @@ run_test "Chaos with type filter" \
     --loadfile-only --count 100 --output-path "$TEST_OUTPUT_DIR/dat_chaos_typed" \
     --chaos-mode --chaos-amount "10" --chaos-types "quotes,columns" --seed 42
 
-props_file=$(find "$TEST_OUTPUT_DIR/dat_chaos_typed" -name "*_properties.json")
+props_file=$(find "$TEST_OUTPUT_DIR/dat_chaos_typed" -name "*_properties.json" -print -quit)
 [[ -z "$props_file" ]] && print_error "No _properties.json file found"
 
 # Verify only specified types appear
@@ -259,8 +259,8 @@ run_test "Deterministic run 1" \
 run_test "Deterministic run 2" \
     --loadfile-only --count 20 --output-path "$TEST_OUTPUT_DIR/seed_run2" --seed 999
 
-dat1=$(find "$TEST_OUTPUT_DIR/seed_run1" -name "*.dat")
-dat2=$(find "$TEST_OUTPUT_DIR/seed_run2" -name "*.dat")
+dat1=$(find "$TEST_OUTPUT_DIR/seed_run1" -name "*.dat" -print -quit)
+dat2=$(find "$TEST_OUTPUT_DIR/seed_run2" -name "*.dat" -print -quit)
 [[ -z "$dat1" ]] && print_error "No .dat file found for seed_run1"
 [[ -z "$dat2" ]] && print_error "No .dat file found for seed_run2"
 

--- a/tests/run-tests-manual-verify.sh
+++ b/tests/run-tests-manual-verify.sh
@@ -84,7 +84,7 @@ function verify_output() {
   print_info ".dat file header is correct."
 
   # Verify file count in zip
-  local zip_file_count=$(unzip -l "$zip_file" | strings | grep -c "\.$file_type")
+  local zip_file_count=$(unzip -l "$zip_file" | strings | grep -c "\.$file_type" || true)
   if [ "$zip_file_count" -ne "$expected_count" ]; then
     print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
   fi
@@ -98,7 +98,7 @@ function verify_output() {
       txt_count=$(unzip -l "$zip_file" | grep "\.txt$" | grep -v "attachment" | wc -l)
     else
       # For other file types, count all text files
-      txt_count=$(unzip -l "$zip_file" | strings | grep -c "\.txt")
+      txt_count=$(unzip -l "$zip_file" | strings | grep -c "\.txt" || true)
     fi
     if [ "$txt_count" -ne "$expected_count" ]; then
       print_error "Incorrect .txt file count in .zip file. Expected $expected_count, found $txt_count."
@@ -148,7 +148,7 @@ function verify_eml_output() {
 
   # Verify that some attachments are listed in the .dat file
   # We check for more than 2 because the header has "Attachment"
-  local attachment_count=$($dat_content_cmd < "$dat_file" | grep -c "attachment")
+  local attachment_count=$($dat_content_cmd < "$dat_file" | grep -c "attachment" || true)
   if [ "$attachment_count" -lt 2 ]; then
     print_error "No attachments found in .dat file, but they were expected."
   fi
@@ -229,7 +229,7 @@ function verify_load_file_included() {
     trap "rm -rf $temp_dir" RETURN
 
     unzip -j "$zip_file" "*.dat" -d "$temp_dir" > /dev/null
-    local extracted_dat=$(find "$temp_dir" -name "*.dat" | head -1)
+    local extracted_dat=$(find "$temp_dir" -name "*.dat" -print -quit)
 
     local dat_content_cmd="cat"
     if [ "$encoding" = "UTF-16" ]; then
@@ -258,7 +258,7 @@ function verify_load_file_included() {
     print_info ".dat file header is correct."
 
     # Verify file count in zip (excluding the .dat file)
-    local zip_file_count=$(unzip -l "$zip_file" | strings | grep -c "\.$file_type")
+    local zip_file_count=$(unzip -l "$zip_file" | strings | grep -c "\.$file_type" || true)
     if [ "$zip_file_count" -ne "$expected_count" ]; then
         print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
     fi

--- a/tests/run-tests-optimized.sh
+++ b/tests/run-tests-optimized.sh
@@ -103,7 +103,7 @@ function verify_output() {
   print_info ".dat file header is correct."
 
   # Verify file count in zip (using cached zip listing)
-  local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type")
+  local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type" || true)
   if [[ "$zip_file_count" -ne "$expected_count" ]]; then
     print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
   fi
@@ -117,7 +117,7 @@ function verify_output() {
       txt_count=$(echo "$zip_listing" | grep "\.txt$" | grep -v "attachment" | wc -l)
     else
       # For other file types, count all text files
-      txt_count=$(echo "$zip_listing" | grep -c "\.txt")
+      txt_count=$(echo "$zip_listing" | grep -c "\.txt" || true)
     fi
     if [[ "$txt_count" -ne "$expected_count" ]]; then
       print_error "Incorrect .txt file count in .zip file. Expected $expected_count, found $txt_count."
@@ -174,7 +174,7 @@ function verify_eml_output() {
   print_info "Found $attachment_files attachment files in ZIP archive (expected at least $min_expected_attachments)."
 
   # Verify that some attachments are listed in the .dat file (using cached content)
-  local attachment_count=$(echo "$dat_content" | grep -c "attachment")
+  local attachment_count=$(echo "$dat_content" | grep -c "attachment" || true)
   if [[ "$attachment_count" -lt 2 ]]; then
     print_error "No attachments found in .dat file, but they were expected."
   fi
@@ -248,7 +248,7 @@ function verify_load_file_included() {
     get_zip_listing "$zip_file" zip_listing
 
     # Verify .dat file exists in zip archive
-    local dat_in_zip=$(echo "$zip_listing" | grep -c "\.dat$")
+    local dat_in_zip=$(echo "$zip_listing" | grep -c "\.dat$" || true)
     if [[ "$dat_in_zip" -ne 1 ]]; then
         print_error "Expected 1 .dat file in zip archive, found $dat_in_zip"
     fi
@@ -259,7 +259,7 @@ function verify_load_file_included() {
     trap "rm -rf $temp_dir" RETURN
 
     unzip -j "$zip_file" "*.dat" -d "$temp_dir" > /dev/null
-    local extracted_dat=$(find "$temp_dir" -name "*.dat" | head -1)
+    local extracted_dat=$(find "$temp_dir" -name "*.dat" -print -quit)
 
     local dat_content_cmd="cat"
     if [[ "$encoding" = "UTF-16" ]]; then
@@ -291,8 +291,7 @@ function verify_load_file_included() {
     print_info ".dat file header is correct."
 
     # Verify file count in zip (excluding the .dat file, using cached listing)
-    local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type")
-    if [[ "$zip_file_count" -ne "$expected_count" ]]; then
+    local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type" || true)    if [[ "$zip_file_count" -ne "$expected_count" ]]; then
         print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
     fi
     print_info ".zip file count for .$file_type is correct ($zip_file_count)."

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -102,7 +102,7 @@ function verify_output() {
   print_info ".dat file header is correct."
 
   # Verify file count in zip (using cached zip listing)
-  local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type")
+  local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type" || true)
   if [[ "$zip_file_count" -ne "$expected_count" ]]; then
     print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
   fi
@@ -116,7 +116,7 @@ function verify_output() {
       txt_count=$(echo "$zip_listing" | grep "\.txt$" | grep -v "attachment" | wc -l)
     else
       # For other file types, count all text files
-      txt_count=$(echo "$zip_listing" | grep -c "\.txt")
+      txt_count=$(echo "$zip_listing" | grep -c "\.txt" || true)
     fi
     if [[ "$txt_count" -ne "$expected_count" ]]; then
       print_error "Incorrect .txt file count in .zip file. Expected $expected_count, found $txt_count."
@@ -173,7 +173,7 @@ function verify_eml_output() {
   print_info "Found $attachment_files attachment files in ZIP archive (expected at least $min_expected_attachments)."
 
   # Verify that some attachments are listed in the .dat file (using cached content)
-  local attachment_count=$(echo "$dat_content" | grep -c "attachment")
+  local attachment_count=$(echo "$dat_content" | grep -c "attachment" || true)
   if [[ "$attachment_count" -lt 2 ]]; then
     print_error "No attachments found in .dat file, but they were expected."
   fi
@@ -252,7 +252,7 @@ function verify_load_file_included() {
     get_zip_listing "$zip_file" zip_listing
 
     # Verify .dat file exists in zip archive
-    local dat_in_zip=$(echo "$zip_listing" | grep -c "\.dat$")
+    local dat_in_zip=$(echo "$zip_listing" | grep -c "\.dat$" || true)
     if [[ "$dat_in_zip" -ne 1 ]]; then
         print_error "Expected 1 .dat file in zip archive, found $dat_in_zip"
     fi
@@ -263,7 +263,7 @@ function verify_load_file_included() {
     trap "rm -rf $temp_dir" RETURN
 
     unzip -j "$zip_file" "*.dat" -d "$temp_dir" > /dev/null
-    local extracted_dat=$(find "$temp_dir" -name "*.dat" | head -1)
+    local extracted_dat=$(find "$temp_dir" -name "*.dat" -print -quit)
 
     local dat_content_cmd="cat"
     if [[ "$encoding" = "UTF-16" ]]; then
@@ -295,7 +295,7 @@ function verify_load_file_included() {
     print_info ".dat file header is correct."
 
     # Verify file count in zip (excluding the .dat file, using cached listing)
-    local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type")
+    local zip_file_count=$(echo "$zip_listing" | grep -c "\.$file_type" || true)
     if [[ "$zip_file_count" -ne "$expected_count" ]]; then
         print_error "Incorrect file count in .zip file. Expected $expected_count, found $zip_file_count."
     fi

--- a/tests/stress/stress-10gb-filecount.sh
+++ b/tests/stress/stress-10gb-filecount.sh
@@ -159,8 +159,8 @@ validate_results() {
 
     print_info "Validating generated files..."
 
-    local zip_file=$(find "$OUTPUT_DIR" -name "*.zip" | head -1)
-    local dat_file=$(find "$OUTPUT_DIR" -name "*.dat" | head -1)
+    local zip_file=$(find "$OUTPUT_DIR" -name "*.zip" -print -quit)
+    local dat_file=$(find "$OUTPUT_DIR" -name "*.dat" -print -quit)
 
     if [ -z "$zip_file" ]; then
         print_error "No .zip file found"

--- a/tests/stress/stress-30gb-attachments.sh
+++ b/tests/stress/stress-30gb-attachments.sh
@@ -183,8 +183,8 @@ validate_results() {
 
     print_info "Validating attachment-heavy archive..."
 
-    local zip_file=$(find "$OUTPUT_DIR" -name "*.zip" | head -1)
-    local dat_file=$(find "$OUTPUT_DIR" -name "*.dat" | head -1)
+    local zip_file=$(find "$OUTPUT_DIR" -name "*.zip" -print -quit)
+    local dat_file=$(find "$OUTPUT_DIR" -name "*.dat" -print -quit)
 
     if [ -z "$zip_file" ]; then
         print_error "No .zip file found"
@@ -266,7 +266,7 @@ validate_results() {
     fi
 
     # Check for attachment entries in DAT file
-    local attachment_entries=$(grep -c "attachment" "$dat_file" | head -1)
+    local attachment_entries=$(grep -c "attachment" "$dat_file" || true)
     if [ "$attachment_entries" -gt "$EML_COUNT" ]; then
         print_success "Attachment entries found in load file: $(printf "%'d" $attachment_entries)"
     else

--- a/tests/stress/stress-large-loadfile.sh
+++ b/tests/stress/stress-large-loadfile.sh
@@ -145,8 +145,8 @@ run_scenario_1_external_utf8() {
     local duration=$((end_time - start_time))
 
     # Validate results
-    local zip_file=$(find "$scenario_dir" -name "*.zip" | head -1)
-    local dat_file=$(find "$scenario_dir" -name "*.dat" | head -1)
+    local zip_file=$(find "$scenario_dir" -name "*.zip" -print -quit)
+    local dat_file=$(find "$scenario_dir" -name "*.dat" -print -quit)
     local dat_size=$(stat -c%s "$dat_file")
     local dat_size_mb=$(echo "scale=2; $dat_size / 1024^2" | bc)
 
@@ -178,7 +178,7 @@ run_scenario_2_embedded_utf8() {
     local duration=$((end_time - start_time))
 
     # Validate results
-    local zip_file=$(find "$scenario_dir" -name "*.zip" | head -1)
+    local zip_file=$(find "$scenario_dir" -name "*.zip" -print -quit)
     local zip_size=$(stat -c%s "$zip_file")
     local zip_size_mb=$(echo "scale=2; $zip_size / 1024^2" | bc)
 
@@ -186,7 +186,7 @@ run_scenario_2_embedded_utf8() {
     local temp_dir=$(mktemp -d)
     trap "rm -rf $temp_dir" RETURN
     unzip -j "$zip_file" "*.dat" -d "$temp_dir" > /dev/null
-    local embedded_dat=$(find "$temp_dir" -name "*.dat" | head -1)
+    local embedded_dat=$(find "$temp_dir" -name "*.dat" -print -quit)
     local dat_size=$(stat -c%s "$embedded_dat")
     local dat_size_mb=$(echo "scale=2; $dat_size / 1024^2" | bc)
 
@@ -218,8 +218,8 @@ run_scenario_3_external_utf16() {
     local duration=$((end_time - start_time))
 
     # Validate results
-    local zip_file=$(find "$scenario_dir" -name "*.zip" | head -1)
-    local dat_file=$(find "$scenario_dir" -name "*.dat" | head -1)
+    local zip_file=$(find "$scenario_dir" -name "*.zip" -print -quit)
+    local dat_file=$(find "$scenario_dir" -name "*.dat" -print -quit)
     local dat_size=$(stat -c%s "$dat_file")
     local dat_size_mb=$(echo "scale=2; $dat_size / 1024^2" | bc)
 
@@ -250,8 +250,8 @@ run_scenario_4_external_ansi() {
     local duration=$((end_time - start_time))
 
     # Validate results
-    local zip_file=$(find "$scenario_dir" -name "*.zip" | head -1)
-    local dat_file=$(find "$scenario_dir" -name "*.dat" | head -1)
+    local zip_file=$(find "$scenario_dir" -name "*.zip" -print -quit)
+    local dat_file=$(find "$scenario_dir" -name "*.dat" -print -quit)
     local dat_size=$(stat -c%s "$dat_file")
     local dat_size_mb=$(echo "scale=2; $dat_size / 1024^2" | bc)
 
@@ -272,31 +272,31 @@ analyze_performance() {
     local ansi_external_size=0
 
     # Scenario 1: UTF-8 External
-    local dat_file=$(find "$OUTPUT_DIR/scenario1_external_utf8" -name "*.dat" | head -1)
+    local dat_file=$(find "$OUTPUT_DIR/scenario1_external_utf8" -name "*.dat" -print -quit)
     if [ -n "$dat_file" ]; then
         utf8_external_size=$(stat -c%s "$dat_file")
     fi
 
     # Scenario 2: UTF-8 Embedded
-    local zip_file=$(find "$OUTPUT_DIR/scenario2_embedded_utf8" -name "*.zip" | head -1)
+    local zip_file=$(find "$OUTPUT_DIR/scenario2_embedded_utf8" -name "*.zip" -print -quit)
     if [ -n "$zip_file" ]; then
         local temp_dir=$(mktemp -d)
         trap "rm -rf $temp_dir" RETURN
         unzip -j "$zip_file" "*.dat" -d "$temp_dir" > /dev/null
-        local embedded_dat=$(find "$temp_dir" -name "*.dat" | head -1)
+        local embedded_dat=$(find "$temp_dir" -name "*.dat" -print -quit)
         if [ -n "$embedded_dat" ]; then
             utf8_embedded_size=$(stat -c%s "$embedded_dat")
         fi
     fi
 
     # Scenario 3: UTF-16 External
-    dat_file=$(find "$OUTPUT_DIR/scenario3_external_utf16" -name "*.dat" | head -1)
+    dat_file=$(find "$OUTPUT_DIR/scenario3_external_utf16" -name "*.dat" -print -quit)
     if [ -n "$dat_file" ]; then
         utf16_external_size=$(stat -c%s "$dat_file")
     fi
 
     # Scenario 4: ANSI External
-    dat_file=$(find "$OUTPUT_DIR/scenario4_external_ansi" -name "*.dat" | head -1)
+    dat_file=$(find "$OUTPUT_DIR/scenario4_external_ansi" -name "*.dat" -print -quit)
     if [ -n "$dat_file" ]; then
         ansi_external_size=$(stat -c%s "$dat_file")
     fi
@@ -335,7 +335,7 @@ analyze_performance() {
     local expected_lines=$((FILE_COUNT + 1))  # +1 for header
 
     for scenario in "scenario1_external_utf8" "scenario3_external_utf16" "scenario4_external_ansi"; do
-        local dat_file=$(find "$OUTPUT_DIR/$scenario" -name "*.dat" | head -1)
+        local dat_file=$(find "$OUTPUT_DIR/$scenario" -name "*.dat" -print -quit)
         if [ -n "$dat_file" ]; then
             local line_count=$(wc -l < "$dat_file")
             if [ "$line_count" -eq "$expected_lines" ]; then

--- a/tests/test-chaos-anomaly-coverage.sh
+++ b/tests/test-chaos-anomaly-coverage.sh
@@ -70,13 +70,13 @@ print_success "Golden fixture schema validation — PASSED"
 # ---------------------------------------------------------------------------
 print_info "Generating no-chaos DAT baseline (seed 42, count 500)..."
 zipper --loadfile-only --count 500 --output-path "$TEST_OUTPUT_DIR/baseline_dat" --seed 42
-BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline_dat" -name "*.dat" | head -1)
+BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline_dat" -name "*.dat" -print -quit)
 [[ -z "$BASELINE_DAT" ]] && print_error "No baseline DAT file generated"
 
 print_info "Generating no-chaos OPT baseline (seed 42, count 500)..."
 zipper --loadfile-only --loadfile-format opt --count 500 \
     --output-path "$TEST_OUTPUT_DIR/baseline_opt" --seed 42
-BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline_opt" -name "*.opt" | head -1)
+BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline_opt" -name "*.opt" -print -quit)
 [[ -z "$BASELINE_OPT" ]] && print_error "No baseline OPT file generated"
 
 # ---------------------------------------------------------------------------
@@ -97,7 +97,7 @@ while IFS= read -r TYPE; do
     zipper --loadfile-only --count 500 --output-path "$OUT_DIR/run1" \
         --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
 
-    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" -print -quit)
     [[ -z "$PROPS" ]] && print_error "No _properties.json for type: $TYPE"
 
     # B3: schema
@@ -134,7 +134,7 @@ while IFS= read -r TYPE; do
     [[ -n "$BAD_LINES" ]] && print_error "Line number out of [1,$MAX_LINE] for type: $TYPE: $BAD_LINES"
 
     # Baseline diff: chaos file must differ from no-chaos baseline
-    CHAOS_DAT=$(find "$OUT_DIR/run1" -name "*.dat" | head -1)
+    CHAOS_DAT=$(find "$OUT_DIR/run1" -name "*.dat" -print -quit)
     if cmp -s "$BASELINE_DAT" "$CHAOS_DAT" 2>/dev/null; then
         print_error "Chaos DAT identical to baseline for type: $TYPE — anomaly not injected?"
     fi
@@ -142,8 +142,8 @@ while IFS= read -r TYPE; do
     # Determinism: run 2 must produce byte-identical output
     zipper --loadfile-only --count 500 --output-path "$OUT_DIR/run2" \
         --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
-    CHAOS_DAT2=$(find "$OUT_DIR/run2" -name "*.dat" | head -1)
-    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+    CHAOS_DAT2=$(find "$OUT_DIR/run2" -name "*.dat" -print -quit)
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" -print -quit)
     cmp -s "$CHAOS_DAT" "$CHAOS_DAT2" \
         || print_error "Determinism failed (DAT differs) for type: $TYPE"
     # Compare _properties.json content excluding fileName (which contains a timestamp)
@@ -176,7 +176,7 @@ while IFS= read -r TYPE; do
         --output-path "$OUT_DIR/run1" \
         --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
 
-    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" -print -quit)
     [[ -z "$PROPS" ]] && print_error "No _properties.json for OPT type: $TYPE"
 
     validate_properties_json "$PROPS"
@@ -206,7 +206,7 @@ while IFS= read -r TYPE; do
         | .[]?' "$PROPS" 2>/dev/null || true)
     [[ -n "$BAD_LINES" ]] && print_error "Line number out of [1,$MAX_LINE] for OPT type: $TYPE"
 
-    CHAOS_OPT=$(find "$OUT_DIR/run1" -name "*.opt" | head -1)
+    CHAOS_OPT=$(find "$OUT_DIR/run1" -name "*.opt" -print -quit)
     if cmp -s "$BASELINE_OPT" "$CHAOS_OPT" 2>/dev/null; then
         print_error "Chaos OPT identical to baseline for type: $TYPE — anomaly not injected?"
     fi
@@ -214,8 +214,8 @@ while IFS= read -r TYPE; do
     zipper --loadfile-only --loadfile-format opt --count 500 \
         --output-path "$OUT_DIR/run2" \
         --chaos-mode --chaos-types "$TYPE" --chaos-amount 10 --seed 42
-    CHAOS_OPT2=$(find "$OUT_DIR/run2" -name "*.opt" | head -1)
-    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+    CHAOS_OPT2=$(find "$OUT_DIR/run2" -name "*.opt" -print -quit)
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" -print -quit)
     cmp -s "$CHAOS_OPT" "$CHAOS_OPT2" \
         || print_error "Determinism failed (OPT differs) for type: $TYPE"
     PROPS_CANONICAL=$(jq 'del(.fileName)' "$PROPS")
@@ -254,7 +254,7 @@ while IFS= read -r SCENARIO; do
         --output-path "$OUT_DIR/run1" \
         --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 $FORMAT_FLAG
 
-    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" | head -1)
+    PROPS=$(find "$OUT_DIR/run1" -name "*_properties.json" -print -quit)
     [[ -z "$PROPS" ]] && print_error "No _properties.json for scenario: $SCENARIO"
 
     validate_properties_json "$PROPS"
@@ -278,14 +278,14 @@ while IFS= read -r SCENARIO; do
         --output-path "$OUT_DIR/run2" \
         --chaos-mode --chaos-scenario "$SCENARIO" --seed 42 $FORMAT_FLAG
 
-    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" | head -1)
+    PROPS2=$(find "$OUT_DIR/run2" -name "*_properties.json" -print -quit)
 
     if [[ "$FMT" == "opt" ]]; then
-        FILE1=$(find "$OUT_DIR/run1" -name "*.opt" | head -1)
-        FILE2=$(find "$OUT_DIR/run2" -name "*.opt" | head -1)
+        FILE1=$(find "$OUT_DIR/run1" -name "*.opt" -print -quit)
+        FILE2=$(find "$OUT_DIR/run2" -name "*.opt" -print -quit)
     else
-        FILE1=$(find "$OUT_DIR/run1" -name "*.dat" | head -1)
-        FILE2=$(find "$OUT_DIR/run2" -name "*.dat" | head -1)
+        FILE1=$(find "$OUT_DIR/run1" -name "*.dat" -print -quit)
+        FILE2=$(find "$OUT_DIR/run2" -name "*.dat" -print -quit)
     fi
     cmp -s "$FILE1" "$FILE2" \
         || print_error "Determinism failed (load file differs) for scenario: $SCENARIO"

--- a/tests/test-chaos-production-set.sh
+++ b/tests/test-chaos-production-set.sh
@@ -42,8 +42,8 @@ print_info "T1: Production-set mode — chaos DAT/OPT and properties must differ
 zipper --type pdf --count 100 --seed 42 \
     --production-set --bates-prefix CHAOS \
     --output-path "$TEST_OUTPUT_DIR/baseline"
-BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline" -name "$DAT_NAME" | head -1)
-BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline" -name "$OPT_NAME" | head -1)
+BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline" -name "$DAT_NAME" -print -quit)
+BASELINE_OPT=$(find "$TEST_OUTPUT_DIR/baseline" -name "$OPT_NAME" -print -quit)
 [[ -z "$BASELINE_DAT" ]] && print_error "No baseline production-set DAT generated"
 [[ -z "$BASELINE_OPT" ]] && print_error "No baseline production-set OPT generated"
 
@@ -51,9 +51,9 @@ zipper --type pdf --count 100 --seed 42 \
     --production-set --bates-prefix CHAOS \
     --chaos-mode --chaos-types quotes --chaos-amount "10%" \
     --output-path "$TEST_OUTPUT_DIR/chaos_run1"
-CHAOS_DAT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$DAT_NAME" | head -1)
-CHAOS_OPT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$OPT_NAME" | head -1)
-CHAOS_PROPERTIES=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$PROPERTIES_NAME" | head -1)
+CHAOS_DAT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$DAT_NAME" -print -quit)
+CHAOS_OPT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$OPT_NAME" -print -quit)
+CHAOS_PROPERTIES=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$PROPERTIES_NAME" -print -quit)
 [[ -z "$CHAOS_DAT" ]] && print_error "No chaos production-set DAT generated"
 [[ -z "$CHAOS_OPT" ]] && print_error "No chaos production-set OPT generated"
 [[ -z "$CHAOS_PROPERTIES" ]] && print_error "No chaos properties generated"
@@ -84,9 +84,9 @@ zipper --type pdf --count 100 --seed 42 \
     --production-set --bates-prefix CHAOS \
     --chaos-mode --chaos-types quotes --chaos-amount "10%" \
     --output-path "$TEST_OUTPUT_DIR/chaos_run2"
-CHAOS_DAT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$DAT_NAME" | head -1)
-CHAOS_OPT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$OPT_NAME" | head -1)
-CHAOS_PROPERTIES2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$PROPERTIES_NAME" | head -1)
+CHAOS_DAT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$DAT_NAME" -print -quit)
+CHAOS_OPT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$OPT_NAME" -print -quit)
+CHAOS_PROPERTIES2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$PROPERTIES_NAME" -print -quit)
 [[ -z "$CHAOS_DAT2" ]] && print_error "No chaos DAT2 for production-set"
 [[ -z "$CHAOS_OPT2" ]] && print_error "No chaos OPT2 for production-set"
 [[ -z "$CHAOS_PROPERTIES2" ]] && print_error "No chaos properties2 for production-set"
@@ -110,8 +110,8 @@ print_info "T3: No-chaos production-set baseline is stable across two runs"
 zipper --type pdf --count 100 --seed 42 \
     --production-set --bates-prefix CHAOS \
     --output-path "$TEST_OUTPUT_DIR/baseline2"
-BASELINE2_DAT=$(find "$TEST_OUTPUT_DIR/baseline2" -name "$DAT_NAME" | head -1)
-BASELINE2_OPT=$(find "$TEST_OUTPUT_DIR/baseline2" -name "$OPT_NAME" | head -1)
+BASELINE2_DAT=$(find "$TEST_OUTPUT_DIR/baseline2" -name "$DAT_NAME" -print -quit)
+BASELINE2_OPT=$(find "$TEST_OUTPUT_DIR/baseline2" -name "$OPT_NAME" -print -quit)
 [[ -z "$BASELINE2_DAT" ]] && print_error "No second baseline DAT"
 [[ -z "$BASELINE2_OPT" ]] && print_error "No second baseline OPT"
 

--- a/tests/test-chaos-standard-mode.sh
+++ b/tests/test-chaos-standard-mode.sh
@@ -39,14 +39,14 @@ print_info "T1: Standard mode — chaos DAT must differ from no-chaos baseline"
 
 zipper --type pdf --count 200 --seed 42 \
     --output-path "$TEST_OUTPUT_DIR/baseline"
-BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline" -name "*.dat" | head -1)
+BASELINE_DAT=$(find "$TEST_OUTPUT_DIR/baseline" -name "*.dat" -print -quit)
 [[ -z "$BASELINE_DAT" ]] && print_error "No baseline DAT file generated"
 
 zipper --type pdf --count 200 --seed 42 \
     --chaos-mode --chaos-types quotes --chaos-amount "10%" \
     --output-path "$TEST_OUTPUT_DIR/chaos_run1"
-CHAOS_DAT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "*.dat" | head -1)
-CHAOS_PROPERTIES=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$PROPERTIES_NAME" | head -1)
+CHAOS_DAT=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "*.dat" -print -quit)
+CHAOS_PROPERTIES=$(find "$TEST_OUTPUT_DIR/chaos_run1" -name "$PROPERTIES_NAME" -print -quit)
 [[ -z "$CHAOS_DAT" ]] && print_error "No chaos DAT file generated"
 [[ -z "$CHAOS_PROPERTIES" ]] && print_error "No chaos properties generated"
 
@@ -72,8 +72,8 @@ print_info "T2: Standard mode — determinism (same seed → same output)"
 zipper --type pdf --count 200 --seed 42 \
     --chaos-mode --chaos-types quotes --chaos-amount "10%" \
     --output-path "$TEST_OUTPUT_DIR/chaos_run2"
-CHAOS_DAT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "*.dat" | head -1)
-CHAOS_PROPERTIES2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$PROPERTIES_NAME" | head -1)
+CHAOS_DAT2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "*.dat" -print -quit)
+CHAOS_PROPERTIES2=$(find "$TEST_OUTPUT_DIR/chaos_run2" -name "$PROPERTIES_NAME" -print -quit)
 [[ -z "$CHAOS_DAT2" ]] && print_error "No chaos DAT2 file generated"
 [[ -z "$CHAOS_PROPERTIES2" ]] && print_error "No chaos properties2 generated"
 
@@ -95,7 +95,7 @@ for TYPE in mixed-delimiters quotes columns eol encoding; do
         --chaos-mode --chaos-types "$TYPE" --chaos-amount "10%" \
         --output-path "$OUT_DIR"
 
-    TYPE_DAT=$(find "$OUT_DIR" -name "*.dat" | head -1)
+    TYPE_DAT=$(find "$OUT_DIR" -name "*.dat" -print -quit)
     [[ -z "$TYPE_DAT" ]] && print_error "No DAT for chaos type: $TYPE"
 
     if cmp -s "$BASELINE_DAT" "$TYPE_DAT"; then
@@ -117,7 +117,7 @@ zipper --type pdf --count 200 --seed 42 \
     --include-load-file \
     --output-path "$TEST_OUTPUT_DIR/chaos_run3"
 
-CHAOS_ZIP=$(find "$TEST_OUTPUT_DIR/chaos_run3" -name "*.zip" | head -1)
+CHAOS_ZIP=$(find "$TEST_OUTPUT_DIR/chaos_run3" -name "*.zip" -print -quit)
 [[ -z "$CHAOS_ZIP" ]] && print_error "No ZIP archive generated"
 
 # Check ZIP contents

--- a/tests/test-column-profile-builtin-matrix.sh
+++ b/tests/test-column-profile-builtin-matrix.sh
@@ -91,7 +91,7 @@ for profile in "${PROFILES[@]}"; do
                 --loadfile-only \
                 --output-path "$out_dir"
 
-            dat_file=$(find "$out_dir" -name "*.dat" | head -1)
+            dat_file=$(find "$out_dir" -name "*.dat" -print -quit)
             [[ -z "$dat_file" ]] && print_error "${combo}: No .dat file produced"
 
             # --- Assertion 1: Column headers match profile declaration in order ---
@@ -124,7 +124,7 @@ for profile in "${PROFILES[@]}"; do
                     --loadfile-only \
                     --output-path "$rerun_dir"
 
-                rerun_dat=$(find "$rerun_dir" -name "*.dat" | head -1)
+                rerun_dat=$(find "$rerun_dir" -name "*.dat" -print -quit)
                 if ! diff -q "$dat_file" "$rerun_dat" > /dev/null 2>&1; then
                     print_error "${combo}: Output is not deterministic — two runs with seed=42 differ"
                 fi
@@ -136,8 +136,8 @@ for profile in "${PROFILES[@]}"; do
 
         # --- Assertion 4: Seed sensitivity — seed=42 vs seed=1337 differ ---
         TOTAL=$((TOTAL + 1))
-        seed42_dat=$(find "$TEST_OUTPUT_DIR/${profile}_${filetype}_seed42" -name "*.dat" | head -1)
-        seed1337_dat=$(find "$TEST_OUTPUT_DIR/${profile}_${filetype}_seed1337" -name "*.dat" | head -1)
+        seed42_dat=$(find "$TEST_OUTPUT_DIR/${profile}_${filetype}_seed42" -name "*.dat" -print -quit)
+        seed1337_dat=$(find "$TEST_OUTPUT_DIR/${profile}_${filetype}_seed1337" -name "*.dat" -print -quit)
 
         if diff -q "$seed42_dat" "$seed1337_dat" > /dev/null 2>&1; then
             print_error "seed-sensitivity (${profile}/${filetype}): seed=42 and seed=1337 produced identical output"

--- a/tests/test-column-profile-custom-kinds.sh
+++ b/tests/test-column-profile-custom-kinds.sh
@@ -33,7 +33,7 @@ zipper \
     --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/run1"
 
-dat_file=$(find "$TEST_OUTPUT_DIR/run1" -name "*.dat" | head -1)
+dat_file=$(find "$TEST_OUTPUT_DIR/run1" -name "*.dat" -print -quit)
 [[ -z "$dat_file" ]] && print_error "No .dat file produced"
 
 # Expected columns from the fixture profile (same order as the JSON).
@@ -206,7 +206,7 @@ zipper \
     --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/run2"
 
-dat_file2=$(find "$TEST_OUTPUT_DIR/run2" -name "*.dat" | head -1)
+dat_file2=$(find "$TEST_OUTPUT_DIR/run2" -name "*.dat" -print -quit)
 if ! diff -q "$dat_file" "$dat_file2" > /dev/null 2>&1; then
     print_error "Determinism check failed: two runs with seed=$SEED differ"
 fi

--- a/tests/test-column-profile-empty-pct.sh
+++ b/tests/test-column-profile-empty-pct.sh
@@ -63,7 +63,7 @@ for seed in 1 42 99 1337; do
         --loadfile-only \
         --output-path "$out_dir"
 
-    dat_file=$(find "$out_dir" -name "*.dat" | head -1)
+    dat_file=$(find "$out_dir" -name "*.dat" -print -quit)
     [[ -z "$dat_file" ]] && print_error "No .dat file produced (seed=$seed)"
 
     empties=$(count_empties "$dat_file")
@@ -99,7 +99,7 @@ zipper \
     --seed 42 --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/pct0"
 
-dat_0=$(find "$TEST_OUTPUT_DIR/pct0" -name "*.dat" | head -1)
+dat_0=$(find "$TEST_OUTPUT_DIR/pct0" -name "*.dat" -print -quit)
 empties_0=$(count_empties "$dat_0")
 [[ "$empties_0" -ne 0 ]] && print_error "EmptyPercentage=0: expected 0 empties, got $empties_0"
 print_success "EmptyPercentage=0: exactly 0 empty values"
@@ -128,7 +128,7 @@ zipper \
     --seed 42 --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/pct100"
 
-dat_100=$(find "$TEST_OUTPUT_DIR/pct100" -name "*.dat" | head -1)
+dat_100=$(find "$TEST_OUTPUT_DIR/pct100" -name "*.dat" -print -quit)
 empties_100=$(count_empties "$dat_100")
 [[ "$empties_100" -ne "$COUNT" ]] && print_error "EmptyPercentage=100: expected $COUNT empties, got $empties_100"
 print_success "EmptyPercentage=100: all $COUNT values are empty"
@@ -157,7 +157,7 @@ zipper \
     --seed 42 --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/pct10"
 
-dat_10=$(find "$TEST_OUTPUT_DIR/pct10" -name "*.dat" | head -1)
+dat_10=$(find "$TEST_OUTPUT_DIR/pct10" -name "*.dat" -print -quit)
 empties_10=$(count_empties "$dat_10")
 print_info "EmptyPercentage=10: observed $empties_10 empty out of $COUNT"
 if ! bash "$CHI_SQ" "$empties_10" "$COUNT" "0.10" "$SIGNIFICANCE"; then
@@ -189,7 +189,7 @@ zipper \
     --seed 42 --loadfile-only \
     --output-path "$TEST_OUTPUT_DIR/pct50"
 
-dat_50=$(find "$TEST_OUTPUT_DIR/pct50" -name "*.dat" | head -1)
+dat_50=$(find "$TEST_OUTPUT_DIR/pct50" -name "*.dat" -print -quit)
 empties_50=$(count_empties "$dat_50")
 print_info "EmptyPercentage=50: observed $empties_50 empty out of $COUNT"
 if ! bash "$CHI_SQ" "$empties_50" "$COUNT" "0.50" "$SIGNIFICANCE"; then

--- a/tests/test-cross-platform.sh
+++ b/tests/test-cross-platform.sh
@@ -60,8 +60,8 @@ test_basic_functionality() {
     zipper --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/basic_pdf"
 
     # Check for .zip and .dat files (Zipper uses timestamped archive names)
-    local zip_file=$(find "$TEST_OUTPUT_DIR/basic_pdf" -name "*.zip" 2>/dev/null | head -1)
-    local dat_file=$(find "$TEST_OUTPUT_DIR/basic_pdf" -name "*.dat" 2>/dev/null | head -1)
+    local zip_file=$(find "$TEST_OUTPUT_DIR/basic_pdf" -name "*.zip" -print -quit 2>/dev/null)
+    local dat_file=$(find "$TEST_OUTPUT_DIR/basic_pdf" -name "*.dat" -print -quit 2>/dev/null)
 
     if [[ -n "$zip_file" ]] && [[ -n "$dat_file" ]]; then
         print_success "Basic PDF generation completed"
@@ -74,8 +74,8 @@ test_basic_functionality() {
     print_info "Test 2: Basic EML generation"
     zipper --type eml --count 3 --output-path "$TEST_OUTPUT_DIR/basic_eml"
 
-    zip_file=$(find "$TEST_OUTPUT_DIR/basic_eml" -name "*.zip" 2>/dev/null | head -1)
-    dat_file=$(find "$TEST_OUTPUT_DIR/basic_eml" -name "*.dat" 2>/dev/null | head -1)
+    zip_file=$(find "$TEST_OUTPUT_DIR/basic_eml" -name "*.zip" -print -quit 2>/dev/null)
+    dat_file=$(find "$TEST_OUTPUT_DIR/basic_eml" -name "*.dat" -print -quit 2>/dev/null)
 
     if [[ -n "$zip_file" ]] && [[ -n "$dat_file" ]]; then
         print_success "Basic EML generation completed"
@@ -97,9 +97,9 @@ test_basic_functionality() {
     zipper --type pdf --count 3 --output-path "$TEST_OUTPUT_DIR/ansi" --encoding ANSI
 
     # Check all files exist (Zipper creates subdirectories with timestamped archives)
-    local utf8_zip=$(find "$TEST_OUTPUT_DIR/utf8" -name "*.zip" 2>/dev/null | head -1)
-    local utf16_zip=$(find "$TEST_OUTPUT_DIR/utf16" -name "*.zip" 2>/dev/null | head -1)
-    local ansi_zip=$(find "$TEST_OUTPUT_DIR/ansi" -name "*.zip" 2>/dev/null | head -1)
+    local utf8_zip=$(find "$TEST_OUTPUT_DIR/utf8" -name "*.zip" -print -quit 2>/dev/null)
+    local utf16_zip=$(find "$TEST_OUTPUT_DIR/utf16" -name "*.zip" -print -quit 2>/dev/null)
+    local ansi_zip=$(find "$TEST_OUTPUT_DIR/ansi" -name "*.zip" -print -quit 2>/dev/null)
 
     if [[ -n "$utf8_zip" ]] && [[ -n "$utf16_zip" ]] && [[ -n "$ansi_zip" ]]; then
         print_success "All encoding tests completed"
@@ -114,7 +114,7 @@ test_basic_functionality() {
     for dist in "proportional" "gaussian" "exponential"; do
         zipper --type pdf --count 10 --output-path "$TEST_OUTPUT_DIR/dist_${dist}" --folders 3 --distribution "$dist"
 
-        local dist_zip=$(find "$TEST_OUTPUT_DIR/dist_${dist}" -name "*.zip" 2>/dev/null | head -1)
+        local dist_zip=$(find "$TEST_OUTPUT_DIR/dist_${dist}" -name "*.zip" -print -quit 2>/dev/null)
         if [[ -n "$dist_zip" ]]; then
             print_success "${dist} distribution test completed"
         else
@@ -145,8 +145,8 @@ test_refactored_components() {
     # Verify all tests (Zipper creates subdirectories with timestamped archives)
     local tests=("metadata" "text" "eml_attachments")
     for test in "${tests[@]}"; do
-        local test_zip=$(find "$TEST_OUTPUT_DIR/${test}" -name "*.zip" 2>/dev/null | head -1)
-        local test_dat=$(find "$TEST_OUTPUT_DIR/${test}" -name "*.dat" 2>/dev/null | head -1)
+        local test_zip=$(find "$TEST_OUTPUT_DIR/${test}" -name "*.zip" -print -quit 2>/dev/null)
+        local test_dat=$(find "$TEST_OUTPUT_DIR/${test}" -name "*.dat" -print -quit 2>/dev/null)
         if [[ -n "$test_zip" ]] && [[ -n "$test_dat" ]]; then
             print_success "${test} test completed"
         else
@@ -168,8 +168,8 @@ test_filesystem_compatibility() {
     for path in "${test_paths[@]}"; do
         zipper --type pdf --count 2 --output-path "$path"
 
-        local path_zip=$(find "$path" -name "*.zip" 2>/dev/null | head -1)
-        local path_dat=$(find "$path" -name "*.dat" 2>/dev/null | head -1)
+        local path_zip=$(find "$path" -name "*.zip" -print -quit 2>/dev/null)
+        local path_dat=$(find "$path" -name "*.dat" -print -quit 2>/dev/null)
         if [[ -n "$path_zip" ]] && [[ -n "$path_dat" ]]; then
             print_success "Path compatibility test: '$path'"
         else
@@ -182,8 +182,8 @@ test_filesystem_compatibility() {
     print_info "Testing special characters"
     zipper --folders 1 --distribution proportional --type pdf --count 2 --output-path "$TEST_OUTPUT_DIR/special"
 
-    local special_zip=$(find "$TEST_OUTPUT_DIR/special" -name "*.zip" 2>/dev/null | head -1)
-    local special_dat=$(find "$TEST_OUTPUT_DIR/special" -name "*.dat" 2>/dev/null | head -1)
+    local special_zip=$(find "$TEST_OUTPUT_DIR/special" -name "*.zip" -print -quit 2>/dev/null)
+    local special_dat=$(find "$TEST_OUTPUT_DIR/special" -name "*.dat" -print -quit 2>/dev/null)
     if [[ -n "$special_zip" ]] && [[ -n "$special_dat" ]]; then
         print_success "Special characters test completed"
     else
@@ -212,8 +212,8 @@ test_performance() {
     fi
 
     # Verify output (Zipper creates subdirectories with timestamped archives)
-    local perf_zip=$(find "$TEST_OUTPUT_DIR/perf" -name "*.zip" 2>/dev/null | head -1)
-    local perf_dat=$(find "$TEST_OUTPUT_DIR/perf" -name "*.dat" 2>/dev/null | head -1)
+    local perf_zip=$(find "$TEST_OUTPUT_DIR/perf" -name "*.zip" -print -quit 2>/dev/null)
+    local perf_dat=$(find "$TEST_OUTPUT_DIR/perf" -name "*.dat" -print -quit 2>/dev/null)
     if [[ -n "$perf_zip" ]] && [[ -n "$perf_dat" ]]; then
         print_success "Performance test output verified"
     else

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -18,14 +18,6 @@ FILE_COUNT=20 # Use a consistent number of files for most tests
 # Shared binary resolver: builds once, exposes the `zipper` function.
 # shellcheck source=./_zipper-cli.sh
 source "$(dirname "$0")/_zipper-cli.sh"
-# Keep ZIPPER_CMD available for any eval/exec call sites that reference it.
-if [[ -n "${_ZIPPER_BIN:-}" ]] && [[ -x "${_ZIPPER_BIN}" ]]; then
-    ZIPPER_CMD="${_ZIPPER_BIN}"
-else
-    # Fallback WITHOUT --no-build: if the helper's build failed, dotnet run
-    # needs to be able to compile on demand.
-    ZIPPER_CMD="dotnet run -c Release --project $REPO_ROOT/src/Zipper.csproj --"
-fi
 
 # Clean up function
 cleanup() {
@@ -92,7 +84,7 @@ verify_attachments() {
     fi
 
     local attachment_dat_count
-    attachment_dat_count=$(tail -n +2 "$dat_file" | cut -d$'\024' -f"$attachment_col_index" | grep -c -v '^þþ$')
+    attachment_dat_count=$(tail -n +2 "$dat_file" | cut -d$'\024' -f"$attachment_col_index" | grep -c -v '^þþ$' || true)
     
     local attachment_zip_count
     # Robustly get filenames and count attachments
@@ -201,7 +193,7 @@ run_test() {
 
             if [[ "$check_attachments" = true ]]; then
                 local eml_count
-                eml_count=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -v '/$' | grep -c '\.eml$')
+                eml_count=$(unzip -l "$archive_file" | awk '/[0-9][0-9]:[0-9][0-9]/ {print $4}' | grep -v '/$' | grep -c '\.eml$' || true)
                 if ! verify_attachments "$dat_file" "$archive_file" "$attachment_rate" "$eml_count"; then
                     all_checks_passed=false
                 fi

--- a/tests/test-load-file-formats.sh
+++ b/tests/test-load-file-formats.sh
@@ -258,7 +258,7 @@ for format in "dat" "opt" "csv" "xml" "concordance"; do
     "concordance") ext="dat" ;;
   esac
 
-  load_file=$(find "$TEST_OUTPUT_DIR/test6_$format" -name "*.$ext")
+  load_file=$(find "$TEST_OUTPUT_DIR/test6_$format" -name "*.$ext" -print -quit)
 
   if [[ -z "$load_file" ]]; then
     print_error "Test 6: No .$ext file found for format $format"

--- a/tests/test-office-formats.sh
+++ b/tests/test-office-formats.sh
@@ -182,7 +182,7 @@ for format in "dat" "opt" "csv" "xml"; do
     "xml") ext="xml" ;;
   esac
 
-  load_file=$(find "$TEST_OUTPUT_DIR/test5_$format" -name "*.$ext")
+  load_file=$(find "$TEST_OUTPUT_DIR/test5_$format" -name "*.$ext" -print -quit)
 
   if [[ -z "$load_file" ]]; then
     print_error "Test 5: No .$ext file found for format $format"

--- a/tests/test-production-sets.sh
+++ b/tests/test-production-sets.sh
@@ -46,7 +46,7 @@ zipper \
   --volume-size 3
 
 # Find production dir
-prod_dir=$(find "$TEST_OUTPUT_DIR/test1" -type d -name "PRODUCTION_*" | head -n 1)
+prod_dir=$(find "$TEST_OUTPUT_DIR/test1" -type d -name "PRODUCTION_*" -print -quit)
 
 if [[ -z "$prod_dir" ]]; then
   print_error "Test 1: No production directory found."
@@ -64,8 +64,8 @@ if [[ ! -f "$prod_dir/DATA/loadfile.opt" ]]; then print_error "Missing OPT load 
 if [[ ! -f "$prod_dir/_manifest.json" ]]; then print_error "Missing manifest JSON"; fi
 
 # Verify volumes (10 docs / 3 = 4 volumes)
-vol1=$(find "$prod_dir/NATIVES" -name "VOL001")
-vol4=$(find "$prod_dir/NATIVES" -name "VOL004")
+vol1=$(find "$prod_dir/NATIVES" -name "VOL001" -print -quit)
+vol4=$(find "$prod_dir/NATIVES" -name "VOL004" -print -quit)
 if [[ -z "$vol1" ]]; then print_error "Missing VOL001"; fi
 if [[ -z "$vol4" ]]; then print_error "Missing VOL004"; fi
 
@@ -88,14 +88,14 @@ zipper \
   --output-path "$TEST_OUTPUT_DIR/test2" \
   --bates-prefix "ZIP"
 
-zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" | head -n 1)
+zip_file=$(find "$TEST_OUTPUT_DIR/test2" -name "*.zip" -print -quit)
 
 if [[ -z "$zip_file" ]]; then
   print_error "Test 2: No ZIP archive generated."
 fi
 
 # Make sure manifest exists and matches
-prod_dir=$(find "$TEST_OUTPUT_DIR/test2" -type d -name "PRODUCTION_*" | head -n 1)
+prod_dir=$(find "$TEST_OUTPUT_DIR/test2" -type d -name "PRODUCTION_*" -print -quit)
 if [[ ! -f "$prod_dir/_manifest.json" ]]; then print_error "Missing manifest JSON"; fi
 
 print_success "Test Case 2: Production ZIP passed"


### PR DESCRIPTION
## Summary
Follow-up to #298 — fixes issues identified in review that would cause test failures under `set -euo pipefail`.

## Changes

### `grep -c` guarded with `|| true`
`grep -c` returns exit code 1 when zero matches are found, which kills the script under `set -e`. All instances now use `|| true`.

### `find | head -n 1` replaced with `-print -quit`
Under `set -o pipefail`, piping `find` to `head` causes SIGPIPE when `head` closes the pipe early. Replaced all instances with `find ... -print -quit`.

### Dead code removed
Removed unused `ZIPPER_CMD` variable from `test-eml-comprehensive.sh`.

## Testing
- Unit tests: 890 passed
- E2E basic: 5/5 passed
- E2E loadfile: 7/7 passed
- Golden regression: 13/13 passed
- Chaos standard mode: 8/8 passed
- Column profile matrix: 60/60 passed
- Production sets: passed

Closes #294