### PR TITLE
refactor: split ProductionSetGenerator path planning from file writing

### DIFF
--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -61,10 +61,9 @@ internal static class ProductionSetGenerator
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : new Random();
 #pragma warning restore S2245
-        var batesConfig = request.Bates
-            ?? throw new InvalidOperationException("Production set requires Bates configuration. Specify --bates-prefix.");
 
-        // Calculate volume distribution
+        // Plan document layout (no I/O)
+        var plans = ProductionSetPlanner.Plan(request);
         int volumeCount = (int)Math.Ceiling((double)request.Output.FileCount / request.Production.VolumeSize);
 
         // Pre-create volume subdirectories
@@ -81,44 +80,30 @@ internal static class ProductionSetGenerator
         var fileGenerator = FileGeneratorFactory.Create(request.Output.FileType, request)
             ?? throw new InvalidOperationException($"Unknown file type: {request.Output.FileType}");
 
-        // Generate files and collect records for load files
+        // Generate files using the plan
         var fileDataList = new List<FileData>();
 
-        for (long i = 0; i < request.Output.FileCount; i++)
+        foreach (var plan in plans)
         {
-            int volumeIndex = (int)(i / request.Production.VolumeSize) + 1;
-            var volName = $"VOL{volumeIndex:D3}";
-            var batesNumber = BatesNumberGenerator.Generate(batesConfig, i);
-
-            var nativeExt = request.Output.FileTypeLower;
-            var nativeRelPath = Path.Combine("NATIVES", volName, $"{batesNumber}.{nativeExt}");
-            var textRelPath = Path.Combine("TEXT", volName, $"{batesNumber}.txt");
-            var imageRelPath = Path.Combine("IMAGES", volName, $"{batesNumber}.tif");
-
-            // Write native file
-            var nativeFullPath = Path.Combine(productionPath, nativeRelPath);
             var workItem = new FileWorkItem
             {
-                Index = i + 1,
-                FolderNumber = volumeIndex,
-                FolderName = volName,
-                FileName = $"{batesNumber}.{nativeExt}",
-                FilePathInZip = nativeRelPath,
+                Index = plan.Index + 1,
+                FolderNumber = plan.VolumeIndex,
+                FolderName = plan.VolumeName,
+                FileName = $"{plan.BatesNumber}.{request.Output.FileTypeLower}",
+                FilePathInZip = plan.NativeRelPath,
             };
             var generated = fileGenerator.Generate(workItem, request);
             var nativeContent = generated.Content;
 
-            await File.WriteAllBytesAsync(nativeFullPath, nativeContent);
+            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.NativeRelPath), nativeContent);
 
-            // Write text file
-            var textFullPath = Path.Combine(productionPath, textRelPath);
-            var textContent = $"Extracted text for document {batesNumber}. " +
+            var textContent = $"Extracted text for document {plan.BatesNumber}. " +
                               Profiles.LoremIpsum.GetParagraph(random);
-            await File.WriteAllTextAsync(textFullPath, textContent, encoding);
+            await File.WriteAllTextAsync(Path.Combine(productionPath, plan.TextRelPath), textContent, encoding);
 
             // Write placeholder TIFF image (single-pixel stub)
-            var imageFullPath = Path.Combine(productionPath, imageRelPath);
-            await File.WriteAllBytesAsync(imageFullPath, PlaceholderFiles.GetContent("tiff"));
+            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff"));
 
             fileDataList.Add(new FileData
             {
@@ -127,9 +112,9 @@ internal static class ProductionSetGenerator
             });
 
             // Progress reporting
-            if ((i + 1) % 1000 == 0 || i == request.Output.FileCount - 1)
+            if ((plan.Index + 1) % 1000 == 0 || plan.Index == request.Output.FileCount - 1)
             {
-                Console.Write($"\r  Progress: {i + 1:N0} / {request.Output.FileCount:N0} documents");
+                Console.Write($"\r  Progress: {plan.Index + 1:N0} / {request.Output.FileCount:N0} documents");
             }
         }
 
