### PR TITLE
fix: resolve CodedGenerator infinite-loop on multi-value + weighted/pareto

### DIFF
--- a/src/Profiles/Generation/CodedGenerator.cs
+++ b/src/Profiles/Generation/CodedGenerator.cs
@@ -35,9 +35,10 @@ internal sealed class CodedGenerator : IColumnValueGenerator
             }
 
             var selected = new HashSet<string>();
+            selected.Add(this.PickValue(context));
             while (selected.Count < count && selected.Count < this.values.Count)
             {
-                selected.Add(this.PickValue(context));
+                selected.Add(this.values[context.Seeded.Next(this.values.Count)]);
             }
 
             return string.Join(this.multiValueDelimiter, selected);

--- a/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+using Zipper.Profiles;
+using Zipper.Profiles.Generation;
+
+namespace Zipper.Tests.Profiles.Generation;
+
+public class CodedGeneratorTests
+{
+    private static ColumnDefinition MultiValueColumn(int min = 2, int max = 3) => new()
+    {
+        Name = "TestCoded",
+        Type = "coded",
+        MultiValue = true,
+        MultiValueCount = new RangeConfig { Min = min, Max = max },
+    };
+
+    private static ProfileSettings DefaultSettings() => new() { MultiValueDelimiter = ";" };
+
+    private static ColumnGenerationContext MakeContext(int docIndex, int seed = 42) => new()
+    {
+        NativeFileIndex = docIndex,
+        FolderNumber = 1,
+        DocumentIndex = docIndex,
+        Seeded = new Random(seed + docIndex),
+        Now = DateTime.UtcNow,
+    };
+
+    private static int[] WeightedIndices(int count)
+    {
+        // All point to first value — worst case for the bug
+        var indices = new int[count];
+        return indices;
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task Generate_MultiValue_Weighted_CompletesAndReturnsDistinctValues()
+    {
+        var values = new List<string> { "Alpha", "Beta", "Gamma", "Delta" };
+        var indices = WeightedIndices(100);
+        var col = MultiValueColumn(min: 2, max: 3);
+        var generator = new CodedGenerator(values, indices, col, DefaultSettings());
+
+        var result = await Task.Run(() => generator.Generate(MakeContext(0)));
+
+        var parts = result.Split(';');
+        Assert.InRange(parts.Length, 2, 3);
+        Assert.Equal(parts.Length, parts.Distinct().Count());
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task Generate_MultiValue_Pareto_CompletesAndReturnsDistinctValues()
+    {
+        var values = new List<string> { "Red", "Green", "Blue", "Yellow" };
+
+        // Pareto-like: heavily skewed toward index 0
+        var indices = Enumerable.Range(0, 200).Select(i => i < 180 ? 0 : 1).ToArray();
+        var col = MultiValueColumn(min: 2, max: 3);
+        var generator = new CodedGenerator(values, indices, col, DefaultSettings());
+
+        var result = await Task.Run(() => generator.Generate(MakeContext(5)));
+
+        var parts = result.Split(';');
+        Assert.InRange(parts.Length, 2, 3);
+        Assert.Equal(parts.Length, parts.Distinct().Count());
+    }
+
+    [Fact]
+    public void Generate_SingleValue_Weighted_UsesDocumentIndexPath()
+    {
+        var values = new List<string> { "One", "Two", "Three" };
+        var indices = new[] { 2, 0, 1 };
+        var col = new ColumnDefinition { Name = "Test", Type = "coded", MultiValue = false };
+        var generator = new CodedGenerator(values, indices, col, DefaultSettings());
+
+        // index 0 -> distributionIndices[0]=2 -> values[2]="Three"
+        var result = generator.Generate(MakeContext(0));
+        Assert.Equal("Three", result);
+
+        // index 1 -> distributionIndices[1]=0 -> values[0]="One"
+        result = generator.Generate(MakeContext(1));
+        Assert.Equal("One", result);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #285

Fixes an infinite loop in `CodedGenerator.Generate` when a column is `MultiValue` AND uses a precomputed distribution index array (`weighted`/`pareto`).

## Root Cause

`PickValue(context)` with `distributionIndices` is deterministic per `DocumentIndex` — it always returns the same value. In multi-value mode, the `HashSet` never grows past 1 element, so the `while (selected.Count < count)` loop never terminates.

## Fix

First pick uses `PickValue` (distribution-aware for the primary value). Subsequent picks use `context.Seeded.Next(this.values.Count)` to randomly select from the full value list, ensuring the set grows.

## Testing
- `Generate_MultiValue_Weighted_CompletesAndReturnsDistinctValues` — 2s timeout, verifies 2-3 distinct values
- `Generate_MultiValue_Pareto_CompletesAndReturnsDistinctValues` — same with pareto-skewed indices
- `Generate_SingleValue_Weighted_UsesDocumentIndexPath` — regression: single-value still uses deterministic distribution path
- All 896 unit tests pass, lint clean

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests validating multi-value generation with weighted and Pareto distributions completes successfully and returns correct distinct value counts
  * Added test coverage for single-value weighted generation with distribution index selection

* **Refactor**
  * Improved multi-value generation selection process for enhanced performance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->