### PR TITLE
fix: resolve deadlock in ParallelFileGenerator when consumer throws

### DIFF
--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -81,20 +81,38 @@ namespace Zipper
                 // Wait for all producers to complete, wrapped in a task that ensures completion
                 var allProducersTask = Task.WhenAll(producerTasks);
 
+                // Race producers against consumer — if consumer faults, unblock producers
                 Exception? producerException = null;
                 try
                 {
-                    await allProducersTask;
+                    var completed = await Task.WhenAny(allProducersTask, consumerTask);
+                    if (completed == consumerTask && consumerTask.IsFaulted)
+                    {
+                        // Consumer died — complete channel with its exception to unblock producers
+                        resultChannel.Writer.TryComplete(consumerTask.Exception);
+                        try
+                        {
+                            await allProducersTask;
+                        }
+                        catch
+                        {
+                            // Producers will get ChannelClosedException — expected
+                        }
+                    }
+                    else
+                    {
+                        // Producers finished first (normal path)
+                        await allProducersTask;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    // Capture exception — must await consumer before rethrowing
                     producerException = ex;
                 }
                 finally
                 {
                     // Signal production done so consumer can drain and exit
-                    resultChannel.Writer.Complete(null);
+                    resultChannel.Writer.TryComplete(null);
                 }
 
                 // Always wait for consumer (releases zip file handles)

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -499,5 +499,64 @@ namespace Zipper
             var result = generator.CalculatePaddingPerFile(targetSize, baseSize, fileCount, withText);
             Assert.Equal(expectedPadding, result);
         }
+
+        [Fact(Timeout = 10000)]
+        public async Task GenerateFilesAsync_ConsumerFaults_PipelineTerminatesWithException()
+        {
+            // Windows ReadOnly attribute on directories doesn't prevent file creation
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
+
+            try
+            {
+                // Make directory read-only so zip file creation fails inside the consumer
+                File.SetAttributes(outputPath, FileAttributes.ReadOnly);
+                if (!OperatingSystem.IsWindows())
+                {
+                    // On Linux, directory write permission controls file creation
+                    System.Diagnostics.Process.Start("chmod", $"555 {outputPath}")?.WaitForExit();
+                }
+
+                var generator = new ParallelFileGenerator();
+
+                // This should throw (not hang) because the consumer cannot create the zip
+                await Assert.ThrowsAnyAsync<Exception>(async () =>
+                {
+                    await generator.GenerateFilesAsync(new FileGenerationRequest
+                    {
+                        Output = new OutputConfig
+                        {
+                            OutputPath = outputPath,
+                            FileCount = 100,
+                            FileType = "pdf",
+                            Folders = 2,
+                            Concurrency = 4,
+                        },
+                    });
+                });
+            }
+            finally
+            {
+                // Restore permissions before cleanup
+                if (!OperatingSystem.IsWindows())
+                {
+                    System.Diagnostics.Process.Start("chmod", $"755 {outputPath}")?.WaitForExit();
+                }
+                else
+                {
+                    File.SetAttributes(outputPath, FileAttributes.Normal);
+                }
+
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #279

Fixes a deadlock where producers block forever on a bounded channel when the archive consumer (ZipArchiveService) throws mid-generation.

## Root Cause

If `consumerTask` faults (I/O error, disk full, permissions), the result channel fills to capacity and producers block on `WriteAsync` forever. `allProducersTask` never completes, so `resultChannel.Writer.Complete()` is never called.

## Fix

Race `allProducersTask` against `consumerTask` via `Task.WhenAny`:
- If consumer faults first → `TryComplete` the channel with its exception → producers get `ChannelClosedException` and exit
- If producers finish first → normal path continues
- Changed `Writer.Complete` to `Writer.TryComplete` to handle double-completion safely

## Testing
- New test: `GenerateFilesAsync_ConsumerFaults_PipelineTerminatesWithException` — makes output dir read-only, confirms pipeline throws (not hangs) within timeout
- Before fix: test hangs indefinitely (killed by timeout)
- After fix: completes in ~133ms
- All 897 unit tests pass, lint clean

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a hang where file generation could deadlock if the ZIP-writing step failed; the pipeline now detects consumer failures and terminates with an error instead of waiting indefinitely.

* **Tests**
  * Added a test verifying the generation pipeline fails promptly when the ZIP output cannot be created.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->