### PR TITLE
test: add FileGeneratorFactoryTests covering all known file types

### DIFF
--- a/src/Zipper.Tests/FileGeneratorFactoryTests.cs
+++ b/src/Zipper.Tests/FileGeneratorFactoryTests.cs
@@ -1,0 +1,81 @@
+using Xunit;
+
+using Zipper.Config;
+
+namespace Zipper.Tests;
+
+public class FileGeneratorFactoryTests
+{
+    private static FileGenerationRequest MinimalRequest() => new()
+    {
+        Output = new OutputConfig { FileType = "pdf", FileCount = 1, Concurrency = 1 },
+    };
+
+    [Theory]
+    [InlineData("pdf", typeof(PlaceholderFileGenerator))]
+    [InlineData("jpg", typeof(PlaceholderFileGenerator))]
+    [InlineData("jpeg", typeof(PlaceholderFileGenerator))]
+    [InlineData("png", typeof(PlaceholderFileGenerator))]
+    [InlineData("bmp", typeof(PlaceholderFileGenerator))]
+    [InlineData("txt", typeof(PlaceholderFileGenerator))]
+    [InlineData("eml", typeof(EmlFileGenerator))]
+    [InlineData("docx", typeof(OfficeFileGenerator))]
+    [InlineData("xlsx", typeof(OfficeFileGenerator))]
+    [InlineData("tiff", typeof(TiffFileGenerator))]
+    public void Create_KnownType_ReturnsCorrectGenerator(string fileType, Type expectedType)
+    {
+        var generator = FileGeneratorFactory.Create(fileType, MinimalRequest());
+
+        Assert.NotNull(generator);
+        Assert.IsType(expectedType, generator);
+    }
+
+    [Theory]
+    [InlineData("PDF")]
+    [InlineData("Tiff")]
+    [InlineData("EML")]
+    public void Create_CaseInsensitive_ReturnsGenerator(string fileType)
+    {
+        var generator = FileGeneratorFactory.Create(fileType, MinimalRequest());
+        Assert.NotNull(generator);
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData("mp3")]
+    [InlineData("")]
+    public void Create_UnknownType_ReturnsNull(string fileType)
+    {
+        var generator = FileGeneratorFactory.Create(fileType, MinimalRequest());
+        Assert.Null(generator);
+    }
+
+    [Theory]
+    [InlineData("pdf", true)]
+    [InlineData("eml", true)]
+    [InlineData("tiff", true)]
+    [InlineData("docx", true)]
+    [InlineData("xlsx", true)]
+    [InlineData("unknown", false)]
+    [InlineData("mp3", false)]
+    public void IsKnownType_ReturnsExpected(string fileType, bool expected)
+    {
+        Assert.Equal(expected, FileGeneratorFactory.IsKnownType(fileType));
+    }
+
+    [Fact]
+    public void Create_PlaceholderTypes_SetCorrectFileType()
+    {
+        var gen = FileGeneratorFactory.Create("pdf", MinimalRequest()) as PlaceholderFileGenerator;
+        Assert.NotNull(gen);
+        Assert.Equal("pdf", gen!.FileType);
+    }
+
+    [Fact]
+    public void Create_EmlGenerator_IsNotPlaceholderBased()
+    {
+        var gen = FileGeneratorFactory.Create("eml", MinimalRequest());
+        Assert.NotNull(gen);
+        Assert.False(gen!.IsPlaceholderBased);
+    }
+}


### PR DESCRIPTION
## Summary
Partial progress on #288 — adds dedicated unit tests for `FileGeneratorFactory`.

## Changes
- `FileGeneratorFactoryTests.cs`: 25 tests covering:
  - `Create` returns correct generator type for all 10 known file types
  - Case-insensitive dispatch
  - Unknown types return null
  - `IsKnownType` returns expected values
  - Placeholder generators set correct FileType
  - EML generator is not placeholder-based

## Testing
- All 934 unit tests pass, lint clean

Partial progress on #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for file type handling and generator selection to ensure reliability and correctness across different file types and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/316)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->