### PR TITLE
fix: audit file totalRecords off-by-one in Standard + Production modes

### DIFF
--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -119,7 +119,7 @@ internal static class ProductionSetGenerator
             await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine);
         }
 
-        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, datTotalLines, datChaosEngine?.Anomalies);
+        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, fileDataList.Count, datChaosEngine?.Anomalies);
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson);
 
         // Write OPT load file

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -91,6 +91,7 @@ namespace Zipper
                     ? processedFiles.Count
                     : processedFiles.Count + 1;
                 var chaosEngine = ChaosEngineBuilder.Build(request, totalChaosLines, format);
+                long totalRecords = processedFiles.Count;
 
                 if (request.Output.IncludeLoadFile)
                 {
@@ -101,7 +102,7 @@ namespace Zipper
                     }
 
                     // Write audit file to ZIP
-                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, totalChaosLines, chaosEngine?.Anomalies);
+                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, totalRecords, chaosEngine?.Anomalies);
                     var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
                     using (var propertiesStream = propertiesEntry.Open())
                     using (var propertiesWriter = new StreamWriter(propertiesStream))
@@ -120,7 +121,7 @@ namespace Zipper
                     await fileStream.FlushAsync();
 
                     // Write audit file to disk
-                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalChaosLines, chaosEngine?.Anomalies);
+                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies);
                     await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
 
                     actualLoadFilePath = currentFilePath;

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -447,4 +447,18 @@ public class ProductionSetTests : IDisposable
         Assert.Contains("DOCID", datContent);
         Assert.Equal(4, datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
     }
+
+    [Fact]
+    public async Task ProductionSet_AuditFile_TotalRecordsEqualsFileCount()
+    {
+        const int fileCount = 6;
+        var request = this.CreateTestRequest(count: fileCount);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datPropsPath = Path.Combine(result.ProductionPath, "DATA", "loadfile_properties.json");
+        Assert.True(File.Exists(datPropsPath));
+        var json = await File.ReadAllTextAsync(datPropsPath);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        Assert.Equal(fileCount, doc.RootElement.GetProperty("totalRecords").GetInt64());
+    }
 }

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -386,5 +386,54 @@ namespace Zipper.Tests
             var optLines = (await optStream.ReadToEndAsync()).Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(3, optLines.Length); // Opticon: no header, 3 rows
         }
+
+        [Fact]
+        public async Task CreateArchiveAsync_AuditFile_TotalRecordsEqualsFileCount()
+        {
+            // Arrange
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var zipPath = Path.Combine(tempDir, "test.zip");
+            var loadPath = Path.Combine(tempDir, "load.dat");
+            const int fileCount = 7;
+
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    FileType = "pdf",
+                    FileCount = fileCount,
+                    Concurrency = 1,
+                    IncludeLoadFile = false,
+                },
+            };
+
+            var testFiles = new List<FileData>();
+            for (int i = 0; i < fileCount; i++)
+            {
+                testFiles.Add(this.CreateTestFileData(i));
+            }
+
+            var channel = Channel.CreateUnbounded<FileData>();
+            foreach (var file in testFiles)
+            {
+                await channel.Writer.WriteAsync(file);
+            }
+
+            channel.Writer.Complete();
+
+            // Act
+            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+
+            // Assert — audit file totalRecords should equal fileCount, not fileCount+1
+            var propertiesPath = loadPath + "_properties.json";
+            Assert.True(File.Exists(propertiesPath));
+            var json = await File.ReadAllTextAsync(propertiesPath);
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+            Assert.Equal(fileCount, doc.RootElement.GetProperty("totalRecords").GetInt64());
+
+            // Cleanup
+            Directory.Delete(tempDir, true);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #281

The `_properties.json` audit file reported `totalRecords` as `fileCount + 1` in Standard and Production Set modes (DAT format) because the header-inclusive line count used by ChaosEngine was also passed to the audit writer.

## Changes
- `ZipArchiveService.cs`: Introduced separate `totalRecords = processedFiles.Count` for audit, keeping `totalChaosLines` for ChaosEngine
- `ProductionSetGenerator.cs`: DAT audit now passes `fileDataList.Count` instead of `datTotalLines`

## Testing
- `CreateArchiveAsync_AuditFile_TotalRecordsEqualsFileCount` — Standard mode
- `ProductionSet_AuditFile_TotalRecordsEqualsFileCount` — Production Set mode
- All 899 unit tests pass, lint clean

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a counting discrepancy in audit metadata file generation where total record counts now accurately reflect the actual number of processed files.

* **Tests**
  * Added regression tests to verify audit metadata record counts consistently match the actual file counts across production set and archive operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->