### PR TITLE
fix: add actionlint for early workflow YAML error detection

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -81,6 +81,22 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # ──────────────────────────────────────────────────
+# 1b. actionlint — validate GitHub Actions workflow YAML
+# ──────────────────────────────────────────────────
+STAGED_YAML=()
+while IFS= read -r f; do
+    [[ -n "$f" && "$f" == .github/workflows/*.yml ]] && STAGED_YAML+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ ${#STAGED_YAML[@]} -gt 0 ]] && command -v actionlint >/dev/null 2>&1; then
+    echo "▶ Running actionlint on ${#STAGED_YAML[@]} workflow file(s)..."
+    if ! actionlint "${STAGED_YAML[@]}"; then
+        echo "❌ actionlint found issues in workflow files. Commit aborted." >&2
+        exit 1
+    fi
+fi
+
+# ──────────────────────────────────────────────────
 # 2. dotnet format — scoped to staged C# files only
 # ──────────────────────────────────────────────────
 STAGED_CS=()

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -80,21 +80,6 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-# ──────────────────────────────────────────────────
-# 1b. actionlint — validate GitHub Actions workflow YAML
-# ──────────────────────────────────────────────────
-STAGED_YAML=()
-while IFS= read -r f; do
-    [[ -n "$f" && "$f" == .github/workflows/*.yml ]] && STAGED_YAML+=("$f")
-done < <(git diff --cached --name-only --diff-filter=ACMR)
-
-if [[ ${#STAGED_YAML[@]} -gt 0 ]] && command -v actionlint >/dev/null 2>&1; then
-    echo "▶ Running actionlint on ${#STAGED_YAML[@]} workflow file(s)..."
-    if ! actionlint "${STAGED_YAML[@]}"; then
-        echo "❌ actionlint found issues in workflow files. Commit aborted." >&2
-        exit 1
-    fi
-fi
 
 # ──────────────────────────────────────────────────
 # 2. dotnet format — scoped to staged C# files only

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
             VERSION="$major.$minor.$NEW_PATCH-dev"
             echo "Version from bump: $VERSION (latest tag: $LATEST_TAG)"
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: prepare
@@ -215,7 +215,7 @@ jobs:
 
           git tag "$NEW_TAG"
           git push origin "$NEW_TAG"
-          echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         if: steps.tag_step.outputs.tag != ''

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,8 +66,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: eifinger/actionlint-action@v1.10.2
-        with:
-          actionlint_flags: -shellcheck= .github/workflows/*.yml
       - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,12 +65,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - name: Lint workflow YAML with actionlint
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest /usr/local/bin
-          actionlint -shellcheck= .github/workflows/*.yml
+      - uses: eifinger/actionlint-action@v4
+        with:
+          actionlint_flags: -shellcheck= .github/workflows/*.yml
       - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - name: Lint workflow YAML with actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest /usr/local/bin
+          actionlint .github/workflows/*.yml
       - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest /usr/local/bin
-          actionlint .github/workflows/*.yml
+          actionlint -shellcheck= .github/workflows/*.yml
       - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: eifinger/actionlint-action@v4
+      - uses: eifinger/actionlint-action@v1.10.2
         with:
           actionlint_flags: -shellcheck= .github/workflows/*.yml
       - uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Problem

PR #374 introduced a YAML syntax error in `pr.yml` that silently broke the PR Checks workflow for all subsequent PRs. The error went undetected because there was no validation step for workflow files.

## Changes

**Pre-commit hook** (`.github/hooks/pre-commit`):
- Added actionlint step that validates staged `.github/workflows/*.yml` files
- Only runs when actionlint is installed (graceful skip if not found)
- Runs before dotnet format, so workflow errors are caught first

**CI** (`.github/workflows/pr.yml`):
- Added actionlint step to `validate-agents-md` job (runs before AGENTS.md validation)
- Downloads latest actionlint on each run (no caching needed, ~3s)
- Catches YAML syntax errors, invalid expressions, missing fields, etc.

## What actionlint catches

- YAML syntax errors (like the python3 -c indentation issue from PR #374)
- Invalid `${{ }}` expressions
- Missing required workflow/job/step fields
- Wrong action versions or missing uses/run
- Type mismatches in workflow context values

## Local setup (optional)

```bash
# macOS
brew install actionlint

# Linux
curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest ~/.local/bin
```