### PR TITLE
refactor: canonicalize File Type set to 6 documented types

### DIFF
--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -27,6 +27,12 @@ public static class CliValidator
             return false;
         }
 
+        if (!string.IsNullOrEmpty(parsed.FileType) && !FileGeneratorFactory.IsKnownType(parsed.FileType))
+        {
+            Console.Error.WriteLine($"Error: Unsupported file type '{parsed.FileType}'. Supported types: pdf, jpg, tiff, eml, docx, xlsx.");
+            return false;
+        }
+
         if (!parsed.Count.HasValue)
         {
             Console.Error.WriteLine("Error: --count is required.");

--- a/src/FileGeneratorFactory.cs
+++ b/src/FileGeneratorFactory.cs
@@ -9,7 +9,7 @@ internal static class FileGeneratorFactory
     /// <summary>
     /// Creates an <see cref="IFileGenerator"/> for the specified file type.
     /// </summary>
-    /// <param name="fileType">The file type (e.g. "pdf", "eml", "docx", "xlsx", "tiff").</param>
+    /// <param name="fileType">The file type: "pdf", "jpg", "tiff", "eml", "docx", "xlsx".</param>
     /// <param name="request">The generation request for context-dependent generators.</param>
     /// <returns>A file generator for the specified type, or null if the type is unknown.</returns>
     internal static IFileGenerator? Create(string fileType, FileGenerationRequest request)
@@ -18,7 +18,7 @@ internal static class FileGeneratorFactory
 
         return lower switch
         {
-            "pdf" or "jpg" or "jpeg" or "png" or "bmp" or "txt" => new PlaceholderFileGenerator(lower),
+            "pdf" or "jpg" => new PlaceholderFileGenerator(lower),
             "eml" => new EmlFileGenerator(),
             "docx" or "xlsx" => new OfficeFileGenerator(lower),
             "tiff" => new TiffFileGenerator(request),
@@ -32,7 +32,6 @@ internal static class FileGeneratorFactory
     internal static bool IsKnownType(string fileType)
     {
         var lower = fileType.ToLowerInvariant();
-        return lower is "pdf" or "jpg" or "jpeg" or "png" or "bmp" or "txt"
-            or "eml" or "docx" or "xlsx" or "tiff";
+        return lower is "pdf" or "jpg" or "eml" or "docx" or "xlsx" or "tiff";
     }
 }

--- a/src/Zipper.Tests/FileGeneratorFactoryTests.cs
+++ b/src/Zipper.Tests/FileGeneratorFactoryTests.cs
@@ -14,10 +14,6 @@ public class FileGeneratorFactoryTests
     [Theory]
     [InlineData("pdf", typeof(PlaceholderFileGenerator))]
     [InlineData("jpg", typeof(PlaceholderFileGenerator))]
-    [InlineData("jpeg", typeof(PlaceholderFileGenerator))]
-    [InlineData("png", typeof(PlaceholderFileGenerator))]
-    [InlineData("bmp", typeof(PlaceholderFileGenerator))]
-    [InlineData("txt", typeof(PlaceholderFileGenerator))]
     [InlineData("eml", typeof(EmlFileGenerator))]
     [InlineData("docx", typeof(OfficeFileGenerator))]
     [InlineData("xlsx", typeof(OfficeFileGenerator))]
@@ -44,6 +40,10 @@ public class FileGeneratorFactoryTests
     [InlineData("unknown")]
     [InlineData("mp3")]
     [InlineData("")]
+    [InlineData("jpeg")]
+    [InlineData("png")]
+    [InlineData("bmp")]
+    [InlineData("txt")]
     public void Create_UnknownType_ReturnsNull(string fileType)
     {
         var generator = FileGeneratorFactory.Create(fileType, MinimalRequest());
@@ -52,10 +52,13 @@ public class FileGeneratorFactoryTests
 
     [Theory]
     [InlineData("pdf", true)]
+    [InlineData("jpg", true)]
     [InlineData("eml", true)]
     [InlineData("tiff", true)]
     [InlineData("docx", true)]
     [InlineData("xlsx", true)]
+    [InlineData("jpeg", false)]
+    [InlineData("png", false)]
     [InlineData("unknown", false)]
     [InlineData("mp3", false)]
     public void IsKnownType_ReturnsExpected(string fileType, bool expected)

--- a/src/Zipper.Tests/OutputConfigTests.cs
+++ b/src/Zipper.Tests/OutputConfigTests.cs
@@ -17,10 +17,6 @@ namespace Zipper.Tests
         [InlineData("docx", "docx")]
         [InlineData("xlsx", "xlsx")]
         [InlineData("jpg", "jpg")]
-        [InlineData("jpeg", "jpeg")]
-        [InlineData("png", "png")]
-        [InlineData("bmp", "bmp")]
-        [InlineData("txt", "txt")]
         public void FileTypeLower_ReturnsLowercaseFileType(string fileType, string expected)
         {
             // Arrange


### PR DESCRIPTION
## Summary
Closes #269

Resolves the source-of-truth conflict between docs (6 types) and implementation (10 types) by removing undocumented types and adding CLI validation.

## Decision
Keep only the 6 documented types: `pdf`, `jpg`, `tiff`, `eml`, `docx`, `xlsx`. The undocumented `jpeg`, `png`, `bmp`, `txt` were never in README, Requirements, or UBIQUITOUS_LANGUAGE.

## Changes
- `CliValidator.cs`: Added validation rejecting unsupported `--type` values with clear error
- `FileGeneratorFactory.cs`: Removed `jpeg`, `png`, `bmp`, `txt` from Create and IsKnownType
- Tests updated: undocumented types now assert null/rejected

## Testing
- All 933 unit tests pass, lint clean
- `FileGeneratorFactoryTests`: undocumented types now in the "returns null" test set

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-type validation with clearer error messaging that lists supported formats when an unsupported type is provided.
  * Refined supported file types to: PDF, JPG, EML, DOCX, XLSX, TIFF.

* **Tests**
  * Updated test expectations to align with the revised set of supported file types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/318)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->