### PR TITLE
refactor: introduce LoadFileRecord + ILoadFileSerializer seam

### DIFF
--- a/src/LoadFiles/DatSerializer.cs
+++ b/src/LoadFiles/DatSerializer.cs
@@ -1,0 +1,132 @@
+using System.Text;
+
+namespace Zipper.LoadFiles;
+
+/// <summary>
+/// Serializes <see cref="LoadFileRecord"/> instances to standard DAT format
+/// (ASCII 20 column delimiter, ASCII 254 quote delimiter).
+/// </summary>
+internal sealed class DatSerializer : ILoadFileSerializer
+{
+    private readonly char columnDelimiter;
+    private readonly char quoteDelimiter;
+    private readonly bool hasQuote;
+    private readonly string newlineDelimiter;
+    private readonly Encoding encoding;
+    private StreamWriter? writer;
+    private Stream? boundStream;
+
+    public DatSerializer(char columnDelimiter = '\x14', char quoteDelimiter = '\xfe', string newlineDelimiter = "\xae")
+    {
+        this.columnDelimiter = columnDelimiter;
+        this.quoteDelimiter = quoteDelimiter;
+        this.hasQuote = quoteDelimiter != '\0';
+        this.newlineDelimiter = newlineDelimiter;
+        this.encoding = Encoding.UTF8;
+    }
+
+    public DatSerializer(FileGenerationRequest request)
+    {
+        this.columnDelimiter = request.Delimiters.GetColumnChar();
+        this.quoteDelimiter = request.Delimiters.GetQuoteChar();
+        this.hasQuote = this.quoteDelimiter != '\0';
+        this.newlineDelimiter = request.Delimiters.NewlineDelimiter;
+        this.encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+    }
+
+    public string FormatName => "DAT";
+
+    public string FileExtension => ".dat";
+
+    public async Task WriteHeaderAsync(Stream stream, IReadOnlyList<string> columns)
+    {
+        this.EnsureWriter(stream);
+        var sb = new StringBuilder();
+        for (int i = 0; i < columns.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(this.columnDelimiter);
+            }
+
+            this.AppendField(sb, columns[i]);
+        }
+
+        await this.writer!.WriteLineAsync(sb.ToString());
+    }
+
+    public async Task WriteRecordAsync(Stream stream, LoadFileRecord record)
+    {
+        this.EnsureWriter(stream);
+        var sb = new StringBuilder();
+        for (int i = 0; i < record.Columns.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(this.columnDelimiter);
+            }
+
+            var value = record.Values.TryGetValue(record.Columns[i], out var v) ? v : string.Empty;
+            var escaped = this.EscapeField(value);
+            this.AppendField(sb, escaped);
+        }
+
+        await this.writer!.WriteLineAsync(sb.ToString());
+    }
+
+    public async Task FlushAsync(Stream stream)
+    {
+        if (this.writer != null)
+        {
+            await this.writer!.FlushAsync();
+        }
+    }
+
+    private void EnsureWriter(Stream stream)
+    {
+        if (this.writer == null || this.boundStream != stream)
+        {
+            this.writer = new StreamWriter(stream, this.encoding, leaveOpen: true);
+            this.boundStream = stream;
+        }
+    }
+
+    private void AppendField(StringBuilder sb, string value)
+    {
+        if (this.hasQuote)
+        {
+            sb.Append(this.quoteDelimiter);
+            sb.Append(value);
+            sb.Append(this.quoteDelimiter);
+        }
+        else
+        {
+            sb.Append(value);
+        }
+    }
+
+    private string EscapeField(string field)
+    {
+        if (string.IsNullOrEmpty(field))
+        {
+            return field;
+        }
+
+        var result = field;
+        if (this.hasQuote && result.Contains(this.quoteDelimiter))
+        {
+            result = result.Replace(
+                this.quoteDelimiter.ToString(),
+                new string(this.quoteDelimiter, 2));
+        }
+
+        if (!string.IsNullOrEmpty(this.newlineDelimiter))
+        {
+            result = result.Replace("\r\n", this.newlineDelimiter)
+                           .Replace("\n", this.newlineDelimiter)
+                           .Replace("\r", this.newlineDelimiter);
+        }
+
+        return result;
+    }
+}

--- a/src/LoadFiles/ILoadFileSerializer.cs
+++ b/src/LoadFiles/ILoadFileSerializer.cs
@@ -1,0 +1,33 @@
+namespace Zipper.LoadFiles;
+
+/// <summary>
+/// Serializes <see cref="LoadFileRecord"/> instances to a specific load file format.
+/// Separates "what data goes in a row" from "how that row is written."
+/// </summary>
+internal interface ILoadFileSerializer
+{
+    /// <summary>
+    /// Gets the human-readable format name.
+    /// </summary>
+    string FormatName { get; }
+
+    /// <summary>
+    /// Gets the file extension (including the dot).
+    /// </summary>
+    string FileExtension { get; }
+
+    /// <summary>
+    /// Writes a header row to the stream.
+    /// </summary>
+    Task WriteHeaderAsync(Stream stream, IReadOnlyList<string> columns);
+
+    /// <summary>
+    /// Writes a single data record to the stream.
+    /// </summary>
+    Task WriteRecordAsync(Stream stream, LoadFileRecord record);
+
+    /// <summary>
+    /// Flushes any buffered output.
+    /// </summary>
+    Task FlushAsync(Stream stream);
+}

