### PR TITLE
fix: CsvWriter honours --encoding instead of hardcoding UTF-8

### DIFF
--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -18,7 +18,8 @@ internal class CsvWriter : LoadFileWriterBase
         ChaosEngine? chaosEngine = null)
     {
         // Use leaveOpen: true to avoid disposing the caller's stream
-        await using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);
+        var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+        await using var writer = new StreamWriter(stream, encoding, leaveOpen: true);
 
 #pragma warning disable S2245
         var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -23,6 +23,8 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
         {
             Async = true,
             Indent = true,
+
+            // Intentionally UTF-8: EDRM XML schema requires UTF-8 per the XML declaration.
             Encoding = Encoding.UTF8,
             CloseOutput = false,
         };

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -915,5 +915,57 @@ namespace Zipper
                 throw new OperationCanceledException();
             }
         }
+
+        [Fact]
+        public async Task CsvWriter_WithUtf16Encoding_ProducesUtf16Output()
+        {
+            var request = this.CreateTestRequest();
+            request.LoadFile = request.LoadFile with { Encoding = "UTF-16" };
+            var fileData = this.CreateTestFileData();
+            var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Csv);
+            var outputPath = Path.Combine(this.tempDir, "test_utf16.csv");
+
+            await using (var stream = File.OpenWrite(outputPath))
+            {
+                await writer.WriteAsync(stream, request, fileData);
+            }
+
+            var bytes = await File.ReadAllBytesAsync(outputPath);
+
+            // UTF-16 LE BOM: FF FE
+            Assert.True(bytes.Length >= 2);
+            Assert.Equal(0xFF, bytes[0]);
+            Assert.Equal(0xFE, bytes[1]);
+
+            // Verify content is readable as UTF-16
+            var content = await File.ReadAllTextAsync(outputPath, System.Text.Encoding.Unicode);
+            Assert.Contains("Control Number", content);
+        }
+
+        [Fact]
+        public async Task CsvWriter_WithAnsiEncoding_ProducesAnsiOutput()
+        {
+            var request = this.CreateTestRequest();
+            request.LoadFile = request.LoadFile with { Encoding = "ANSI" };
+            var fileData = this.CreateTestFileData();
+            var writer = LoadFileWriterFactory.CreateWriter(LoadFileFormat.Csv);
+            var outputPath = Path.Combine(this.tempDir, "test_ansi.csv");
+
+            await using (var stream = File.OpenWrite(outputPath))
+            {
+                await writer.WriteAsync(stream, request, fileData);
+            }
+
+            var bytes = await File.ReadAllBytesAsync(outputPath);
+
+            // ANSI (Windows-1252) has no BOM — first byte should be ASCII
+            Assert.True(bytes[0] < 0x80 || bytes[0] >= 0x80); // Not UTF-16 BOM
+            Assert.NotEqual(0xFF, bytes[0]);
+
+            // Verify content is readable as Windows-1252
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+            var content = System.Text.Encoding.GetEncoding(1252).GetString(bytes);
+            Assert.Contains("Control Number", content);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #284

`CsvWriter` hardcoded `Encoding.UTF8`, ignoring `--encoding UTF-16` and `--encoding ANSI`. DAT and OPT writers already honoured the setting.

## Changes
- `CsvWriter.cs`: Use `EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding)`
- `XmlLoadFileWriter.cs`: Added comment documenting intentional UTF-8 (EDRM XML requirement)
- Tests: `CsvWriter_WithUtf16Encoding_ProducesUtf16Output` (BOM check), `CsvWriter_WithAnsiEncoding_ProducesAnsiOutput`

## Testing
- All 904 unit tests pass, lint clean

Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV exports now support custom encoding selection. Files are generated using the encoding specified in load requests, providing greater flexibility for downstream systems requiring specific character encodings such as UTF-16 or ANSI.

* **Tests**
  * Added test coverage for CSV encoding behavior to verify proper handling of UTF-16 and ANSI encoded files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/309)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->