### PR TITLE
test: add --with-families smoke test, close E2E coverage gap

### DIFF
--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -175,6 +175,21 @@ else
     fail "--custodian-count command failed"
 fi
 
+# --- --with-families flag ---
+
+print_info "Test: --with-families accepted with EML + attachments"
+if zipper --type eml --count 10 --output-path "$TEST_OUTPUT_DIR/families" \
+    --with-families --attachment-rate 50 > /dev/null 2>&1; then
+    dat_file=$(find "$TEST_OUTPUT_DIR/families" -name "*.dat" -print -quit)
+    if [[ -n "$dat_file" && -s "$dat_file" ]]; then
+        pass "--with-families accepted and produces output"
+    else
+        fail "--with-families: no .dat file produced"
+    fi
+else
+    fail "--with-families command failed"
+fi
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary
Closes #287

Adds the final missing E2E test for `--with-families`, completing coverage for all flags listed in the issue.

## Note on --with-families
The flag is parsed and stored in config but not consumed by any load file writer — it's effectively a no-op. The BEGATTACH/ENDATTACH/PARENTDOCID columns only exist in the `litigation` built-in profile. The test verifies the flag is accepted without error.

## Testing
- All 14/14 E2E coverage gap tests pass

Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E CLI test coverage for the `--with-families` flag when generating output with attachments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->