--- a/src/LoadFiles/LoadFileRecord.cs
+++ b/src/LoadFiles/LoadFileRecord.cs
@@ -1,0 +1,18 @@
+namespace Zipper.LoadFiles;
+
+/// <summary>
+/// A single row of load file data, independent of output format.
+/// Column names are ordered; values are keyed by column name.
+/// </summary>
+internal sealed class LoadFileRecord
+{
+    /// <summary>
+    /// Gets the ordered column names for this record set.
+    /// </summary>
+    public required IReadOnlyList<string> Columns { get; init; }
+
+    /// <summary>
+    /// Gets the column values keyed by column name.
+    /// </summary>
+    public required IReadOnlyDictionary<string, string> Values { get; init; }
+}

--- a/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
+++ b/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
@@ -1,0 +1,123 @@
+using System.Text;
+
+using Xunit;
+
+using Zipper.LoadFiles;
+
+namespace Zipper.Tests.LoadFiles;
+
+public class DatSerializerTests
+{
+    [Fact]
+    public async Task WriteHeaderAsync_ProducesDelimitedHeader()
+    {
+        var serializer = new DatSerializer();
+        using var stream = new MemoryStream();
+        var columns = new List<string> { "DOCID", "FILEPATH", "CUSTODIAN" };
+
+        await serializer.WriteHeaderAsync(stream, columns);
+        await serializer.FlushAsync(stream);
+
+        stream.Position = 0;
+        var content = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Contains("DOCID", content);
+        Assert.Contains("FILEPATH", content);
+        Assert.Contains("CUSTODIAN", content);
+        Assert.Contains("\x14", content); // column delimiter
+    }
+
+    [Fact]
+    public async Task WriteRecordAsync_ProducesDelimitedRow()
+    {
+        var serializer = new DatSerializer();
+        using var stream = new MemoryStream();
+        var columns = new List<string> { "DOCID", "FILEPATH" };
+        var record = new LoadFileRecord
+        {
+            Columns = columns,
+            Values = new Dictionary<string, string>
+            {
+                ["DOCID"] = "DOC001",
+                ["FILEPATH"] = "folder/file.pdf",
+            },
+        };
+
+        await serializer.WriteRecordAsync(stream, record);
+        await serializer.FlushAsync(stream);
+
+        stream.Position = 0;
+        var content = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Contains("DOC001", content);
+        Assert.Contains("folder/file.pdf", content);
+        Assert.Contains("\x14", content); // column delimiter
+    }
+
+    [Fact]
+    public async Task WriteRecordAsync_EscapesQuoteDelimiter()
+    {
+        var serializer = new DatSerializer();
+        using var stream = new MemoryStream();
+        var columns = new List<string> { "VALUE" };
+        var record = new LoadFileRecord
+        {
+            Columns = columns,
+            Values = new Dictionary<string, string>
+            {
+                ["VALUE"] = "has\xfequote",
+            },
+        };
+
+        await serializer.WriteRecordAsync(stream, record);
+        await serializer.FlushAsync(stream);
+
+        stream.Position = 0;
+        var content = Encoding.UTF8.GetString(stream.ToArray());
+
+        // Quote delimiter should be doubled
+        Assert.Contains("\xfe\xfe", content);
+    }
+
+    [Fact]
+    public async Task WriteRecordAsync_ReplacesNewlines()
+    {
+        var serializer = new DatSerializer();
+        using var stream = new MemoryStream();
+        var columns = new List<string> { "TEXT" };
+        var record = new LoadFileRecord
+        {
+            Columns = columns,
+            Values = new Dictionary<string, string>
+            {
+                ["TEXT"] = "line1\nline2",
+            },
+        };
+
+        await serializer.WriteRecordAsync(stream, record);
+        await serializer.FlushAsync(stream);
+
+        stream.Position = 0;
+        var content = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.DoesNotContain("\n", content.TrimEnd('\r', '\n'));
+        Assert.Contains("\xae", content);
+    }
+
+    [Fact]
+    public async Task NoQuoteMode_OmitsQuoteDelimiters()
+    {
+        var serializer = new DatSerializer(columnDelimiter: '|', quoteDelimiter: '\0');
+        using var stream = new MemoryStream();
+        var columns = new List<string> { "A", "B" };
+        var record = new LoadFileRecord
+        {
+            Columns = columns,
+            Values = new Dictionary<string, string> { ["A"] = "x", ["B"] = "y" },
+        };
+
+        await serializer.WriteRecordAsync(stream, record);
+        await serializer.FlushAsync(stream);
+
+        stream.Position = 0;
+        var content = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.StartsWith("x|y", content);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #261

Introduces the `LoadFileRecord` + `ILoadFileSerializer` seam that separates 'what data goes in a row' from 'how that row is written to a specific format.'

## Changes
- `LoadFileRecord.cs`: Format-independent row model with ordered columns and keyed values
- `ILoadFileSerializer.cs`: Interface with `WriteHeaderAsync`, `WriteRecordAsync`, `FlushAsync`
- `DatSerializer.cs`: First implementation — standard DAT format with configurable delimiters, quote escaping, newline replacement
- `DatSerializerTests.cs`: 5 tests covering header, record, escape, newline, and no-quote modes

## Design Decisions
- Additive only — existing `ILoadFileWriter` implementations are unchanged
- `DatSerializer` accepts either explicit delimiter chars or a `FileGenerationRequest`
- `LoadFileRecord` uses `IReadOnlyDictionary<string, string>` matching `DataGenerator.GenerateRow` output
- Future: migrate existing writers to compose `ILoadFileSerializer` internally

## Testing
- All 952 unit tests pass, lint clean
- No behavior changes to existing code

Closes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DAT file export with configurable column delimiter, optional quoting with escaping, newline normalization, and UTF‑8 encoding support.
  * Added a generic load-file record model and a serializer contract to support multiple export formats.

* **Tests**
  * Added tests covering header/record output, quote escaping, newline normalization, and quote-mode behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/324)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->