### PR TITLE
refactor: fix large-index seed truncation in per-row Random creation

### DIFF
--- a/src/EmlFileGenerator.cs
+++ b/src/EmlFileGenerator.cs
@@ -14,7 +14,7 @@ internal sealed class EmlFileGenerator : IFileGenerator
     public GeneratedFileContent Generate(FileWorkItem workItem, FileGenerationRequest request)
     {
         var random = request.Metadata.Seed.HasValue
-            ? new Random(request.Metadata.Seed.Value + (int)workItem.Index)
+            ? new Random(unchecked((int)(request.Metadata.Seed.Value + workItem.Index)))
             : Random.Shared;
 
         var email = EmailFactory.Create(workItem, request, random);

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -259,7 +259,7 @@ internal class DatWriter : LoadFileWriterBase
         var imagesPath = imagePath.Replace(Path.DirectorySeparatorChar, '\\');
 
 #pragma warning disable S2245
-        var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + (int)workItem.Index) : Random.Shared;
+        var random = request.Metadata.Seed.HasValue ? new Random(unchecked((int)(request.Metadata.Seed.Value + workItem.Index))) : Random.Shared;
 #pragma warning restore S2245
         var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
         var maxCustodians = Math.Max(2, request.Metadata.CustodianCountOverride ?? 10);

--- a/src/TiffMultiPageGenerator.cs
+++ b/src/TiffMultiPageGenerator.cs
@@ -57,7 +57,7 @@ internal static class TiffMultiPageGenerator
         // to ensure deterministic page counts for testing, while avoiding
         // shared state contention.
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
-        var random = new Random((seed ?? 0) + (int)fileIndex);
+        var random = new Random(unchecked((int)((seed ?? 0) + fileIndex)));
 #pragma warning restore S2245
         return random.Next(clampedMin, clampedMax + 1);
     }


### PR DESCRIPTION
## Summary
Closes #265

Fixes the large-index truncation bug where `(int)workItem.Index` would overflow for indexes > 2B.

## Changes
- `DatWriter.cs`: `new Random(unchecked((int)(seed + workItem.Index)))`
- `EmlFileGenerator.cs`: Same pattern
- `TiffMultiPageGenerator.cs`: Same pattern

## Testing
- All 916 unit tests pass, lint clean

Closes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in random data generation across file processing operations when using seed values to ensure deterministic results are handled more reliably.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/328)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->