### PR TITLE
fix: use InvariantCulture for EML Date header (RFC 2822)

### DIFF
--- a/src/Emails/EmailSerializer.cs
+++ b/src/Emails/EmailSerializer.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using System.Text;
 
 namespace Zipper.Emails;
@@ -62,7 +63,7 @@ internal static class EmailSerializer
         }
 
         writer.WriteLine($"Subject: {email.Subject}");
-        writer.WriteLine($"Date: {email.SentDate:ddd, dd MMM yyyy HH:mm:ss zzz}");
+        writer.WriteLine($"Date: {email.SentDate.ToString("ddd, dd MMM yyyy HH:mm:ss zzz", CultureInfo.InvariantCulture)}");
         writer.WriteLine("MIME-Version: 1.0");
 
         if (email.IsHighPriority)

--- a/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
@@ -24,10 +24,39 @@ namespace Zipper
             Assert.Contains("From: sender@example.com", content);
             Assert.Contains("To: recipient@example.com", content);
             Assert.Contains("Subject: RFC 2822 Test", content);
-            Assert.Contains("Date:", content);
+            Assert.Contains("Date: Fri, 15 Mar 2024 10:30:00", content);
             Assert.Contains("MIME-Version: 1.0", content);
             Assert.Contains("Content-Type: text/plain; charset=utf-8", content);
             Assert.Contains("Content-Transfer-Encoding: 8bit", content);
+        }
+
+        [Fact]
+        public void ToEml_DateHeader_UsesEnglishAbbreviationsRegardlessOfLocale()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL");
+
+                var email = new Email
+                {
+                    To = "test@example.com",
+                    From = "sender@example.com",
+                    Subject = "Locale test",
+                    SentDate = new DateTime(2024, 1, 15, 14, 0, 0), // Monday, January
+                    Body = "Body.",
+                };
+
+                var result = EmailSerializer.ToEml(email, null);
+                var content = Encoding.UTF8.GetString(result);
+
+                // Must use English abbreviations per RFC 2822
+                Assert.Contains("Date: Mon, 15 Jan 2024 14:00:00", content);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Closes #283

The `Date:` header in generated EML files used thread-local culture for day/month abbreviations, producing invalid headers on non-English locales (e.g., `lun, 15 mar` instead of `Mon, 15 Mar`).

## Fix
- `EmailSerializer.cs`: Format `SentDate` with `CultureInfo.InvariantCulture`

## Testing
- Strengthened `ToEml_ProducesRfc2822ValidHeaders` to assert exact English abbreviations
- Added `ToEml_DateHeader_UsesEnglishAbbreviationsRegardlessOfLocale` — sets `pl-PL` culture and asserts English output
- All 902 unit tests pass, lint clean

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email header date formatting to consistently use RFC 2822-compliant format with English abbreviations, regardless of system locale settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/308)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->