### PR TITLE
fix: address CodeRabbit review on argument-interaction tests

### DIFF
--- a/.kiro/skills/github-issue-workflow/SKILL.md
+++ b/.kiro/skills/github-issue-workflow/SKILL.md
@@ -146,18 +146,21 @@ If issues are found:
 
 ### 9. Address Review Comments
 
-Watch for PR comments:
+**Do not merge until all review comments are addressed.** Check for comments after CI completes:
 ```bash
 gh pr view <pr-number> --comments
+gh pr view <pr-number> --json reviews --jq '.reviews[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED") | {author: .author.login, state: .state}'
 ```
 
 For each review comment:
-- Address the feedback
-- Commit changes
-- Push to the same branch
-- Reply to the comment indicating it's addressed
+- Fix actionable issues (blocking comments are required, nitpicks are optional but preferred)
+- Commit changes and push to the same branch
+- **Reply to the comment on GitHub** indicating it's addressed (or explain why it was skipped):
+  ```bash
+  gh pr comment <pr-number> --body "Addressed CodeRabbit feedback: <summary of what was fixed>"
+  ```
 
-**Stale reviews after force-push:** CodeRabbit and other bots review the commit at push time. After amending and force-pushing, their comments may reference code that no longer exists. Before acting on a review comment, verify it still applies to the current code. Skip comments that were already addressed by the amend.
+**Stale reviews after force-push:** CodeRabbit and other bots review the commit at push time. After amending and force-pushing, their comments may reference code that no longer exists. Before acting on a review comment, verify it still applies to the current code. Skip comments that were already addressed by the amend — but still reply acknowledging them.
 
 ### 10. Merge on Green
 

--- a/tests/test-argument-interactions.sh
+++ b/tests/test-argument-interactions.sh
@@ -22,26 +22,30 @@ trap cleanup EXIT
 assert_rejected() {
     local desc="$1"
     shift
-    if zipper "$@" --output-path "$TEMP_DIR/out_$$" > /dev/null 2>&1; then
+    local out_path="$TEMP_DIR/out_${PASSED}_${FAILED}"
+    if zipper "$@" --output-path "$out_path" > /dev/null 2>&1; then
         print_error "FAIL: $desc (expected rejection, got success)"
         FAILED=$((FAILED + 1))
     else
         print_info "PASS: $desc"
         PASSED=$((PASSED + 1))
     fi
+    rm -rf "$out_path" 2>/dev/null || true
 }
 
 # Assert command exits zero (accepted)
 assert_accepted() {
     local desc="$1"
     shift
-    if zipper "$@" --output-path "$TEMP_DIR/out_$$" > /dev/null 2>&1; then
+    local out_path="$TEMP_DIR/out_${PASSED}_${FAILED}"
+    if zipper "$@" --output-path "$out_path" > /dev/null 2>&1; then
         print_info "PASS: $desc"
         PASSED=$((PASSED + 1))
     else
         print_error "FAIL: $desc (expected success, got rejection)"
         FAILED=$((FAILED + 1))
     fi
+    rm -rf "$out_path" 2>/dev/null || true
 }
 
 print_info "=== CLI Argument Interaction Tests ==="


### PR DESCRIPTION
## Summary
Follow-up to PR #314 — addresses CodeRabbit review comments.

## Changes
- `test-argument-interactions.sh`: Use unique per-test output paths (`out_${PASSED}_${FAILED}`) instead of shared `out_$$` to prevent cross-test pollution. Cleanup after each test.
- `.kiro/skills/github-issue-workflow/SKILL.md`: Updated step 9 to require addressing review comments before merge and replying on GitHub.

## Testing
- All 15 argument-interaction tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub issue workflow guidance for addressing review feedback with enhanced procedures for handling comments and maintaining branch consistency.

* **Tests**
  * Improved test script cleanup procedures to ensure proper artifact removal between test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->