### PR TITLE
fix: clean up partial production set output on generation failure

### DIFF
--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -21,6 +21,32 @@ internal static class ProductionSetGenerator
         var productionName = $"PRODUCTION_{DateTime.Now:yyyyMMdd_HHmmss}";
         var productionPath = Path.Combine(request.Output.OutputPath, productionName);
 
+        try
+        {
+            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch);
+        }
+        catch
+        {
+            // Clean up partial output on failure
+            if (Directory.Exists(productionPath))
+            {
+                try
+                {
+                    Directory.Delete(productionPath, true);
+                }
+                catch
+                {
+                    // Best-effort cleanup; don't mask the original exception
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task<ProductionSetResult> GenerateCoreAsync(
+        FileGenerationRequest request, string productionPath, string productionName, Stopwatch stopwatch)
+    {
         // Create directory structure
         var dataDir = Path.Combine(productionPath, "DATA");
         var nativesDir = Path.Combine(productionPath, "NATIVES");

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -461,4 +461,52 @@ public class ProductionSetTests : IDisposable
         var doc = System.Text.Json.JsonDocument.Parse(json);
         Assert.Equal(fileCount, doc.RootElement.GetProperty("totalRecords").GetInt64());
     }
+
+    [Fact]
+    public async Task ProductionSet_OnFailure_CleansUpPartialOutput()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // Directory permissions don't prevent file creation on Windows
+        }
+
+        var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = outputPath,
+                    FileCount = 10,
+                    FileType = "pdf",
+                },
+                Production = new ProductionConfig { ProductionSet = true, VolumeSize = 5000 },
+                Bates = new BatesNumberConfig { Prefix = "FAIL", Start = 1, Digits = 8 },
+            };
+
+            // Make the NATIVES dir read-only after structure creation to trigger failure mid-write
+            // We need to hook into the directory creation — use a path that will fail
+            // Simpler: use an invalid file type that will throw during generation
+            request.Output = request.Output with { FileType = "INVALID_TYPE_THAT_DOES_NOT_EXIST" };
+
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await ProductionSetGenerator.GenerateAsync(request);
+            });
+
+            // Verify: no PRODUCTION_* directory should remain
+            var productionDirs = Directory.GetDirectories(outputPath, "PRODUCTION_*");
+            Assert.Empty(productionDirs);
+        }
+        finally
+        {
+            if (Directory.Exists(outputPath))
+            {
+                Directory.Delete(outputPath, true);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Closes #293

`ProductionSetGenerator.GenerateAsync` now cleans up the partial production directory on any failure, preventing confusing partial output from being left on disk.

## Changes
- Extracted generation logic into `GenerateCoreAsync`
- `GenerateAsync` wraps it in try/catch, deletes `productionPath` on exception (best-effort), re-throws

## Testing
- `ProductionSet_OnFailure_CleansUpPartialOutput` — triggers failure via invalid file type, asserts no PRODUCTION_* directory remains
- All 909 unit tests pass, lint clean

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generation failures now automatically clean up partial output directories and files, preventing incomplete output from persisting after failed generation attempts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->