### PR TITLE
fix: resolve YAML syntax error breaking PR Checks workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -175,17 +175,17 @@ jobs:
         if: matrix.coverage == true
         run: |
           if [[ -f TestResults/test-results.xml ]]; then
-            python3 -c "
-import xml.etree.ElementTree as ET
-tree = ET.parse('TestResults/test-results.xml')
-tests = [(t.get('classname',''), t.get('name',''), float(t.get('time',0))) for t in tree.iter() if t.tag == 'testcase' and float(t.get('time',0)) > 0.5]
-tests.sort(key=lambda x: -x[2])
-print('Slowest tests (>0.5s):')
-for cls, name, secs in tests[:20]:
-    print(f'  {secs:.2f}s  {cls}.{name}')
-if not tests:
-    print('All tests under 0.5s')
-" || true
+            python3 <<'SCRIPT'
+          import xml.etree.ElementTree as ET
+          tree = ET.parse('TestResults/test-results.xml')
+          tests = [(t.get('classname',''), t.get('name',''), float(t.get('time',0))) for t in tree.iter() if t.tag == 'testcase' and float(t.get('time',0)) > 0.5]
+          tests.sort(key=lambda x: -x[2])
+          print('Slowest tests (>0.5s):')
+          for cls, name, secs in tests[:20]:
+              print(f'  {secs:.2f}s  {cls}.{name}')
+          if not tests:
+              print('All tests under 0.5s')
+          SCRIPT
           fi
 
       - name: Cache reportgenerator tool (Linux)


### PR DESCRIPTION
## Problem

The PR Checks workflow (`.github/workflows/pr.yml`) has been failing with 0 jobs since PR #374 was merged. Every push to a branch triggers a `.github/workflows/pr.yml` failure (workflow name falls back to file path instead of `PR Checks`).

## Root Cause

PR #374 introduced a `python3 -c \"...\"` block with embedded Python code at column 1 (zero indentation). This breaks the YAML `|` block scalar because lines with less indentation than the block scalar level are interpreted as new YAML elements.

When GitHub can't parse the workflow file:
1. Workflow name falls back to file path (`.github/workflows/pr.yml`)
2. The `on: pull_request` trigger is misinterpreted
3. Push events trigger the workflow with 0 jobs → failure
4. **PR Checks never run** on pull requests

## Fix

Convert `python3 -c \"...\"` to heredoc (`python3 <<'SCRIPT'`), keeping Python code properly indented within the block scalar. This matches the pattern already used in `perf-guard.yml`.

## Before (broken)

```yaml
run: |
  if [[ -f TestResults/test-results.xml ]]; then
    python3 -c \"
import xml.etree.ElementTree as ET    # <-- column 1, breaks YAML
tree = ET.parse(...
\"
  fi
```

## After (fixed)

```yaml
run: |
  if [[ -f TestResults/test-results.xml ]]; then
    python3 <<'SCRIPT'
  import xml.etree.ElementTree as ET  # <-- indented, valid YAML
  tree = ET.parse(...
  SCRIPT
  fi
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal test timing report workflow configuration for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->