### PR TITLE
refactor: simplify ParallelFileGenerator internal plumbing

### DIFF
--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -9,7 +9,7 @@ namespace Zipper
     /// <summary>
     /// Generates files in parallel with controlled concurrency and memory pooling.
     /// </summary>
-    public class ParallelFileGenerator : IDisposable
+    public class ParallelFileGenerator
     {
         private readonly PerformanceMonitor performanceMonitor = new PerformanceMonitor();
 
@@ -64,12 +64,11 @@ namespace Zipper
                 });
 
                 // Start the consumer task to write the archive concurrently
-                var consumerTask = this.WriteArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader);
+                var consumerTask = ZipArchiveService.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader);
 
                 // Generate files in parallel (producers)
-                using var semaphore = new SemaphoreSlim(request.Output.Concurrency);
                 var producerTasks = Enumerable.Range(0, request.Output.Concurrency)
-                    .Select(i => this.ProcessFileWorkAsync(semaphore, workChannelReader, paddingPerFile, resultChannel.Writer, request, fileGenerator))
+                    .Select(i => this.ProcessFileWorkAsync(workChannelReader, paddingPerFile, resultChannel.Writer, request, fileGenerator))
                     .ToList();
 
                 // Wait for all producers to complete, wrapped in a task that ensures completion
@@ -173,27 +172,19 @@ namespace Zipper
             return channel.Reader;
         }
 
-        private async Task ProcessFileWorkAsync(SemaphoreSlim semaphore, ChannelReader<FileWorkItem> reader, long paddingPerFile, ChannelWriter<FileData> writer, FileGenerationRequest request, IFileGenerator fileGenerator)
+        private async Task ProcessFileWorkAsync(ChannelReader<FileWorkItem> reader, long paddingPerFile, ChannelWriter<FileData> writer, FileGenerationRequest request, IFileGenerator fileGenerator)
         {
             long filesProcessed = 0;
 
             await foreach (var workItem in reader.ReadAllAsync())
             {
-                await semaphore.WaitAsync();
-                try
-                {
-                    var fileData = this.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
-                    await writer.WriteAsync(fileData);
+                var fileData = this.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+                await writer.WriteAsync(fileData);
 
-                    filesProcessed++;
-                    if (filesProcessed % PerformanceConstants.ProgressBatchSize == 0)
-                    {
-                        this.performanceMonitor.ReportFilesCompleted(PerformanceConstants.ProgressBatchSize);
-                    }
-                }
-                finally
+                filesProcessed++;
+                if (filesProcessed % PerformanceConstants.ProgressBatchSize == 0)
                 {
-                    semaphore.Release();
+                    this.performanceMonitor.ReportFilesCompleted(PerformanceConstants.ProgressBatchSize);
                 }
             }
 
@@ -281,12 +272,6 @@ namespace Zipper
             };
         }
 
-        private async Task<string> WriteArchiveAsync(string zipFilePath, string loadFileName, string loadFilePath, FileGenerationRequest request, ChannelReader<FileData> resultReader)
-        {
-            // Delegate to new ZipArchiveService for actual ZIP creation
-            return await ZipArchiveService.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultReader);
-        }
-
         internal long CalculatePaddingPerFile(long targetSize, int baseSize, long fileCount, bool withText)
         {
             var estimatedBaseSize = this.EstimateCompressedSize(baseSize, fileCount, withText);
@@ -312,10 +297,6 @@ namespace Zipper
             }
 
             return baseSize * count;
-        }
-
-        public void Dispose()
-        {
         }
 
         private static void RethrowIfNotNull(Exception? ex)

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -44,7 +44,7 @@ namespace Zipper
 
                 var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
 
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var request = new FileGenerationRequest
                 {
                     Output = new OutputConfig
@@ -100,7 +100,7 @@ namespace Zipper
 
                 // Parallel generation
                 sw.Restart();
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var request = new FileGenerationRequest
                 {
                     Output = new OutputConfig
@@ -210,7 +210,7 @@ namespace Zipper
                 {
                     var sw = Stopwatch.StartNew();
 
-                    using var generator = new ParallelFileGenerator();
+                    var generator = new ParallelFileGenerator();
                     var request = new FileGenerationRequest
                     {
                         Output = new OutputConfig

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -35,7 +35,7 @@ namespace Zipper
             }
 
             // Use parallel file generator for improved performance
-            using var generator = new ParallelFileGenerator();
+            var generator = new ParallelFileGenerator();
 
             var result = await generator.GenerateFilesAsync(request);
 

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -271,7 +271,7 @@ namespace Zipper
 
             try
             {
-                using (var generator = new ParallelFileGenerator())
+                var generator = new ParallelFileGenerator();
                 {
                     var task = generator.GenerateFilesAsync(new FileGenerationRequest
                     {
@@ -310,7 +310,7 @@ namespace Zipper
 
             try
             {
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
                     generator.GenerateFilesAsync(new FileGenerationRequest
                     {
@@ -343,7 +343,7 @@ namespace Zipper
 
             try
             {
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var result = await generator.GenerateFilesAsync(new FileGenerationRequest
                 {
                     Output = new OutputConfig
@@ -378,7 +378,7 @@ namespace Zipper
 
             try
             {
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
                     generator.GenerateFilesAsync(new FileGenerationRequest
                     {
@@ -411,7 +411,7 @@ namespace Zipper
 
             try
             {
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var result = await generator.GenerateFilesAsync(new FileGenerationRequest
                 {
                     Output = new OutputConfig
@@ -444,7 +444,7 @@ namespace Zipper
 
             try
             {
-                using var generator = new ParallelFileGenerator();
+                var generator = new ParallelFileGenerator();
                 var result = await generator.GenerateFilesAsync(new FileGenerationRequest
                 {
                     Output = new OutputConfig
@@ -474,7 +474,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_NullOutputPath_ThrowsArgumentNullException()
         {
-            using var generator = new ParallelFileGenerator();
+            var generator = new ParallelFileGenerator();
             await Assert.ThrowsAsync<ArgumentNullException>(() =>
                 generator.GenerateFilesAsync(new FileGenerationRequest
                 {


### PR DESCRIPTION
## Summary
Closes #272

Removes three pieces of dead ceremony from `ParallelFileGenerator`.

## Changes
- Removed redundant `SemaphoreSlim` — producer count already equals concurrency
- Removed empty `IDisposable` implementation and `using` at call sites
- Inlined `WriteArchiveAsync` (was a single-line delegation to `ZipArchiveService`)

## Testing
- All 916 unit tests pass, lint clean
- No behavior changes (same concurrency, same output)

Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parallel file generation with improved task-based concurrency control, replacing semaphore-based synchronization.
  * Simplified resource management by removing explicit disposal requirements for the file generator.
  * Enhanced archive-writing integration for streamlined file processing and output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->