### PR TITLE
fix: enforce --loadfile-only requirement for --chaos-mode (REQ-094)

### DIFF
--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -210,6 +210,12 @@ public static class CliValidator
 
         if (parsed.ChaosMode)
         {
+            if (!parsed.LoadfileOnly)
+            {
+                Console.Error.WriteLine("Error: --chaos-mode requires --loadfile-only.");
+                return false;
+            }
+
             var currentFormat = RequestBuilder.GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat;
             if (currentFormat != LoadFileFormat.Dat && currentFormat != LoadFileFormat.Opt)
             {

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -560,14 +560,13 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndParseArguments_ChaosMode_WithoutLoadfileOnly_ShouldSucceed()
+        public void ValidateAndParseArguments_ChaosMode_WithoutLoadfileOnly_ShouldReturnNull()
         {
             var args = new[] { "--type", "pdf", "--count", "10", "--output-path", this.tempDir, "--chaos-mode" };
 
             var result = Cli.Pipeline.Build(args);
 
-            Assert.NotNull(result);
-            Assert.True(result!.Chaos.ChaosMode);
+            Assert.Null(result);
         }
 
         [Fact]

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -171,11 +171,11 @@ namespace Zipper.Tests
         }
 
         [Fact]
-        public void Validate_ChaosMode_WithoutLoadfileOnly_ReturnsTrue()
+        public void Validate_ChaosMode_WithoutLoadfileOnly_ReturnsFalse()
         {
             var args = CreateValidArgs();
             args.ChaosMode = true;
-            Assert.True(CliValidator.Validate(args));
+            Assert.False(CliValidator.Validate(args));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Closes #280

`--chaos-mode` is specified (REQ-094) as requiring `--loadfile-only`. The CLI validator did not enforce this, allowing chaos mode to be silently ignored in Standard/Production modes.

## Changes
- `CliValidator.cs`: Added `!parsed.LoadfileOnly` check before the format check in the ChaosMode block
- `CliValidatorTests.cs`: Replaced `Validate_ChaosMode_WithoutLoadfileOnly_ReturnsTrue` → `ReturnsFalse`
- `CliPipelineTests.cs`: Replaced `ChaosMode_WithoutLoadfileOnly_ShouldSucceed` → `ShouldReturnNull`

## Testing
- All 896 unit tests pass
- Lint clean

Closes #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for `--chaos-mode`: the flag now requires `--loadfile-only` to be specified simultaneously. Using `--chaos-mode` without `--loadfile-only` will fail validation with an error message.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/303)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->