### PR TITLE
fix: validate DateRange and accept legacy column kinds in ColumnProfileLoader

### DIFF
--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -123,16 +123,30 @@ public static class ColumnProfileLoader
         }
 
         // Validate column types
-        var validTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "identifier", "text", "longtext", "date", "datetime", "number", "boolean", "coded", "email",
-        };
-
         foreach (var column in profile.Columns)
         {
-            if (!validTypes.Contains(column.Type))
+            if (!Generation.ColumnValueGeneratorRegistry.IsKnownType(column.Type))
             {
-                throw new InvalidOperationException($"Column '{column.Name}' has invalid type '{column.Type}'. Valid types: {string.Join(", ", validTypes)}");
+                throw new InvalidOperationException($"Column '{column.Name}' has invalid type '{column.Type}'. Valid types: {string.Join(", ", Generation.ColumnValueGeneratorRegistry.KnownTypes)}");
+            }
+        }
+
+        // Validate date ranges
+        foreach (var column in profile.Columns.Where(c => c.DateRange != null))
+        {
+            if (!DateTime.TryParse(column.DateRange!.Min, out var minDate))
+            {
+                throw new InvalidOperationException($"Column '{column.Name}' has invalid DateRange.Min '{column.DateRange.Min}'. Must be a valid date string.");
+            }
+
+            if (!DateTime.TryParse(column.DateRange.Max, out var maxDate))
+            {
+                throw new InvalidOperationException($"Column '{column.Name}' has invalid DateRange.Max '{column.DateRange.Max}'. Must be a valid date string.");
+            }
+
+            if (minDate > maxDate)
+            {
+                throw new InvalidOperationException($"Column '{column.Name}' has DateRange.Min ({column.DateRange.Min}) greater than DateRange.Max ({column.DateRange.Max}).");
             }
         }
 

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -441,5 +441,76 @@ namespace Zipper
             Assert.False(ColumnProfileLoader.IsBuiltInProfile("custom-profile"));
             Assert.False(ColumnProfileLoader.IsBuiltInProfile("NonExistent"));
         }
+
+        [Fact]
+        public void Validate_WithInvalidDateRangeMin_ThrowsInvalidOperationException()
+        {
+            var profile = CreateMinimalProfile();
+            profile.Columns.Add(new ColumnDefinition
+            {
+                Name = "BadDate",
+                Type = "date",
+                DateRange = new DateRangeConfig { Min = "not-a-date", Max = "2024-12-31" },
+            });
+
+            var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+            Assert.Contains("BadDate", ex.Message);
+            Assert.Contains("DateRange.Min", ex.Message);
+        }
+
+        [Fact]
+        public void Validate_WithInvalidDateRangeMax_ThrowsInvalidOperationException()
+        {
+            var profile = CreateMinimalProfile();
+            profile.Columns.Add(new ColumnDefinition
+            {
+                Name = "BadMax",
+                Type = "date",
+                DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "garbage" },
+            });
+
+            var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+            Assert.Contains("BadMax", ex.Message);
+            Assert.Contains("DateRange.Max", ex.Message);
+        }
+
+        [Fact]
+        public void Validate_WithMinGreaterThanMax_ThrowsInvalidOperationException()
+        {
+            var profile = CreateMinimalProfile();
+            profile.Columns.Add(new ColumnDefinition
+            {
+                Name = "Inverted",
+                Type = "date",
+                DateRange = new DateRangeConfig { Min = "2025-01-01", Max = "2020-01-01" },
+            });
+
+            var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+            Assert.Contains("Inverted", ex.Message);
+            Assert.Contains("greater than", ex.Message);
+        }
+
+        [Fact]
+        public void Validate_WithLegacyColumnKind_DoesNotThrow()
+        {
+            var profile = CreateMinimalProfile();
+            profile.Columns.Add(new ColumnDefinition { Name = "Custodian", Type = "foldercustodian" });
+            profile.Columns.Add(new ColumnDefinition { Name = "Size", Type = "filedatasize" });
+
+            ColumnProfileLoader.Validate(profile); // Should not throw
+        }
+
+        private static ColumnProfile CreateMinimalProfile()
+        {
+            return new ColumnProfile
+            {
+                Name = "test",
+                Columns = new List<ColumnDefinition>
+                {
+                    new() { Name = "DOCID", Type = "identifier" },
+                },
+                DataSources = new Dictionary<string, DataSourceConfig>(),
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #292

`ColumnProfileLoader.Validate` had two gaps:
1. Rejected legacy column kinds (`foldercustodian`, `filedatasize`, etc.) that are valid at runtime
2. Did not validate `DateRange` strings, causing delayed `FormatException` at generation time

## Changes
- Use `ColumnValueGeneratorRegistry.KnownTypes` as the source of truth for valid types
- Added `DateRange` validation: parse Min/Max, enforce Min ≤ Max
- Clear error messages identifying the column name

## Testing
- `Validate_WithInvalidDateRangeMin_ThrowsInvalidOperationException`
- `Validate_WithInvalidDateRangeMax_ThrowsInvalidOperationException`
- `Validate_WithMinGreaterThanMax_ThrowsInvalidOperationException`
- `Validate_WithLegacyColumnKind_DoesNotThrow`
- All 908 unit tests pass, lint clean

Closes #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messages for date range configurations in column profiles to clearly indicate invalid minimum/maximum values and range ordering issues.

* **Tests**
  * Expanded test coverage for column profile validation, including date range parsing errors, range boundary validation, and legacy column type compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->