### PR TITLE
Centralize CLI option metadata and fix numeric parse errors

### DIFF
--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -1,0 +1,27 @@
+namespace Zipper.Cli;
+
+/// <summary>
+/// Centralized catalog of CLI option metadata.
+/// Single source of truth for flag names and whether a flag takes a value.
+/// </summary>
+internal static class CliOptions
+{
+    /// <summary>
+    /// All flags that accept no following value.
+    /// Used by <see cref="CliParser"/> to prevent the next argument being consumed
+    /// as a value when it is itself a flag.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ParameterlessFlags = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "--benchmark",
+        "--chaos-list",
+        "--chaos-mode",
+        "--include-load-file",
+        "--loadfile-only",
+        "--production-set",
+        "--production-zip",
+        "--with-families",
+        "--with-metadata",
+        "--with-text",
+    };
+}

--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -63,9 +63,18 @@ public static class CliParser
 
                     break;
                 case "--folders":
-                    if (TryGetValue(args, i, out var foldersStr) && int.TryParse(foldersStr, out var folders))
+                    if (TryGetValue(args, i, out var foldersStr))
                     {
-                        parsed.Folders = folders;
+                        if (int.TryParse(foldersStr, out var folders))
+                        {
+                            parsed.Folders = folders;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --folders: '{foldersStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -93,9 +102,18 @@ public static class CliParser
                     parsed.WithText = true;
                     break;
                 case "--attachment-rate":
-                    if (TryGetValue(args, i, out var attRateStr) && int.TryParse(attRateStr, out var attachmentRate))
+                    if (TryGetValue(args, i, out var attRateStr))
                     {
-                        parsed.AttachmentRate = attachmentRate;
+                        if (int.TryParse(attRateStr, out var attachmentRate))
+                        {
+                            parsed.AttachmentRate = attachmentRate;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --attachment-rate: '{attRateStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -128,17 +146,35 @@ public static class CliParser
 
                     break;
                 case "--bates-start":
-                    if (TryGetValue(args, i, out var batesStartStr) && long.TryParse(batesStartStr, out var batesStart))
+                    if (TryGetValue(args, i, out var batesStartStr))
                     {
-                        parsed.BatesStart = batesStart;
+                        if (long.TryParse(batesStartStr, out var batesStart))
+                        {
+                            parsed.BatesStart = batesStart;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --bates-start: '{batesStartStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
                     break;
                 case "--bates-digits":
-                    if (TryGetValue(args, i, out var batesDigitsStr) && int.TryParse(batesDigitsStr, out var batesDigits))
+                    if (TryGetValue(args, i, out var batesDigitsStr))
                     {
-                        parsed.BatesDigits = batesDigits;
+                        if (int.TryParse(batesDigitsStr, out var batesDigits))
+                        {
+                            parsed.BatesDigits = batesDigits;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --bates-digits: '{batesDigitsStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -160,9 +196,18 @@ public static class CliParser
 
                     break;
                 case "--seed":
-                    if (TryGetValue(args, i, out var seedStr) && int.TryParse(seedStr, out var seed))
+                    if (TryGetValue(args, i, out var seedStr))
                     {
-                        parsed.Seed = seed;
+                        if (int.TryParse(seedStr, out var seed))
+                        {
+                            parsed.Seed = seed;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --seed: '{seedStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -176,17 +221,35 @@ public static class CliParser
 
                     break;
                 case "--empty-percentage":
-                    if (TryGetValue(args, i, out var emptyPctStr) && int.TryParse(emptyPctStr, out var emptyPct))
+                    if (TryGetValue(args, i, out var emptyPctStr))
                     {
-                        parsed.EmptyPercentage = emptyPct;
+                        if (int.TryParse(emptyPctStr, out var emptyPct))
+                        {
+                            parsed.EmptyPercentage = emptyPct;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --empty-percentage: '{emptyPctStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
                     break;
                 case "--custodian-count":
-                    if (TryGetValue(args, i, out var custCountStr) && int.TryParse(custCountStr, out var custCount))
+                    if (TryGetValue(args, i, out var custCountStr))
                     {
-                        parsed.CustodianCount = custCount;
+                        if (int.TryParse(custCountStr, out var custCount))
+                        {
+                            parsed.CustodianCount = custCount;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --custodian-count: '{custCountStr}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -216,6 +279,11 @@ public static class CliParser
                         parsed.DelimiterColumn = delCol;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --delimiter-column requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--delimiter-quote":
@@ -223,6 +291,11 @@ public static class CliParser
                     {
                         parsed.DelimiterQuote = delQuote;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --delimiter-quote requires a value.");
+                        return null;
                     }
 
                     break;
@@ -335,9 +408,18 @@ public static class CliParser
                     parsed.ProductionZip = true;
                     break;
                 case "--volume-size":
-                    if (TryGetValue(args, i, out var volumeSizeVal) && int.TryParse(volumeSizeVal, out var volumeSize))
+                    if (TryGetValue(args, i, out var volumeSizeVal))
                     {
-                        parsed.VolumeSize = volumeSize;
+                        if (int.TryParse(volumeSizeVal, out var volumeSize))
+                        {
+                            parsed.VolumeSize = volumeSize;
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine($"Error: Invalid value for --volume-size: '{volumeSizeVal}'");
+                            return null;
+                        }
+
                         i++;
                     }
 
@@ -370,17 +452,6 @@ public static class CliParser
             return false;
         }
 
-        return arg.ToLowerInvariant() switch
-        {
-            "--with-metadata" => true,
-            "--with-text" => true,
-            "--include-load-file" => true,
-            "--with-families" => true,
-            "--loadfile-only" => true,
-            "--chaos-mode" => true,
-            "--production-set" => true,
-            "--production-zip" => true,
-            _ => false,
-        };
+        return CliOptions.ParameterlessFlags.Contains(arg);
     }
 }

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -192,6 +192,5 @@ namespace Zipper.Tests
             var result = CliParser.Parse(new[] { "--type", "--benchmark" });
             Assert.Null(result);
         }
-
     }
 }

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -117,5 +117,81 @@ namespace Zipper.Tests
             var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "not-a-number", "--output-path", "/tmp" });
             Assert.Null(result);
         }
+
+        [Fact]
+        public void Parse_InvalidFolders_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--folders", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidAttachmentRate_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--attachment-rate", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidBatesStart_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--bates-start", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidBatesDigits_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--bates-digits", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidSeed_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--seed", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidEmptyPercentage_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--empty-percentage", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidCustodianCount_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--custodian-count", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_InvalidVolumeSize_ReturnsNull()
+        {
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--volume-size", "notanumber" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_ChaosListNotConsumedAsValueForPrecedingArg()
+        {
+            // Before fix: --chaos-list would be consumed as the value for --type.
+            // After fix: TryGetValue returns false (--chaos-list is parameterless),
+            // so --type fails with a missing-value error and Parse returns null.
+            var result = CliParser.Parse(new[] { "--type", "--chaos-list" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Parse_BenchmarkNotConsumedAsValueForPrecedingArg()
+        {
+            // --benchmark is a parameterless flag; it must not be consumed as a value
+            // for a preceding option such as --type.
+            var result = CliParser.Parse(new[] { "--type", "--benchmark" });
+            Assert.Null(result);
+        }
+
     }
 }


### PR DESCRIPTION
Closes #271

## Summary

Centralizes CLI option metadata by introducing `CliOptions` as the single source of truth for parameterless flags. Fixes three parser robustness bugs identified in the issue comments:

1. **`--chaos-list` and `--benchmark` missing from parameterless flags** — these could be silently consumed as values for a preceding option (e.g., `--type --chaos-list` would set `FileType = "--chaos-list"` instead of failing).
2. **Silent failures on non-numeric values** — 8 numeric options (`--folders`, `--attachment-rate`, `--bates-start`, `--bates-digits`, `--seed`, `--empty-percentage`, `--custodian-count`, `--volume-size`) silently ignored parse failures; the invalid token re-surfaced as an "Unknown argument" warning. Now they fail immediately with a clear error message.
3. **Inconsistent delimiter error handling** — `--delimiter-column` and `--delimiter-quote` silently left the default when no value was provided; `--delimiter-newline` hard-errored. All three now hard-error consistently.

## Changes

- **New: `src/Cli/CliOptions.cs`** — `CliOptions.ParameterlessFlags` HashSet (OrdinalIgnoreCase); replaces the switch expression in `IsParameterlessFlag`. Adds `--benchmark` and `--chaos-list` to the set.
- **Modified: `src/Cli/CliParser.cs`** — `IsParameterlessFlag` now delegates to `CliOptions.ParameterlessFlags.Contains()`. Eight numeric options restructured to print a diagnostic and return `null` when `TryParse` fails. `--delimiter-column` and `--delimiter-quote` now return `null` when no value is present.
- **Modified: `src/Zipper.Tests/CliParserTests.cs`** — 10 new `[Fact]` tests: one per numeric option (8) + `--chaos-list` not consumed as value + `--benchmark` not consumed as value.

## Verification

- `dotnet build` — all three projects must succeed
- `lint` — StyleCop / dotnet-format must pass
- `test` — all existing tests pass + 10 new parser tests pass
- `goldens` — no load-file or archive behavior changed; goldens should be byte-identical


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for numeric CLI options so invalid values are rejected with clear error messages and parsing fails instead of producing incorrect results.
  * Fixed parsing so parameterless flags are no longer mistakenly consumed as the value for a preceding option.

* **Tests**
  * Added comprehensive tests covering invalid numeric option handling.
  * Added regression tests ensuring parameterless flag parsing behaves correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/322)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->