### PR TITLE
refactor: centralize Chaos anomaly type definitions

### DIFF
--- a/src/ChaosAnomalyTypes.cs
+++ b/src/ChaosAnomalyTypes.cs
@@ -1,0 +1,28 @@
+namespace Zipper;
+
+/// <summary>
+/// Canonical catalog of Chaos anomaly type names.
+/// Single source of truth consumed by both CliValidator and ChaosEngine.
+/// </summary>
+internal static class ChaosAnomalyTypes
+{
+    public static readonly IReadOnlyList<string> Dat = new[]
+    {
+        "mixed-delimiters", "quotes", "columns", "eol", "encoding",
+    };
+
+    public static readonly IReadOnlyList<string> Opt = new[]
+    {
+        "opt-boundary", "opt-columns", "opt-pagecount", "opt-path", "opt-batesid",
+    };
+
+    /// <summary>
+    /// Returns the valid anomaly types for the given format.
+    /// </summary>
+    public static IReadOnlyList<string> ForFormat(LoadFileFormat format) =>
+        format switch
+        {
+            LoadFileFormat.Opt => Opt,
+            _ => Dat,
+        };
+}

--- a/src/ChaosEngine.cs
+++ b/src/ChaosEngine.cs
@@ -11,8 +11,8 @@ namespace Zipper;
 /// </remarks>
 internal class ChaosEngine
 {
-    private static readonly string[] DatChaosTypes = { "mixed-delimiters", "quotes", "columns", "eol", "encoding" };
-    private static readonly string[] OptChaosTypes = { "opt-boundary", "opt-columns", "opt-pagecount", "opt-path", "opt-batesid" };
+    private static readonly string[] DatChaosTypes = ChaosAnomalyTypes.Dat.ToArray();
+    private static readonly string[] OptChaosTypes = ChaosAnomalyTypes.Opt.ToArray();
     private static readonly char[] AlternativeDelimiters = { ',', '\t', '|' };
 
     private readonly HashSet<long> targetLines;

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -357,10 +357,8 @@ public static class CliValidator
 
         if (!string.IsNullOrEmpty(parsed.ChaosTypes))
         {
-            var validDat = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "mixed-delimiters", "quotes", "columns", "eol", "encoding" };
-            var validOpt = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "opt-boundary", "opt-columns", "opt-pagecount", "opt-path", "opt-batesid" };
             var format = RequestBuilder.GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat;
-            var validTypes = format == LoadFileFormat.Opt ? validOpt : validDat;
+            var validTypes = new HashSet<string>(ChaosAnomalyTypes.ForFormat(format), StringComparer.OrdinalIgnoreCase);
             var types = parsed.ChaosTypes.Split(',');
             foreach (var t in types)
             {

--- a/src/Zipper.Tests/ChaosAnomalyTypesTests.cs
+++ b/src/Zipper.Tests/ChaosAnomalyTypesTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+
+namespace Zipper.Tests;
+
+public class ChaosAnomalyTypesTests
+{
+    [Fact]
+    public void Dat_ContainsExpectedTypes()
+    {
+        Assert.Contains("mixed-delimiters", ChaosAnomalyTypes.Dat);
+        Assert.Contains("quotes", ChaosAnomalyTypes.Dat);
+        Assert.Contains("columns", ChaosAnomalyTypes.Dat);
+        Assert.Contains("eol", ChaosAnomalyTypes.Dat);
+        Assert.Contains("encoding", ChaosAnomalyTypes.Dat);
+        Assert.Equal(5, ChaosAnomalyTypes.Dat.Count);
+    }
+
+    [Fact]
+    public void Opt_ContainsExpectedTypes()
+    {
+        Assert.Contains("opt-boundary", ChaosAnomalyTypes.Opt);
+        Assert.Contains("opt-columns", ChaosAnomalyTypes.Opt);
+        Assert.Contains("opt-pagecount", ChaosAnomalyTypes.Opt);
+        Assert.Contains("opt-path", ChaosAnomalyTypes.Opt);
+        Assert.Contains("opt-batesid", ChaosAnomalyTypes.Opt);
+        Assert.Equal(5, ChaosAnomalyTypes.Opt.Count);
+    }
+
+    [Fact]
+    public void ForFormat_Dat_ReturnsDatTypes()
+    {
+        var types = ChaosAnomalyTypes.ForFormat(LoadFileFormat.Dat);
+        Assert.Equal(ChaosAnomalyTypes.Dat, types);
+    }
+
+    [Fact]
+    public void ForFormat_Opt_ReturnsOptTypes()
+    {
+        var types = ChaosAnomalyTypes.ForFormat(LoadFileFormat.Opt);
+        Assert.Equal(ChaosAnomalyTypes.Opt, types);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #273

Eliminates duplication of DAT/OPT chaos anomaly type lists between `CliValidator` and `ChaosEngine`.

## Changes
- `ChaosAnomalyTypes.cs`: New internal static catalog with `Dat`, `Opt`, and `ForFormat()`
- `ChaosEngine.cs`: Uses `ChaosAnomalyTypes.Dat/Opt` instead of private arrays
- `CliValidator.cs`: Uses `ChaosAnomalyTypes.ForFormat()` instead of inline HashSets
- `ChaosAnomalyTypesTests.cs`: Verifies catalog contents and format dispatch

## Testing
- All 937 unit tests pass, lint clean
- No behavior changes — pure refactor

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized chaos anomaly type definitions for consistent handling across DAT and OPT formats, improving maintainability and validation accuracy.

* **Tests**
  * Added tests to ensure format-specific anomaly lists and format selection behave as expected, strengthening validation coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/319)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->