@@ -164,8 +149,8 @@ internal static class ProductionSetGenerator
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson);
 
         // Write manifest
-        var batesStart = BatesNumberGenerator.Generate(batesConfig, 0);
-        var batesEnd = BatesNumberGenerator.Generate(batesConfig, request.Output.FileCount - 1);
+        var batesStart = plans[0].BatesNumber;
+        var batesEnd = plans[^1].BatesNumber;
         var manifestPath = await ProductionManifestWriter.WriteAsync(
             productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed);
 

--- a/src/ProductionSetPlanner.cs
+++ b/src/ProductionSetPlanner.cs
@@ -1,0 +1,67 @@
+namespace Zipper;
+
+/// <summary>
+/// Immutable plan for a single document in a Production Set.
+/// Separates path planning from file writing.
+/// </summary>
+internal sealed record ProductionDocumentPlan
+{
+    public required long Index { get; init; }
+
+    public required int VolumeIndex { get; init; }
+
+    public required string VolumeName { get; init; }
+
+    public required string BatesNumber { get; init; }
+
+    public required string NativeRelPath { get; init; }
+
+    public required string TextRelPath { get; init; }
+
+    public required string ImageRelPath { get; init; }
+}
+
+/// <summary>
+/// Plans the document layout for a Production Set without performing I/O.
+/// </summary>
+internal static class ProductionSetPlanner
+{
+    public static IReadOnlyList<ProductionDocumentPlan> Plan(FileGenerationRequest request)
+    {
+        var batesConfig = request.Bates
+            ?? throw new InvalidOperationException("Production set requires Bates configuration.");
+
+        if (request.Output.FileCount <= 0)
+        {
+            throw new InvalidOperationException("Production set requires FileCount > 0.");
+        }
+
+        if (request.Production.VolumeSize <= 0)
+        {
+            throw new InvalidOperationException("Production set requires VolumeSize > 0.");
+        }
+
+        var plans = new List<ProductionDocumentPlan>((int)request.Output.FileCount);
+        var nativeExt = request.Output.FileTypeLower;
+
+        for (long i = 0; i < request.Output.FileCount; i++)
+        {
+            int volumeIndex = (int)(i / request.Production.VolumeSize) + 1;
+            var volName = $"VOL{volumeIndex:D3}";
+            var batesNumber = BatesNumberGenerator.Generate(batesConfig, i);
+
+            plans.Add(new ProductionDocumentPlan
+            {
+                Index = i,
+                VolumeIndex = volumeIndex,
+                VolumeName = volName,
+                BatesNumber = batesNumber,
+                NativeRelPath = Path.Combine("NATIVES", volName, $"{batesNumber}.{nativeExt}"),
+                TextRelPath = Path.Combine("TEXT", volName, $"{batesNumber}.txt"),
+                ImageRelPath = Path.Combine("IMAGES", volName, $"{batesNumber}.tif"),
+            });
+        }
+
+        return plans;
+    }
+}


### PR DESCRIPTION
## Summary
Closes #274

Separates path planning from file writing in `ProductionSetGenerator`.

## Changes
- `ProductionSetPlanner.cs`: New `ProductionDocumentPlan` record + `Plan()` method that computes all paths/volumes/bates without I/O
- `ProductionSetGenerator.cs`: Consumes the plan via `foreach` instead of computing paths inline

## Design
- `ProductionDocumentPlan`: immutable record with Index, VolumeIndex, VolumeName, BatesNumber, NativeRelPath, TextRelPath, ImageRelPath
- `ProductionSetPlanner.Plan()`: pure function, no side effects, testable independently
- Generator still handles directory creation, file writing, load files, and manifest

## Testing
- All 916 unit tests pass, lint clean
- No output changes (same paths, same content)

Closes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized file generation flow to drive processing from a generated document plan, improving ordering and per-file progress tracking.
  * Adjusted production manifest Bates range calculation to derive start/end from the planned document sequence for more accurate reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/329)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->