### PR TITLE
feat: implement --with-families parent-child load files (REQ-060/061/062)

### DIFF
--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -69,50 +69,9 @@ internal class DatWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-
-            string parentId = request.Bates != null
-                ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
-                : $"DOC{fileData.WorkItem.Index:D8}";
-
-            string childId = hasAttachment ? $"{parentId}_A001" : parentId;
-            string begAttach = parentId;
-            string endAttach = childId;
-            string parentDocId = string.Empty;
-
-            var line = BuildStandardRow(
-                fileData,
-                request,
-                colDelim,
-                quote,
-                profileValues,
-                new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-
-            buffer.AppendLine(line);
-            rowCount++;
-
-            if (hasAttachment)
+            foreach (var (_, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, profileValues))
             {
-                var attach = fileData.Attachment!.Value;
-                var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
-                var childLine = BuildStandardRow(
-                    fileData,
-                    request,
-                    colDelim,
-                    quote,
-                    profileValues,
-                    new RowBuildContext
-                    {
-                        IdOverride = childId,
-                        FilePathOverride = attachmentPath,
-                        FileSizeOverride = attach.content.Length.ToString(),
-                        IsChild = true,
-                        BegAttach = begAttach,
-                        EndAttach = endAttach,
-                        ParentDocId = parentId
-                    });
-
-                buffer.AppendLine(childLine);
+                buffer.AppendLine(rowLine);
                 rowCount++;
             }
 
@@ -162,49 +121,9 @@ internal class DatWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-
-            string parentId = request.Bates != null
-                ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
-                : $"DOC{fileData.WorkItem.Index:D8}";
-
-            string childId = hasAttachment ? $"{parentId}_A001" : parentId;
-            string begAttach = parentId;
-            string endAttach = childId;
-            string parentDocId = string.Empty;
-
-            var line = BuildStandardRow(
-                fileData,
-                request,
-                colDelim,
-                quote,
-                profileValues,
-                new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-
-            rows.Add((currentLineNumber++, parentId, line));
-
-            if (hasAttachment)
+            foreach (var (recordId, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, profileValues))
             {
-                var attach = fileData.Attachment!.Value;
-                var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
-                var childLine = BuildStandardRow(
-                    fileData,
-                    request,
-                    colDelim,
-                    quote,
-                    profileValues,
-                    new RowBuildContext
-                    {
-                        IdOverride = childId,
-                        FilePathOverride = attachmentPath,
-                        FileSizeOverride = attach.content.Length.ToString(),
-                        IsChild = true,
-                        BegAttach = begAttach,
-                        EndAttach = endAttach,
-                        ParentDocId = parentId
-                    });
-
-                rows.Add((currentLineNumber++, childId, childLine));
+                rows.Add((currentLineNumber++, recordId, rowLine));
             }
         }
 
@@ -315,44 +234,9 @@ internal class DatWriter : LoadFileWriterBase
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
-                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-                string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
-                string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
-
-                string begAttach = parentBates;
-                string endAttach = childBates;
-                string parentDocId = string.Empty;
-
-                var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-                await writer.WriteAsync(dataRow + eol);
-
-                if (hasAttachment)
+                foreach (var (_, rowLine) in BuildProductionSetRowsForFile(fileData, request, col, quote))
                 {
-                    var attach = fileData.Attachment!.Value;
-                    var childExt = Path.GetExtension(attach.filename);
-                    var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
-                    var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
-                    var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-
-                    var childRow = BuildProductionSetRow(
-                        fileData,
-                        request,
-                        col,
-                        quote,
-                        new RowBuildContext
-                        {
-                            IdOverride = childBates,
-                            NativePathOverride = childNativePath,
-                            TextPathOverride = childTextPath,
-                            ImagePathOverride = childImagePath,
-                            FileSizeOverride = attach.content.Length.ToString(),
-                            IsChild = true,
-                            BegAttach = begAttach,
-                            EndAttach = endAttach,
-                            ParentDocId = parentBates
-                        });
-
-                    await writer.WriteAsync(childRow + eol);
+                    await writer.WriteAsync(rowLine + eol);
                 }
             }
 
@@ -367,48 +251,113 @@ internal class DatWriter : LoadFileWriterBase
         long currentLineNumber = 2;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-            string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
-            string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
-
-            string begAttach = parentBates;
-            string endAttach = childBates;
-            string parentDocId = string.Empty;
-
-            var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-            rows.Add((currentLineNumber++, parentBates, dataRow));
-
-            if (hasAttachment)
+            foreach (var (recordId, rowLine) in BuildProductionSetRowsForFile(fileData, request, col, quote))
             {
-                var attach = fileData.Attachment!.Value;
-                var childExt = Path.GetExtension(attach.filename);
-                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
-                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
-                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-
-                var childRow = BuildProductionSetRow(
-                    fileData,
-                    request,
-                    col,
-                    quote,
-                    new RowBuildContext
-                    {
-                        IdOverride = childBates,
-                        NativePathOverride = childNativePath,
-                        TextPathOverride = childTextPath,
-                        ImagePathOverride = childImagePath,
-                        FileSizeOverride = attach.content.Length.ToString(),
-                        IsChild = true,
-                        BegAttach = begAttach,
-                        EndAttach = endAttach,
-                        ParentDocId = parentBates
-                    });
-
-                rows.Add((currentLineNumber++, childBates, childRow));
+                rows.Add((currentLineNumber++, recordId, rowLine));
             }
         }
 
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);
+    }
+
+    private static IEnumerable<(string RecordId, string Line)> BuildStandardRowsForFile(
+        FileData fileData,
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        System.Collections.Generic.Dictionary<string, string>? profileValues)
+    {
+        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+
+        string parentId = request.Bates != null
+            ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
+            : $"DOC{fileData.WorkItem.Index:D8}";
+
+        string childId = hasAttachment ? $"{parentId}_A001" : parentId;
+        string begAttach = parentId;
+        string endAttach = childId;
+        string parentDocId = string.Empty;
+
+        var line = BuildStandardRow(
+            fileData,
+            request,
+            colDelim,
+            quote,
+            profileValues,
+            new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
+
+        yield return (parentId, line);
+
+        if (hasAttachment)
+        {
+            var attach = fileData.Attachment!.Value;
+            var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
+            var childLine = BuildStandardRow(
+                fileData,
+                request,
+                colDelim,
+                quote,
+                profileValues,
+                new RowBuildContext
+                {
+                    IdOverride = childId,
+                    FilePathOverride = attachmentPath,
+                    FileSizeOverride = attach.content.Length.ToString(),
+                    IsChild = true,
+                    BegAttach = begAttach,
+                    EndAttach = endAttach,
+                    ParentDocId = parentId
+                });
+
+            yield return (childId, childLine);
+        }
+    }
+
+    private static IEnumerable<(string RecordId, string Line)> BuildProductionSetRowsForFile(
+        FileData fileData,
+        FileGenerationRequest request,
+        string col,
+        string quote)
+    {
+        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+        string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
+        string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
+
+        string begAttach = parentBates;
+        string endAttach = childBates;
+        string parentDocId = string.Empty;
+
+        var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
+        yield return (parentBates, dataRow);
+
+        if (hasAttachment)
+        {
+            var attach = fileData.Attachment!.Value;
+            var childExt = Path.GetExtension(attach.filename);
+            var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
+            var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
+            var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+
+            var childRow = BuildProductionSetRow(
+                fileData,
+                request,
+                col,
+                quote,
+                new RowBuildContext
+                {
+                    IdOverride = childBates,
+                    NativePathOverride = childNativePath,
+                    TextPathOverride = childTextPath,
+                    ImagePathOverride = childImagePath,
+                    FileSizeOverride = attach.content.Length.ToString(),
+                    IsChild = true,
+                    BegAttach = begAttach,
+                    EndAttach = endAttach,
+                    ParentDocId = parentBates
+                });
+
+            yield return (childBates, childRow);
+        }
     }
 
     private static string BuildProductionSetRow(

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -260,6 +260,15 @@ internal class DatWriter : LoadFileWriterBase
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);
     }
 
+    /// <summary>
+    /// Builds standard load file rows (parent and optional child attachments) for a single file.
+    /// </summary>
+    /// <param name="fileData">The generated file data.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="colDelim">The column delimiter character.</param>
+    /// <param name="quote">The quote character.</param>
+    /// <param name="profileValues">The custom metadata profile values.</param>
+    /// <returns>A collection of generated load file rows containing record ID and row string.</returns>
     private static IEnumerable<(string RecordId, string Line)> BuildStandardRowsForFile(
         FileData fileData,
         FileGenerationRequest request,
@@ -313,6 +322,14 @@ internal class DatWriter : LoadFileWriterBase
         }
     }
 
+    /// <summary>
+    /// Builds production set load file rows (parent and optional child attachments) for a single file.
+    /// </summary>
+    /// <param name="fileData">The generated file data.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="col">The column delimiter string.</param>
+    /// <param name="quote">The quote string.</param>
+    /// <returns>A collection of generated load file rows containing record ID and row string.</returns>
     private static IEnumerable<(string RecordId, string Line)> BuildProductionSetRowsForFile(
         FileData fileData,
         FileGenerationRequest request,
@@ -360,6 +377,15 @@ internal class DatWriter : LoadFileWriterBase
         }
     }
 
+    /// <summary>
+    /// Builds a single DAT row for the production set output mode.
+    /// </summary>
+    /// <param name="fileData">The generated file data.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="col">The column delimiter.</param>
+    /// <param name="quote">The quote delimiter.</param>
+    /// <param name="context">The row context containing optional overrides and family boundaries.</param>
+    /// <returns>A formatted DAT row string.</returns>
     private static string BuildProductionSetRow(
         FileData fileData,
         FileGenerationRequest request,
@@ -466,6 +492,16 @@ internal class DatWriter : LoadFileWriterBase
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Builds a single DAT row for the standard output mode.
+    /// </summary>
+    /// <param name="fileData">The generated file data.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="colDelim">The column delimiter character.</param>
+    /// <param name="quote">The quote character.</param>
+    /// <param name="profileValues">The custom metadata profile values.</param>
+    /// <param name="context">The row context containing optional overrides and family boundaries.</param>
+    /// <returns>A formatted DAT row string.</returns>
     private static string BuildStandardRow(
         FileData fileData,
         FileGenerationRequest request,
@@ -617,26 +653,59 @@ internal class DatWriter : LoadFileWriterBase
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Context object containing optional overrides and family boundary information for building a load file row.
+    /// </summary>
     private sealed class RowBuildContext
     {
+        /// <summary>
+        /// Gets the override value for the document control number or Bates number.
+        /// </summary>
         public string? IdOverride { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the relative file path.
+        /// </summary>
         public string? FilePathOverride { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the native path.
+        /// </summary>
         public string? NativePathOverride { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the extracted text path.
+        /// </summary>
         public string? TextPathOverride { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the image path.
+        /// </summary>
         public string? ImagePathOverride { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the file size in bytes.
+        /// </summary>
         public string? FileSizeOverride { get; init; }
 
+        /// <summary>
+        /// Gets a value indicating whether the row represents a child attachment document.
+        /// </summary>
         public bool IsChild { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the BEGATTACH family field.
+        /// </summary>
         public string? BegAttach { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the ENDATTACH family field.
+        /// </summary>
         public string? EndAttach { get; init; }
 
+        /// <summary>
+        /// Gets the override value for the PARENTDOCID family field.
+        /// </summary>
         public string? ParentDocId { get; init; }
     }
 }

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -305,6 +305,50 @@ internal class DatWriter : LoadFileWriterBase
     }
 
     /// <summary>
+    /// Gets the parent and child document IDs along with an indication of whether an attachment is present.
+    /// </summary>
+    private static (string ParentId, string ChildId, bool HasAttachment) GetFamilyIdentifiers(FileData fileData, FileGenerationRequest request)
+    {
+        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+        string parentId = request.Bates != null
+            ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
+            : $"DOC{fileData.WorkItem.Index:D8}";
+        string childId = hasAttachment ? $"{parentId}_A001" : parentId;
+        return (parentId, childId, hasAttachment);
+    }
+
+    /// <summary>
+    /// Builds standard or production set load file rows (parent and optional child attachments) for a single file.
+    /// </summary>
+    private static IEnumerable<(string RecordId, string Line)> BuildRowsForFile(
+        FileData fileData,
+        FileGenerationRequest request,
+        Func<RowBuildContext, string> parentRowBuilder,
+        Func<RowBuildContext, string> childRowBuilder)
+    {
+        var (parentId, childId, hasAttachment) = GetFamilyIdentifiers(fileData, request);
+
+        var parentLine = parentRowBuilder(new RowBuildContext { BegAttach = parentId, EndAttach = childId, ParentDocId = string.Empty });
+        yield return (parentId, parentLine);
+
+        if (hasAttachment)
+        {
+            var attach = fileData.Attachment!.Value;
+            var childLine = childRowBuilder(new RowBuildContext
+            {
+                IdOverride = childId,
+                IsChild = true,
+                BegAttach = parentId,
+                EndAttach = childId,
+                ParentDocId = parentId,
+                FileSizeOverride = attach.content.Length.ToString()
+            });
+
+            yield return (childId, childLine);
+        }
+    }
+
+    /// <summary>
     /// Builds standard load file rows (parent and optional child attachments) for a single file.
     /// </summary>
     /// <param name="fileData">The generated file data.</param>
@@ -320,50 +364,26 @@ internal class DatWriter : LoadFileWriterBase
         char quote,
         System.Collections.Generic.Dictionary<string, string>? profileValues)
     {
-        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-
-        string parentId = request.Bates != null
-            ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
-            : $"DOC{fileData.WorkItem.Index:D8}";
-
-        string childId = hasAttachment ? $"{parentId}_A001" : parentId;
-        string begAttach = parentId;
-        string endAttach = childId;
-        string parentDocId = string.Empty;
-
-        var line = BuildStandardRow(
+        return BuildRowsForFile(
             fileData,
             request,
-            colDelim,
-            quote,
-            profileValues,
-            new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-
-        yield return (parentId, line);
-
-        if (hasAttachment)
-        {
-            var attach = fileData.Attachment!.Value;
-            var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
-            var childLine = BuildStandardRow(
-                fileData,
-                request,
-                colDelim,
-                quote,
-                profileValues,
-                new RowBuildContext
+            context => BuildStandardRow(fileData, request, colDelim, quote, profileValues, context),
+            context =>
+            {
+                var attach = fileData.Attachment!.Value;
+                var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
+                var newContext = new RowBuildContext
                 {
-                    IdOverride = childId,
+                    IdOverride = context.IdOverride,
                     FilePathOverride = attachmentPath,
-                    FileSizeOverride = attach.content.Length.ToString(),
+                    FileSizeOverride = context.FileSizeOverride,
                     IsChild = true,
-                    BegAttach = begAttach,
-                    EndAttach = endAttach,
-                    ParentDocId = parentId
-                });
-
-            yield return (childId, childLine);
-        }
+                    BegAttach = context.BegAttach,
+                    EndAttach = context.EndAttach,
+                    ParentDocId = context.ParentDocId
+                };
+                return BuildStandardRow(fileData, request, colDelim, quote, profileValues, newContext);
+            });
     }
 
     /// <summary>
@@ -380,45 +400,33 @@ internal class DatWriter : LoadFileWriterBase
         string col,
         string quote)
     {
-        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-        string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
-        string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
+        return BuildRowsForFile(
+            fileData,
+            request,
+            context => BuildProductionSetRow(fileData, request, col, quote, context),
+            context =>
+            {
+                var attach = fileData.Attachment!.Value;
+                var childExt = Path.GetExtension(attach.filename);
+                var childBates = context.IdOverride!;
+                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
+                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
+                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
 
-        string begAttach = parentBates;
-        string endAttach = childBates;
-        string parentDocId = string.Empty;
-
-        var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
-        yield return (parentBates, dataRow);
-
-        if (hasAttachment)
-        {
-            var attach = fileData.Attachment!.Value;
-            var childExt = Path.GetExtension(attach.filename);
-            var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
-            var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
-            var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-
-            var childRow = BuildProductionSetRow(
-                fileData,
-                request,
-                col,
-                quote,
-                new RowBuildContext
+                var newContext = new RowBuildContext
                 {
                     IdOverride = childBates,
                     NativePathOverride = childNativePath,
                     TextPathOverride = childTextPath,
                     ImagePathOverride = childImagePath,
-                    FileSizeOverride = attach.content.Length.ToString(),
+                    FileSizeOverride = context.FileSizeOverride,
                     IsChild = true,
-                    BegAttach = begAttach,
-                    EndAttach = endAttach,
-                    ParentDocId = parentBates
-                });
-
-            yield return (childBates, childRow);
-        }
+                    BegAttach = context.BegAttach,
+                    EndAttach = context.EndAttach,
+                    ParentDocId = context.ParentDocId
+                };
+                return BuildProductionSetRow(fileData, request, col, quote, newContext);
+            });
     }
 
     /// <summary>

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -177,21 +177,8 @@ internal class DatWriter : LoadFileWriterBase
         char quote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
         bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
 
-        using var memStream = new MemoryStream();
-        var preamble = encoding.GetPreamble();
-        if (preamble.Length > 0)
-        {
-            await memStream.WriteAsync(preamble, 0, preamble.Length);
-        }
-
         // Build header
         var header = BuildLoadfileOnlyHeader(colDelim, quote, hasQuote, request.Metadata.ColumnProfile?.FieldNamingConvention);
-
-        // Apply chaos to header (line 1)
-        header = ApplyChaosInterception(chaosEngine, 1, header, "HEADER");
-
-        var headerBytes = encoding.GetBytes(header + eolString);
-        await memStream.WriteAsync(headerBytes);
 
         var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
@@ -199,47 +186,32 @@ internal class DatWriter : LoadFileWriterBase
         var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + 1) : new Random();
 #pragma warning restore S2245
 
-        var buffer = new StringBuilder();
+        var rows = new List<(long LineNumber, string RecordId, string Line)>();
+        rows.Add((1, "HEADER", header));
 
         for (long i = 1; i <= request.Output.FileCount; i++)
         {
             long lineNumber = i + 1;
             string recordId = $"DOC{i:D8}";
-
             var line = BuildLoadfileOnlyRow(i, recordId, colDelim, quote, hasQuote, now, random);
-
-            line = ApplyChaosInterception(chaosEngine, lineNumber, line, recordId);
-
-            buffer.Append(line);
-            buffer.Append(eolString);
-
-            // Handle encoding anomalies between lines
-            if (chaosEngine != null && i < request.Output.FileCount)
-            {
-                // Flush current buffer first
-                var bufferedBytes = encoding.GetBytes(buffer.ToString());
-                await memStream.WriteAsync(bufferedBytes);
-                buffer.Clear();
-
-                await WriteEncodingAnomalyBytesAsync(memStream, chaosEngine, lineNumber, lineNumber + 1, encoding);
-            }
-
-            if (buffer.Length > 1000 * 200)
-            {
-                var batchBytes = encoding.GetBytes(buffer.ToString());
-                await memStream.WriteAsync(batchBytes);
-                buffer.Clear();
-            }
+            rows.Add((lineNumber, recordId, line));
         }
 
-        if (buffer.Length > 0)
+        if (chaosEngine == null)
         {
-            var remainingBytes = encoding.GetBytes(buffer.ToString());
-            await memStream.WriteAsync(remainingBytes);
-        }
+            // Simple path: write directly using StreamWriter
+            await using var writer = CreateWriter(stream, request);
+            foreach (var (_, _, line) in rows)
+            {
+                await writer.WriteAsync(line + eolString);
+            }
 
-        memStream.Position = 0;
-        await memStream.CopyToAsync(stream);
+            await writer.FlushAsync();
+        }
+        else
+        {
+            await WriteRowsWithChaosAsync(stream, encoding, eolString, rows, chaosEngine);
+        }
     }
 
     /// <summary>

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -9,13 +9,23 @@ namespace Zipper.LoadFiles;
 /// </summary>
 internal class DatWriter : LoadFileWriterBase
 {
+    /// <summary>
+    /// The writer mode (e.g. Standard, LoadfileOnly, ProductionSet).
+    /// </summary>
     private readonly WriterMode mode;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatWriter"/> class with the specified mode.
+    /// </summary>
+    /// <param name="mode">The writer mode to use.</param>
     internal DatWriter(WriterMode mode = WriterMode.Standard)
     {
         this.mode = mode;
     }
 
+    /// <summary>
+    /// Gets the name of the load file format.
+    /// </summary>
     public override string FormatName => this.mode switch
     {
         WriterMode.LoadfileOnly => "DAT (Metadata)",
@@ -23,8 +33,19 @@ internal class DatWriter : LoadFileWriterBase
         _ => "DAT",
     };
 
+    /// <summary>
+    /// Gets the standard file extension for the load file, including the leading dot.
+    /// </summary>
     public override string FileExtension => ".dat";
 
+    /// <summary>
+    /// Writes the load file to the specified stream based on the current writer mode.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="request">The file generation request containing settings.</param>
+    /// <param name="processedFiles">The list of file data processed during generation.</param>
+    /// <param name="chaosEngine">The optional chaos engine to introduce synthetic errors.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -89,6 +110,14 @@ internal class DatWriter : LoadFileWriterBase
         }
     }
 
+    /// <summary>
+    /// Writes the load file using the standard mode, writing to the stream with optional chaos injection.
+    /// </summary>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="processedFiles">The processed files data.</param>
+    /// <param name="chaosEngine">The optional chaos engine.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteStandardAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -130,6 +159,13 @@ internal class DatWriter : LoadFileWriterBase
         await WriteRowsWithChaosAsync(stream, encoding, eolString, rows, chaosEngine);
     }
 
+    /// <summary>
+    /// Writes the load file using the loadfile-only mode.
+    /// </summary>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="chaosEngine">The optional chaos engine.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteLoadfileOnlyAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -206,6 +242,14 @@ internal class DatWriter : LoadFileWriterBase
         await memStream.CopyToAsync(stream);
     }
 
+    /// <summary>
+    /// Writes the load file using the production set mode.
+    /// </summary>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="processedFiles">The processed files data.</param>
+    /// <param name="chaosEngine">The optional chaos engine.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteProductionSetAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -440,6 +484,12 @@ internal class DatWriter : LoadFileWriterBase
         return string.Join(col, fields.Select(f => $"{quote}{EscapeDatField(f, quote[0], request.Delimiters.NewlineDelimiter)}{quote}"));
     }
 
+    /// <summary>
+    /// Gets the effective profile generator to use for populating metadata fields.
+    /// </summary>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="now">The effective date/time reference.</param>
+    /// <returns>A data generator instance or null if no profile should be used.</returns>
     private static Zipper.Profiles.DataGenerator? GetEffectiveProfileGenerator(FileGenerationRequest request, DateTime now)
     {
         var profile = request.Metadata.ColumnProfile;
@@ -453,6 +503,13 @@ internal class DatWriter : LoadFileWriterBase
         return profile != null ? new Zipper.Profiles.DataGenerator(profile, request.Metadata.Seed, now) : null;
     }
 
+    /// <summary>
+    /// Builds the header line for a standard DAT load file.
+    /// </summary>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="colDelim">The column delimiter character.</param>
+    /// <param name="quote">The quote character.</param>
+    /// <returns>The formatted header string.</returns>
     private static string BuildStandardHeader(FileGenerationRequest request, char colDelim, char quote)
     {
         var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
@@ -575,6 +632,14 @@ internal class DatWriter : LoadFileWriterBase
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Builds the header line for a loadfile-only DAT load file.
+    /// </summary>
+    /// <param name="colDelim">The column delimiter character.</param>
+    /// <param name="quote">The quote character.</param>
+    /// <param name="hasQuote">A value indicating whether quotes should be applied.</param>
+    /// <param name="namingConvention">The naming convention for fields.</param>
+    /// <returns>The formatted header string.</returns>
     private static string BuildLoadfileOnlyHeader(
         char colDelim,
         char quote,
@@ -607,6 +672,17 @@ internal class DatWriter : LoadFileWriterBase
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Builds a row line for a loadfile-only DAT load file.
+    /// </summary>
+    /// <param name="index">The 1-based index of the document.</param>
+    /// <param name="recordId">The record ID of the document.</param>
+    /// <param name="colDelim">The column delimiter character.</param>
+    /// <param name="quote">The quote character.</param>
+    /// <param name="hasQuote">A value indicating whether quotes should be applied.</param>
+    /// <param name="now">The current timestamp reference.</param>
+    /// <param name="random">The random number generator.</param>
+    /// <returns>The formatted row string.</returns>
     private static string BuildLoadfileOnlyRow(
         long index,
         string recordId,

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -86,9 +86,7 @@ internal class DatWriter : LoadFileWriterBase
                 colDelim,
                 quote,
                 profileValues,
-                begAttach: begAttach,
-                endAttach: endAttach,
-                parentDocId: parentDocId);
+                new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
 
             buffer.AppendLine(line);
             rowCount++;
@@ -103,13 +101,16 @@ internal class DatWriter : LoadFileWriterBase
                     colDelim,
                     quote,
                     profileValues,
-                    docIdOverride: childId,
-                    filePathOverride: attachmentPath,
-                    fileSizeOverride: attach.content.Length.ToString(),
-                    isChild: true,
-                    begAttach: begAttach,
-                    endAttach: endAttach,
-                    parentDocId: parentId);
+                    new RowBuildContext
+                    {
+                        IdOverride = childId,
+                        FilePathOverride = attachmentPath,
+                        FileSizeOverride = attach.content.Length.ToString(),
+                        IsChild = true,
+                        BegAttach = begAttach,
+                        EndAttach = endAttach,
+                        ParentDocId = parentId
+                    });
 
                 buffer.AppendLine(childLine);
                 rowCount++;
@@ -178,9 +179,7 @@ internal class DatWriter : LoadFileWriterBase
                 colDelim,
                 quote,
                 profileValues,
-                begAttach: begAttach,
-                endAttach: endAttach,
-                parentDocId: parentDocId);
+                new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
 
             rows.Add((currentLineNumber++, parentId, line));
 
@@ -194,13 +193,16 @@ internal class DatWriter : LoadFileWriterBase
                     colDelim,
                     quote,
                     profileValues,
-                    docIdOverride: childId,
-                    filePathOverride: attachmentPath,
-                    fileSizeOverride: attach.content.Length.ToString(),
-                    isChild: true,
-                    begAttach: begAttach,
-                    endAttach: endAttach,
-                    parentDocId: parentId);
+                    new RowBuildContext
+                    {
+                        IdOverride = childId,
+                        FilePathOverride = attachmentPath,
+                        FileSizeOverride = attach.content.Length.ToString(),
+                        IsChild = true,
+                        BegAttach = begAttach,
+                        EndAttach = endAttach,
+                        ParentDocId = parentId
+                    });
 
                 rows.Add((currentLineNumber++, childId, childLine));
             }
@@ -321,7 +323,7 @@ internal class DatWriter : LoadFileWriterBase
                 string endAttach = childBates;
                 string parentDocId = string.Empty;
 
-                var dataRow = BuildProductionSetRow(fileData, request, col, quote, begAttach: begAttach, endAttach: endAttach, parentDocId: parentDocId);
+                var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
                 await writer.WriteAsync(dataRow + eol);
 
                 if (hasAttachment)
@@ -337,15 +339,18 @@ internal class DatWriter : LoadFileWriterBase
                         request,
                         col,
                         quote,
-                        batesNumberOverride: childBates,
-                        nativePathOverride: childNativePath,
-                        textPathOverride: childTextPath,
-                        imagePathOverride: childImagePath,
-                        fileSizeOverride: attach.content.Length.ToString(),
-                        isChild: true,
-                        begAttach: begAttach,
-                        endAttach: endAttach,
-                        parentDocId: parentBates);
+                        new RowBuildContext
+                        {
+                            IdOverride = childBates,
+                            NativePathOverride = childNativePath,
+                            TextPathOverride = childTextPath,
+                            ImagePathOverride = childImagePath,
+                            FileSizeOverride = attach.content.Length.ToString(),
+                            IsChild = true,
+                            BegAttach = begAttach,
+                            EndAttach = endAttach,
+                            ParentDocId = parentBates
+                        });
 
                     await writer.WriteAsync(childRow + eol);
                 }
@@ -370,7 +375,7 @@ internal class DatWriter : LoadFileWriterBase
             string endAttach = childBates;
             string parentDocId = string.Empty;
 
-            var dataRow = BuildProductionSetRow(fileData, request, col, quote, begAttach: begAttach, endAttach: endAttach, parentDocId: parentDocId);
+            var dataRow = BuildProductionSetRow(fileData, request, col, quote, new RowBuildContext { BegAttach = begAttach, EndAttach = endAttach, ParentDocId = parentDocId });
             rows.Add((currentLineNumber++, parentBates, dataRow));
 
             if (hasAttachment)
@@ -386,15 +391,18 @@ internal class DatWriter : LoadFileWriterBase
                     request,
                     col,
                     quote,
-                    batesNumberOverride: childBates,
-                    nativePathOverride: childNativePath,
-                    textPathOverride: childTextPath,
-                    imagePathOverride: childImagePath,
-                    fileSizeOverride: attach.content.Length.ToString(),
-                    isChild: true,
-                    begAttach: begAttach,
-                    endAttach: endAttach,
-                    parentDocId: parentBates);
+                    new RowBuildContext
+                    {
+                        IdOverride = childBates,
+                        NativePathOverride = childNativePath,
+                        TextPathOverride = childTextPath,
+                        ImagePathOverride = childImagePath,
+                        FileSizeOverride = attach.content.Length.ToString(),
+                        IsChild = true,
+                        BegAttach = begAttach,
+                        EndAttach = endAttach,
+                        ParentDocId = parentBates
+                    });
 
                 rows.Add((currentLineNumber++, childBates, childRow));
             }
@@ -408,23 +416,15 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         string col,
         string quote,
-        string? batesNumberOverride = null,
-        string? nativePathOverride = null,
-        string? textPathOverride = null,
-        string? imagePathOverride = null,
-        string? fileSizeOverride = null,
-        bool isChild = false,
-        string? begAttach = null,
-        string? endAttach = null,
-        string? parentDocId = null)
+        RowBuildContext context)
     {
         var workItem = fileData.WorkItem;
-        var batesNumber = batesNumberOverride ?? BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
-        var imagePath = imagePathOverride ?? workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+        var batesNumber = context.IdOverride ?? BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
+        var imagePath = context.ImagePathOverride ?? workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
             .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif");
 
-        var nativePath = nativePathOverride ?? workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
-        var textPath = textPathOverride ?? nativePath.Replace($".{request.Output.FileType}", ".txt");
+        var nativePath = context.NativePathOverride ?? workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
+        var textPath = context.TextPathOverride ?? nativePath.Replace($".{request.Output.FileType}", ".txt");
         var imagesPath = imagePath.Replace(Path.DirectorySeparatorChar, '\\');
 
 #pragma warning disable S2245
@@ -435,8 +435,8 @@ internal class DatWriter : LoadFileWriterBase
         var custodianProd = $"Custodian {random.Next(1, maxCustodians + 1)}";
         var dateCreated = now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd");
 
-        var fileSize = fileSizeOverride ?? fileData.DataLength.ToString();
-        var fileType = isChild ? Path.GetExtension(fileData.Attachment!.Value.filename).TrimStart('.').ToUpperInvariant() : request.Output.FileType.ToUpperInvariant();
+        var fileSize = context.FileSizeOverride ?? fileData.DataLength.ToString();
+        var fileType = context.IsChild ? Path.GetExtension(fileData.Attachment!.Value.filename).TrimStart('.').ToUpperInvariant() : request.Output.FileType.ToUpperInvariant();
 
         var fields = new List<string>
         {
@@ -456,9 +456,9 @@ internal class DatWriter : LoadFileWriterBase
         {
             fields.AddRange(new[]
             {
-                begAttach ?? string.Empty,
-                endAttach ?? string.Empty,
-                parentDocId ?? string.Empty,
+                context.BegAttach ?? string.Empty,
+                context.EndAttach ?? string.Empty,
+                context.ParentDocId ?? string.Empty,
             });
         }
 
@@ -523,17 +523,11 @@ internal class DatWriter : LoadFileWriterBase
         char colDelim,
         char quote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
-        string? docIdOverride = null,
-        string? filePathOverride = null,
-        string? fileSizeOverride = null,
-        bool isChild = false,
-        string? begAttach = null,
-        string? endAttach = null,
-        string? parentDocId = null)
+        RowBuildContext context)
     {
         var workItem = fileData.WorkItem;
-        var docId = docIdOverride ?? EscapeDatField($"DOC{workItem.Index:D8}", quote, request.Delimiters.NewlineDelimiter);
-        var filePath = filePathOverride ?? EscapeDatField(workItem.FilePathInZip, quote, request.Delimiters.NewlineDelimiter);
+        var docId = context.IdOverride ?? EscapeDatField($"DOC{workItem.Index:D8}", quote, request.Delimiters.NewlineDelimiter);
+        var filePath = context.FilePathOverride ?? EscapeDatField(workItem.FilePathInZip, quote, request.Delimiters.NewlineDelimiter);
 
         var sb = new StringBuilder();
         sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{filePath}{quote}");
@@ -541,38 +535,38 @@ internal class DatWriter : LoadFileWriterBase
         if (request.Metadata.ShouldIncludeMetadataColumns(request.Output))
         {
             var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var dateSent = isChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
-            var author = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var fileSize = fileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
+            var dateSent = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
+            var author = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+            var fileSize = context.FileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
             sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
         }
 
         if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
         {
-            var to = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var from = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var subject = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
-            var sentDate = isChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
-            var attachment = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+            var to = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+            var from = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+            var subject = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
+            var sentDate = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
+            var attachment = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
             sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
         }
 
         if (request.Bates != null)
         {
-            var batesVal = docIdOverride ?? BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1);
+            var batesVal = context.IdOverride ?? BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1);
             sb.Append($"{colDelim}{quote}{batesVal}{quote}");
         }
 
         if (request.Tiff.ShouldIncludePageCount(request.Output))
         {
-            var pageCount = isChild ? 1 : fileData.PageCount;
+            var pageCount = context.IsChild ? 1 : fileData.PageCount;
             sb.Append($"{colDelim}{quote}{pageCount}{quote}");
         }
 
         if (request.Output.WithText)
         {
             string textPath;
-            if (isChild)
+            if (context.IsChild)
             {
                 var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment!.Value.filename)}.txt";
                 textPath = $"{workItem.FolderName}/{workItem.Index}_{attachmentTextFileName}";
@@ -590,7 +584,7 @@ internal class DatWriter : LoadFileWriterBase
 
         if (request.Metadata.WithFamilies)
         {
-            sb.Append($"{colDelim}{quote}{begAttach ?? string.Empty}{quote}{colDelim}{quote}{endAttach ?? string.Empty}{quote}{colDelim}{quote}{parentDocId ?? string.Empty}{quote}");
+            sb.Append($"{colDelim}{quote}{context.BegAttach ?? string.Empty}{quote}{colDelim}{quote}{context.EndAttach ?? string.Empty}{quote}{colDelim}{quote}{context.ParentDocId ?? string.Empty}{quote}");
         }
 
         return sb.ToString();
@@ -672,5 +666,28 @@ internal class DatWriter : LoadFileWriterBase
         AppendField(sb, extractedText, quote, hasQuote);
 
         return sb.ToString();
+    }
+
+    private sealed class RowBuildContext
+    {
+        public string? IdOverride { get; init; }
+
+        public string? FilePathOverride { get; init; }
+
+        public string? NativePathOverride { get; init; }
+
+        public string? TextPathOverride { get; init; }
+
+        public string? ImagePathOverride { get; init; }
+
+        public string? FileSizeOverride { get; init; }
+
+        public bool IsChild { get; init; }
+
+        public string? BegAttach { get; init; }
+
+        public string? EndAttach { get; init; }
+
+        public string? ParentDocId { get; init; }
     }
 }

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -574,24 +574,8 @@ internal class DatWriter : LoadFileWriterBase
         var sb = new StringBuilder();
         sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{filePath}{quote}");
 
-        if (request.Metadata.ShouldIncludeMetadataColumns(request.Output))
-        {
-            var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var dateSent = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
-            var author = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var fileSize = context.FileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
-            sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
-        }
-
-        if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
-        {
-            var to = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var from = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var subject = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
-            var sentDate = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
-            var attachment = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
-        }
+        AppendMetadataColumns(sb, fileData, request, colDelim, quote, profileValues, context);
+        AppendEmailColumns(sb, fileData, request, colDelim, quote, profileValues, context);
 
         if (request.Bates != null)
         {
@@ -605,24 +589,7 @@ internal class DatWriter : LoadFileWriterBase
             sb.Append($"{colDelim}{quote}{pageCount}{quote}");
         }
 
-        if (request.Output.WithText)
-        {
-            string textPath;
-            if (context.IsChild)
-            {
-                var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment!.Value.filename)}.txt";
-                textPath = $"{workItem.FolderName}/{workItem.Index}_{attachmentTextFileName}";
-            }
-            else
-            {
-                var sourceSuffix = $".{request.Output.FileType}";
-                textPath = workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
-                    ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
-                    : workItem.FilePathInZip;
-            }
-
-            sb.Append($"{colDelim}{quote}{textPath}{quote}");
-        }
+        AppendTextColumn(sb, fileData, request, colDelim, quote, context);
 
         if (request.Metadata.WithFamilies)
         {
@@ -630,6 +597,92 @@ internal class DatWriter : LoadFileWriterBase
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends the general metadata columns to the standard row.
+    /// </summary>
+    private static void AppendMetadataColumns(
+        StringBuilder sb,
+        FileData fileData,
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        System.Collections.Generic.Dictionary<string, string>? profileValues,
+        RowBuildContext context)
+    {
+        if (!request.Metadata.ShouldIncludeMetadataColumns(request.Output))
+        {
+            return;
+        }
+
+        var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+        var dateSent = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
+        var author = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+        var fileSize = context.FileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
+
+        sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
+    }
+
+    /// <summary>
+    /// Appends the EML email-specific metadata columns to the standard row.
+    /// </summary>
+    private static void AppendEmailColumns(
+        StringBuilder sb,
+        FileData fileData,
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        System.Collections.Generic.Dictionary<string, string>? profileValues,
+        RowBuildContext context)
+    {
+        if (!request.Metadata.ShouldIncludeEmlColumns(request.Output))
+        {
+            return;
+        }
+
+        var workItem = fileData.WorkItem;
+        var to = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+        var from = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+        var subject = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
+        var sentDate = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
+        var attachment = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+
+        sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
+    }
+
+    /// <summary>
+    /// Appends the extracted text path column to the standard row if enabled.
+    /// </summary>
+    private static void AppendTextColumn(
+        StringBuilder sb,
+        FileData fileData,
+        FileGenerationRequest request,
+        char colDelim,
+        char quote,
+        RowBuildContext context)
+    {
+        if (!request.Output.WithText)
+        {
+            return;
+        }
+
+        var workItem = fileData.WorkItem;
+        string textPath;
+        if (context.IsChild)
+        {
+            var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment!.Value.filename)}.txt";
+            textPath = $"{workItem.FolderName}/{workItem.Index}_{attachmentTextFileName}";
+        }
+        else
+        {
+            var sourceSuffix = $".{request.Output.FileType}";
+            textPath = workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
+                ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
+                : workItem.FilePathInZip;
+        }
+
+        sb.Append($"{colDelim}{quote}{textPath}{quote}");
     }
 
     /// <summary>

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -69,9 +69,51 @@ internal class DatWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            var line = BuildStandardRow(fileData, request, colDelim, quote, profileValues);
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+
+            string parentId = request.Bates != null
+                ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
+                : $"DOC{fileData.WorkItem.Index:D8}";
+
+            string childId = hasAttachment ? $"{parentId}_A001" : parentId;
+            string begAttach = parentId;
+            string endAttach = childId;
+            string parentDocId = string.Empty;
+
+            var line = BuildStandardRow(
+                fileData,
+                request,
+                colDelim,
+                quote,
+                profileValues,
+                begAttach: begAttach,
+                endAttach: endAttach,
+                parentDocId: parentDocId);
+
             buffer.AppendLine(line);
             rowCount++;
+
+            if (hasAttachment)
+            {
+                var attach = fileData.Attachment!.Value;
+                var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
+                var childLine = BuildStandardRow(
+                    fileData,
+                    request,
+                    colDelim,
+                    quote,
+                    profileValues,
+                    docIdOverride: childId,
+                    filePathOverride: attachmentPath,
+                    fileSizeOverride: attach.content.Length.ToString(),
+                    isChild: true,
+                    begAttach: begAttach,
+                    endAttach: endAttach,
+                    parentDocId: parentId);
+
+                buffer.AppendLine(childLine);
+                rowCount++;
+            }
 
             if (rowCount >= 1000)
             {
@@ -115,15 +157,53 @@ internal class DatWriter : LoadFileWriterBase
         var rows = new List<(long LineNumber, string RecordId, string Line)>();
         rows.Add((1, "HEADER", BuildStandardHeader(request, colDelim, quote)));
 
-        int rowIdx = 0;
+        long currentLineNumber = 2;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            long lineNumber = rowIdx + 2;
-            var recordId = $"DOC{fileData.WorkItem.Index:D8}";
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            var line = BuildStandardRow(fileData, request, colDelim, quote, profileValues);
-            rows.Add((lineNumber, recordId, line));
-            rowIdx++;
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+
+            string parentId = request.Bates != null
+                ? BatesNumberGenerator.Generate(request.Bates, fileData.WorkItem.Index - 1)
+                : $"DOC{fileData.WorkItem.Index:D8}";
+
+            string childId = hasAttachment ? $"{parentId}_A001" : parentId;
+            string begAttach = parentId;
+            string endAttach = childId;
+            string parentDocId = string.Empty;
+
+            var line = BuildStandardRow(
+                fileData,
+                request,
+                colDelim,
+                quote,
+                profileValues,
+                begAttach: begAttach,
+                endAttach: endAttach,
+                parentDocId: parentDocId);
+
+            rows.Add((currentLineNumber++, parentId, line));
+
+            if (hasAttachment)
+            {
+                var attach = fileData.Attachment!.Value;
+                var attachmentPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attach.filename}";
+                var childLine = BuildStandardRow(
+                    fileData,
+                    request,
+                    colDelim,
+                    quote,
+                    profileValues,
+                    docIdOverride: childId,
+                    filePathOverride: attachmentPath,
+                    fileSizeOverride: attach.content.Length.ToString(),
+                    isChild: true,
+                    begAttach: begAttach,
+                    endAttach: endAttach,
+                    parentDocId: parentId);
+
+                rows.Add((currentLineNumber++, childId, childLine));
+            }
         }
 
         await WriteRowsWithChaosAsync(stream, encoding, eolString, rows, chaosEngine);
@@ -217,7 +297,12 @@ internal class DatWriter : LoadFileWriterBase
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
-        var headers = new[] { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
+        var headers = new List<string> { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
+        if (request.Metadata.WithFamilies)
+        {
+            headers.AddRange(new[] { "BEGATTACH", "ENDATTACH", "PARENTDOCID" });
+        }
+
         var finalHeaders = headers.Select(h => NamingConventionHelper.ApplyConvention(h, namingConvention));
         var headerLine = string.Join(col, finalHeaders.Select(h => $"{quote}{h}{quote}"));
 
@@ -228,8 +313,42 @@ internal class DatWriter : LoadFileWriterBase
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
-                var dataRow = BuildProductionSetRow(fileData, request, col, quote);
+                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+                string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
+                string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
+
+                string begAttach = parentBates;
+                string endAttach = childBates;
+                string parentDocId = string.Empty;
+
+                var dataRow = BuildProductionSetRow(fileData, request, col, quote, begAttach: begAttach, endAttach: endAttach, parentDocId: parentDocId);
                 await writer.WriteAsync(dataRow + eol);
+
+                if (hasAttachment)
+                {
+                    var attach = fileData.Attachment!.Value;
+                    var childExt = Path.GetExtension(attach.filename);
+                    var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
+                    var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
+                    var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+
+                    var childRow = BuildProductionSetRow(
+                        fileData,
+                        request,
+                        col,
+                        quote,
+                        batesNumberOverride: childBates,
+                        nativePathOverride: childNativePath,
+                        textPathOverride: childTextPath,
+                        imagePathOverride: childImagePath,
+                        fileSizeOverride: attach.content.Length.ToString(),
+                        isChild: true,
+                        begAttach: begAttach,
+                        endAttach: endAttach,
+                        parentDocId: parentBates);
+
+                    await writer.WriteAsync(childRow + eol);
+                }
             }
 
             await writer.FlushAsync();
@@ -240,30 +359,72 @@ internal class DatWriter : LoadFileWriterBase
         var rows = new List<(long LineNumber, string RecordId, string Line)>();
         rows.Add((1, "HEADER", headerLine));
 
-        int rowIdx = 0;
+        long currentLineNumber = 2;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            long lineNumber = rowIdx + 2;
-            var workItem = fileData.WorkItem;
-            var batesNum = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+            string parentBates = BatesNumberGenerator.Generate(request.Bates!, fileData.WorkItem.Index - 1);
+            string childBates = hasAttachment ? $"{parentBates}_A001" : parentBates;
 
-            var dataRow = BuildProductionSetRow(fileData, request, col, quote);
-            rows.Add((lineNumber, batesNum, dataRow));
-            rowIdx++;
+            string begAttach = parentBates;
+            string endAttach = childBates;
+            string parentDocId = string.Empty;
+
+            var dataRow = BuildProductionSetRow(fileData, request, col, quote, begAttach: begAttach, endAttach: endAttach, parentDocId: parentDocId);
+            rows.Add((currentLineNumber++, parentBates, dataRow));
+
+            if (hasAttachment)
+            {
+                var attach = fileData.Attachment!.Value;
+                var childExt = Path.GetExtension(attach.filename);
+                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
+                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
+                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+
+                var childRow = BuildProductionSetRow(
+                    fileData,
+                    request,
+                    col,
+                    quote,
+                    batesNumberOverride: childBates,
+                    nativePathOverride: childNativePath,
+                    textPathOverride: childTextPath,
+                    imagePathOverride: childImagePath,
+                    fileSizeOverride: attach.content.Length.ToString(),
+                    isChild: true,
+                    begAttach: begAttach,
+                    endAttach: endAttach,
+                    parentDocId: parentBates);
+
+                rows.Add((currentLineNumber++, childBates, childRow));
+            }
         }
 
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);
     }
 
-    private static string BuildProductionSetRow(FileData fileData, FileGenerationRequest request, string col, string quote)
+    private static string BuildProductionSetRow(
+        FileData fileData,
+        FileGenerationRequest request,
+        string col,
+        string quote,
+        string? batesNumberOverride = null,
+        string? nativePathOverride = null,
+        string? textPathOverride = null,
+        string? imagePathOverride = null,
+        string? fileSizeOverride = null,
+        bool isChild = false,
+        string? begAttach = null,
+        string? endAttach = null,
+        string? parentDocId = null)
     {
         var workItem = fileData.WorkItem;
-        var batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
-        var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+        var batesNumber = batesNumberOverride ?? BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
+        var imagePath = imagePathOverride ?? workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
             .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif");
 
-        var nativePath = workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
-        var textPath = nativePath.Replace($".{request.Output.FileType}", ".txt");
+        var nativePath = nativePathOverride ?? workItem.FilePathInZip.Replace(Path.DirectorySeparatorChar, '\\');
+        var textPath = textPathOverride ?? nativePath.Replace($".{request.Output.FileType}", ".txt");
         var imagesPath = imagePath.Replace(Path.DirectorySeparatorChar, '\\');
 
 #pragma warning disable S2245
@@ -274,7 +435,10 @@ internal class DatWriter : LoadFileWriterBase
         var custodianProd = $"Custodian {random.Next(1, maxCustodians + 1)}";
         var dateCreated = now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd");
 
-        var fields = new[]
+        var fileSize = fileSizeOverride ?? fileData.DataLength.ToString();
+        var fileType = isChild ? Path.GetExtension(fileData.Attachment!.Value.filename).TrimStart('.').ToUpperInvariant() : request.Output.FileType.ToUpperInvariant();
+
+        var fields = new List<string>
         {
             batesNumber,
             batesNumber,
@@ -284,9 +448,19 @@ internal class DatWriter : LoadFileWriterBase
             imagesPath,
             custodianProd,
             dateCreated,
-            fileData.DataLength.ToString(),
-            request.Output.FileType.ToUpperInvariant(),
+            fileSize,
+            fileType,
         };
+
+        if (request.Metadata.WithFamilies)
+        {
+            fields.AddRange(new[]
+            {
+                begAttach ?? string.Empty,
+                endAttach ?? string.Empty,
+                parentDocId ?? string.Empty,
+            });
+        }
 
         return string.Join(col, fields.Select(f => $"{quote}{EscapeDatField(f, quote[0], request.Delimiters.NewlineDelimiter)}{quote}"));
     }
@@ -335,6 +509,11 @@ internal class DatWriter : LoadFileWriterBase
             sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Extracted Text", namingConvention)}{quote}");
         }
 
+        if (request.Metadata.WithFamilies)
+        {
+            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("BEGATTACH", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("ENDATTACH", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("PARENTDOCID", namingConvention)}{quote}");
+        }
+
         return sb.ToString();
     }
 
@@ -343,50 +522,75 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
-        System.Collections.Generic.Dictionary<string, string>? profileValues)
+        System.Collections.Generic.Dictionary<string, string>? profileValues,
+        string? docIdOverride = null,
+        string? filePathOverride = null,
+        string? fileSizeOverride = null,
+        bool isChild = false,
+        string? begAttach = null,
+        string? endAttach = null,
+        string? parentDocId = null)
     {
         var workItem = fileData.WorkItem;
-        var docId = EscapeDatField($"DOC{workItem.Index:D8}", quote, request.Delimiters.NewlineDelimiter);
+        var docId = docIdOverride ?? EscapeDatField($"DOC{workItem.Index:D8}", quote, request.Delimiters.NewlineDelimiter);
+        var filePath = filePathOverride ?? EscapeDatField(workItem.FilePathInZip, quote, request.Delimiters.NewlineDelimiter);
 
         var sb = new StringBuilder();
-        sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{EscapeDatField(workItem.FilePathInZip, quote, request.Delimiters.NewlineDelimiter)}{quote}");
+        sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{filePath}{quote}");
 
         if (request.Metadata.ShouldIncludeMetadataColumns(request.Output))
         {
             var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var dateSent = profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty;
-            var author = EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
-            var fileSize = profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString();
+            var dateSent = isChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
+            var author = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+            var fileSize = fileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
             sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
         }
 
         if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
         {
-            var to = EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var from = EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
-            var subject = EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
-            var sentDate = profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty;
-            var attachment = EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
+            var to = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+            var from = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILFROM") ?? $"sender{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
+            var subject = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {workItem.Index}", quote, request.Delimiters.NewlineDelimiter);
+            var sentDate = isChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
+            var attachment = isChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
             sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
         }
 
         if (request.Bates != null)
         {
-            sb.Append($"{colDelim}{quote}{BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1)}{quote}");
+            var batesVal = docIdOverride ?? BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1);
+            sb.Append($"{colDelim}{quote}{batesVal}{quote}");
         }
 
         if (request.Tiff.ShouldIncludePageCount(request.Output))
         {
-            sb.Append($"{colDelim}{quote}{fileData.PageCount}{quote}");
+            var pageCount = isChild ? 1 : fileData.PageCount;
+            sb.Append($"{colDelim}{quote}{pageCount}{quote}");
         }
 
         if (request.Output.WithText)
         {
-            var sourceSuffix = $".{request.Output.FileType}";
-            var textPath = workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
-                ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
-                : workItem.FilePathInZip;
+            string textPath;
+            if (isChild)
+            {
+                var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment!.Value.filename)}.txt";
+                textPath = $"{workItem.FolderName}/{workItem.Index}_{attachmentTextFileName}";
+            }
+            else
+            {
+                var sourceSuffix = $".{request.Output.FileType}";
+                textPath = workItem.FilePathInZip.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase)
+                    ? workItem.FilePathInZip[..^sourceSuffix.Length] + ".txt"
+                    : workItem.FilePathInZip;
+            }
+
             sb.Append($"{colDelim}{quote}{textPath}{quote}");
+        }
+
+        if (request.Metadata.WithFamilies)
+        {
+            sb.Append($"{colDelim}{quote}{begAttach ?? string.Empty}{quote}{colDelim}{quote}{endAttach ?? string.Empty}{quote}{colDelim}{quote}{parentDocId ?? string.Empty}{quote}");
         }
 
         return sb.ToString();

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -209,9 +209,7 @@ internal class OptWriter : LoadFileWriterBase
                 bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
                 if (hasAttachment)
                 {
-                    var childBates = $"{batesNumber}_A001";
-                    var childImagePath = Path.Combine("IMAGES", workItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-                    var childLine = $"{childBates},{workItem.FolderName},{childImagePath},Y,,,1";
+                    var childLine = BuildProductionSetChildRow(batesNumber, workItem.FolderName);
                     await writer.WriteAsync(childLine + eol);
                 }
             }
@@ -239,13 +237,18 @@ internal class OptWriter : LoadFileWriterBase
             bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
             if (hasAttachment)
             {
-                var childBates = $"{batesNum}_A001";
-                var childImagePath = Path.Combine("IMAGES", workItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-                var childLine = $"{childBates},{workItem.FolderName},{childImagePath},Y,,,1";
-                rows.Add((currentLineNumber++, childBates, childLine));
+                var childLine = BuildProductionSetChildRow(batesNum, workItem.FolderName);
+                rows.Add((currentLineNumber++, $"{batesNum}_A001", childLine));
             }
         }
 
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);
+    }
+
+    private static string BuildProductionSetChildRow(string batesNumber, string folderName)
+    {
+        var childBates = $"{batesNumber}_A001";
+        var childImagePath = Path.Combine("IMAGES", folderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+        return $"{childBates},{folderName},{childImagePath},Y,,,1";
     }
 }

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -109,23 +109,10 @@ internal class OptWriter : LoadFileWriterBase
 
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            var workItem = fileData.WorkItem;
             bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+            var (batesNumber, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: false);
 
-            // Opticon 7-column format: BatesNumber,Volume,ImagePath,DocBreak,FolderBreak,BoxBreak,PageCount
-            string batesNumber = request.Bates != null
-                ? GenerateBatesNumber(request, workItem)
-                : GenerateDocumentId(workItem);
-            string volume = "VOL001";
-            string imagePath = $"IMAGES\\{batesNumber}.tif";
-            string docBreak = "Y";
-            string folderBreak = string.Empty;
-            string boxBreak = string.Empty;
-            int pageCount = request.Tiff.ShouldIncludePageCount(request.Output) ? fileData.PageCount : 1;
-
-            // Comma-separated, no header — Opticon standard
-            var line = $"{batesNumber},{volume},{imagePath},{docBreak},{folderBreak},{boxBreak},{pageCount}";
-
+            var line = BuildOptRow(batesNumber, volume, imagePath, pageCount);
             buffer.AppendLine(line);
             rowCount++;
 
@@ -133,7 +120,7 @@ internal class OptWriter : LoadFileWriterBase
             {
                 string childBates = $"{batesNumber}_A001";
                 string childImagePath = $"IMAGES\\{childBates}.tif";
-                var childLine = $"{childBates},{volume},{childImagePath},Y,,,{1}";
+                var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
                 buffer.AppendLine(childLine);
                 rowCount++;
             }
@@ -238,21 +225,17 @@ internal class OptWriter : LoadFileWriterBase
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
-                var workItem = fileData.WorkItem;
-                var batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
-                var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
-                    .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
-                    .Replace(Path.DirectorySeparatorChar, '\\');
+                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+                var (batesNumber, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: true);
 
-                var docBreak = "Y";
-                var line = $"{batesNumber},{workItem.FolderName},{imagePath},{docBreak},,,1";
-
+                var line = BuildOptRow(batesNumber, volume, imagePath, pageCount);
                 await writer.WriteAsync(line + eol);
 
-                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
                 if (hasAttachment)
                 {
-                    var childLine = BuildProductionSetChildRow(batesNumber, workItem.FolderName);
+                    string childBates = $"{batesNumber}_A001";
+                    string childImagePath = Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+                    var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
                     await writer.WriteAsync(childLine + eol);
                 }
             }
@@ -268,20 +251,18 @@ internal class OptWriter : LoadFileWriterBase
         long currentLineNumber = 1;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            var workItem = fileData.WorkItem;
-            var batesNum = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
-            var imgPath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
-                .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
-                .Replace(Path.DirectorySeparatorChar, '\\');
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+            var (batesNum, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: true);
 
-            var optLine = $"{batesNum},{workItem.FolderName},{imgPath},Y,,,1";
+            var optLine = BuildOptRow(batesNum, volume, imagePath, pageCount);
             rows.Add((currentLineNumber++, batesNum, optLine));
 
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
             if (hasAttachment)
             {
-                var childLine = BuildProductionSetChildRow(batesNum, workItem.FolderName);
-                rows.Add((currentLineNumber++, $"{batesNum}_A001", childLine));
+                string childBates = $"{batesNum}_A001";
+                string childImagePath = Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+                var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
+                rows.Add((currentLineNumber++, childBates, childLine));
             }
         }
 
@@ -289,15 +270,36 @@ internal class OptWriter : LoadFileWriterBase
     }
 
     /// <summary>
-    /// Builds a single OPT child row for the production set output mode.
+    /// Gets the metadata row data elements for a given file.
     /// </summary>
-    /// <param name="batesNumber">The parent Bates number.</param>
-    /// <param name="folderName">The relative folder name.</param>
-    /// <returns>A formatted OPT row string.</returns>
-    private static string BuildProductionSetChildRow(string batesNumber, string folderName)
+    private static (string BatesNumber, string Volume, string ImagePath, int PageCount) GetRowData(
+        FileData fileData,
+        FileGenerationRequest request,
+        bool isProductionSet)
     {
-        var childBates = $"{batesNumber}_A001";
-        var childImagePath = Path.Combine("IMAGES", folderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-        return $"{childBates},{folderName},{childImagePath},Y,,,1";
+        var workItem = fileData.WorkItem;
+        string batesNumber = isProductionSet
+            ? BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1)
+            : (request.Bates != null ? GenerateBatesNumber(request, workItem) : GenerateDocumentId(workItem));
+
+        string volume = isProductionSet ? workItem.FolderName : "VOL001";
+
+        string imagePath = isProductionSet
+            ? workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+                .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
+                .Replace(Path.DirectorySeparatorChar, '\\')
+            : $"IMAGES\\{batesNumber}.tif";
+
+        int pageCount = !isProductionSet && request.Tiff.ShouldIncludePageCount(request.Output) ? fileData.PageCount : 1;
+
+        return (batesNumber, volume, imagePath, pageCount);
+    }
+
+    /// <summary>
+    /// Builds a single OPT row formatted string.
+    /// </summary>
+    private static string BuildOptRow(string batesNumber, string volume, string imagePath, int pageCount)
+    {
+        return $"{batesNumber},{volume},{imagePath},Y,,,{pageCount}";
     }
 }

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -8,13 +8,23 @@ namespace Zipper.LoadFiles;
 /// </summary>
 internal class OptWriter : LoadFileWriterBase
 {
+    /// <summary>
+    /// The writer mode.
+    /// </summary>
     private readonly WriterMode mode;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OptWriter"/> class with the specified mode.
+    /// </summary>
+    /// <param name="mode">The writer mode to use.</param>
     internal OptWriter(WriterMode mode = WriterMode.Standard)
     {
         this.mode = mode;
     }
 
+    /// <summary>
+    /// Gets the name of the load file format.
+    /// </summary>
     public override string FormatName => this.mode switch
     {
         WriterMode.LoadfileOnly => "OPT (Image)",
@@ -22,8 +32,19 @@ internal class OptWriter : LoadFileWriterBase
         _ => "OPT",
     };
 
+    /// <summary>
+    /// Gets the standard file extension for the load file, including the leading dot.
+    /// </summary>
     public override string FileExtension => ".opt";
 
+    /// <summary>
+    /// Writes the OPT load file to the specified stream based on the current writer mode.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="request">The file generation request containing settings.</param>
+    /// <param name="processedFiles">The list of file data processed during generation.</param>
+    /// <param name="chaosEngine">The optional chaos engine to introduce synthetic errors.</param>
+    /// <returns>A task representing the asynchronous write operation.</returns>
     public override async Task WriteAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -51,6 +72,13 @@ internal class OptWriter : LoadFileWriterBase
         }
     }
 
+    /// <summary>
+    /// Writes the load file using the standard mode.
+    /// </summary>
+    /// <param name="writer">The output stream writer.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="processedFiles">The processed files data.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteStandardRowsAsync(
         StreamWriter writer,
         FileGenerationRequest request,
@@ -124,6 +152,13 @@ internal class OptWriter : LoadFileWriterBase
         }
     }
 
+    /// <summary>
+    /// Writes the load file using the loadfile-only mode.
+    /// </summary>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="chaosEngine">The optional chaos engine.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteLoadfileOnlyAsync(
         Stream stream,
         FileGenerationRequest request,
@@ -181,6 +216,14 @@ internal class OptWriter : LoadFileWriterBase
         await memStream.CopyToAsync(stream);
     }
 
+    /// <summary>
+    /// Writes the load file using the production set mode.
+    /// </summary>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="request">The file generation request.</param>
+    /// <param name="processedFiles">The processed files data.</param>
+    /// <param name="chaosEngine">The optional chaos engine.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     private static async Task WriteProductionSetAsync(
         Stream stream,
         FileGenerationRequest request,

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -278,9 +278,19 @@ internal class OptWriter : LoadFileWriterBase
         bool isProductionSet)
     {
         var workItem = fileData.WorkItem;
-        string batesNumber = isProductionSet
-            ? BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1)
-            : (request.Bates != null ? GenerateBatesNumber(request, workItem) : GenerateDocumentId(workItem));
+        string batesNumber;
+        if (isProductionSet)
+        {
+            batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
+        }
+        else if (request.Bates != null)
+        {
+            batesNumber = GenerateBatesNumber(request, workItem);
+        }
+        else
+        {
+            batesNumber = GenerateDocumentId(workItem);
+        }
 
         string volume = isProductionSet ? workItem.FolderName : "VOL001";
 

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -245,6 +245,12 @@ internal class OptWriter : LoadFileWriterBase
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);
     }
 
+    /// <summary>
+    /// Builds a single OPT child row for the production set output mode.
+    /// </summary>
+    /// <param name="batesNumber">The parent Bates number.</param>
+    /// <param name="folderName">The relative folder name.</param>
+    /// <returns>A formatted OPT row string.</returns>
     private static string BuildProductionSetChildRow(string batesNumber, string folderName)
     {
         var childBates = $"{batesNumber}_A001";

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -144,22 +144,14 @@ internal class OptWriter : LoadFileWriterBase
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
         var eolString = GetEolString(request.Delimiters.EndOfLine);
 
-        using var memStream = new MemoryStream();
-        var preamble = encoding.GetPreamble();
-        if (preamble.Length > 0)
-        {
-            await memStream.WriteAsync(preamble, 0, preamble.Length);
-        }
-
 #pragma warning disable S2245
         var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value + 1) : new Random();
 #pragma warning restore S2245
 
-        var buffer = new StringBuilder();
+        var rows = new List<(long LineNumber, string RecordId, string Line)>();
 
         for (long i = 1; i <= request.Output.FileCount; i++)
         {
-            long lineNumber = i;
             string batesId = $"IMG{i:D8}";
             string volume = "VOL001";
             string imagePath = $"IMAGES\\{batesId}.tif";
@@ -169,28 +161,24 @@ internal class OptWriter : LoadFileWriterBase
             int pageCount = random.Next(1, 11);
 
             string line = $"{batesId},{volume},{imagePath},{docBreak},{folderBreak},{boxBreak},{pageCount}";
-
-            line = ApplyChaosInterception(chaosEngine, lineNumber, line, batesId);
-
-            buffer.Append(line);
-            buffer.Append(eolString);
-
-            if (buffer.Length > 1000 * 200)
-            {
-                var batchBytes = encoding.GetBytes(buffer.ToString());
-                await memStream.WriteAsync(batchBytes);
-                buffer.Clear();
-            }
+            rows.Add((i, batesId, line));
         }
 
-        if (buffer.Length > 0)
+        if (chaosEngine == null)
         {
-            var remainingBytes = encoding.GetBytes(buffer.ToString());
-            await memStream.WriteAsync(remainingBytes);
-        }
+            // Simple path: write directly using StreamWriter
+            await using var writer = CreateWriter(stream, request);
+            foreach (var (_, _, line) in rows)
+            {
+                await writer.WriteAsync(line + eolString);
+            }
 
-        memStream.Position = 0;
-        await memStream.CopyToAsync(stream);
+            await writer.FlushAsync();
+        }
+        else
+        {
+            await WriteRowsWithChaosAsync(stream, encoding, eolString, rows, chaosEngine);
+        }
     }
 
     /// <summary>

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -109,27 +109,17 @@ internal class OptWriter : LoadFileWriterBase
 
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-            var (batesNumber, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: false);
-
-            var line = BuildOptRow(batesNumber, volume, imagePath, pageCount);
-            buffer.AppendLine(line);
-            rowCount++;
-
-            if (hasAttachment)
+            foreach (var (_, line) in BuildOptRowsForFile(fileData, request, isProductionSet: false))
             {
-                string childBates = $"{batesNumber}_A001";
-                string childImagePath = $"IMAGES\\{childBates}.tif";
-                var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
-                buffer.AppendLine(childLine);
+                buffer.AppendLine(line);
                 rowCount++;
-            }
 
-            if (rowCount >= 1000)
-            {
-                await writer.WriteAsync(buffer.ToString());
-                buffer.Clear();
-                rowCount = 0;
+                if (rowCount >= 1000)
+                {
+                    await writer.WriteAsync(buffer.ToString());
+                    buffer.Clear();
+                    rowCount = 0;
+                }
             }
         }
 
@@ -225,18 +215,9 @@ internal class OptWriter : LoadFileWriterBase
 
             foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
-                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-                var (batesNumber, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: true);
-
-                var line = BuildOptRow(batesNumber, volume, imagePath, pageCount);
-                await writer.WriteAsync(line + eol);
-
-                if (hasAttachment)
+                foreach (var (_, line) in BuildOptRowsForFile(fileData, request, isProductionSet: true))
                 {
-                    string childBates = $"{batesNumber}_A001";
-                    string childImagePath = Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-                    var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
-                    await writer.WriteAsync(childLine + eol);
+                    await writer.WriteAsync(line + eol);
                 }
             }
 
@@ -251,18 +232,9 @@ internal class OptWriter : LoadFileWriterBase
         long currentLineNumber = 1;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-            var (batesNum, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet: true);
-
-            var optLine = BuildOptRow(batesNum, volume, imagePath, pageCount);
-            rows.Add((currentLineNumber++, batesNum, optLine));
-
-            if (hasAttachment)
+            foreach (var (recordId, line) in BuildOptRowsForFile(fileData, request, isProductionSet: true))
             {
-                string childBates = $"{batesNum}_A001";
-                string childImagePath = Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
-                var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
-                rows.Add((currentLineNumber++, childBates, childLine));
+                rows.Add((currentLineNumber++, recordId, line));
             }
         }
 
@@ -303,6 +275,31 @@ internal class OptWriter : LoadFileWriterBase
         int pageCount = !isProductionSet && request.Tiff.ShouldIncludePageCount(request.Output) ? fileData.PageCount : 1;
 
         return (batesNumber, volume, imagePath, pageCount);
+    }
+
+    /// <summary>
+    /// Builds the OPT rows (parent and optional child attachments) for a single file.
+    /// </summary>
+    private static IEnumerable<(string RecordId, string Line)> BuildOptRowsForFile(
+        FileData fileData,
+        FileGenerationRequest request,
+        bool isProductionSet)
+    {
+        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+        var (batesNumber, volume, imagePath, pageCount) = GetRowData(fileData, request, isProductionSet);
+
+        var parentLine = BuildOptRow(batesNumber, volume, imagePath, pageCount);
+        yield return (batesNumber, parentLine);
+
+        if (hasAttachment)
+        {
+            string childBates = $"{batesNumber}_A001";
+            string childImagePath = isProductionSet
+                ? Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\')
+                : $"IMAGES\\{childBates}.tif";
+            var childLine = BuildOptRow(childBates, volume, childImagePath, 1);
+            yield return (childBates, childLine);
+        }
     }
 
     /// <summary>

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -82,6 +82,7 @@ internal class OptWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var workItem = fileData.WorkItem;
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
 
             // Opticon 7-column format: BatesNumber,Volume,ImagePath,DocBreak,FolderBreak,BoxBreak,PageCount
             string batesNumber = request.Bates != null
@@ -99,6 +100,15 @@ internal class OptWriter : LoadFileWriterBase
 
             buffer.AppendLine(line);
             rowCount++;
+
+            if (hasAttachment)
+            {
+                string childBates = $"{batesNumber}_A001";
+                string childImagePath = $"IMAGES\\{childBates}.tif";
+                var childLine = $"{childBates},{volume},{childImagePath},Y,,,{1}";
+                buffer.AppendLine(childLine);
+                rowCount++;
+            }
 
             if (rowCount >= 1000)
             {
@@ -183,8 +193,9 @@ internal class OptWriter : LoadFileWriterBase
         {
             await using var writer = CreateWriter(stream, request);
 
-            foreach (var workItem in processedFiles.OrderBy(f => f.WorkItem.Index).Select(f => f.WorkItem))
+            foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
             {
+                var workItem = fileData.WorkItem;
                 var batesNumber = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
                 var imagePath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
                     .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
@@ -194,6 +205,15 @@ internal class OptWriter : LoadFileWriterBase
                 var line = $"{batesNumber},{workItem.FolderName},{imagePath},{docBreak},,,1";
 
                 await writer.WriteAsync(line + eol);
+
+                bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+                if (hasAttachment)
+                {
+                    var childBates = $"{batesNumber}_A001";
+                    var childImagePath = Path.Combine("IMAGES", workItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+                    var childLine = $"{childBates},{workItem.FolderName},{childImagePath},Y,,,1";
+                    await writer.WriteAsync(childLine + eol);
+                }
             }
 
             await writer.FlushAsync();
@@ -204,18 +224,26 @@ internal class OptWriter : LoadFileWriterBase
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
         var rows = new List<(long LineNumber, string RecordId, string Line)>();
 
-        int rowIdx = 0;
-        foreach (var workItem in processedFiles.OrderBy(f => f.WorkItem.Index).Select(f => f.WorkItem))
+        long currentLineNumber = 1;
+        foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
-            long lineNumber = rowIdx + 1; // OPT has no header; first row is line 1
+            var workItem = fileData.WorkItem;
             var batesNum = BatesNumberGenerator.Generate(request.Bates!, workItem.Index - 1);
             var imgPath = workItem.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
                 .Replace(Path.GetExtension(workItem.FilePathInZip), ".tif")
                 .Replace(Path.DirectorySeparatorChar, '\\');
 
             var optLine = $"{batesNum},{workItem.FolderName},{imgPath},Y,,,1";
-            rows.Add((lineNumber, batesNum, optLine));
-            rowIdx++;
+            rows.Add((currentLineNumber++, batesNum, optLine));
+
+            bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+            if (hasAttachment)
+            {
+                var childBates = $"{batesNum}_A001";
+                var childImagePath = Path.Combine("IMAGES", workItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+                var childLine = $"{childBates},{workItem.FolderName},{childImagePath},Y,,,1";
+                rows.Add((currentLineNumber++, childBates, childLine));
+            }
         }
 
         await WriteRowsWithChaosAsync(stream, encoding, eol, rows, chaosEngine);

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -109,7 +109,28 @@ internal static class ProductionSetGenerator
             {
                 WorkItem = workItem,
                 DataLength = nativeContent.Length,
+                Attachment = generated.Attachment,
+                PageCount = generated.PageCount,
+                Email = generated.Email,
             });
+
+            if (request.Metadata.WithFamilies && request.Output.IsEml && generated.Attachment.HasValue)
+            {
+                var attach = generated.Attachment.Value;
+                var childBates = $"{plan.BatesNumber}_A001";
+                var childExt = Path.GetExtension(attach.filename);
+
+                var childNativeRelPath = Path.Combine("NATIVES", plan.VolumeName, $"{childBates}{childExt}");
+                var childTextRelPath = Path.Combine("TEXT", plan.VolumeName, $"{childBates}.txt");
+                var childImageRelPath = Path.Combine("IMAGES", plan.VolumeName, $"{childBates}.tif");
+
+                await File.WriteAllBytesAsync(Path.Combine(productionPath, childNativeRelPath), attach.content);
+
+                var childTextContent = $"Extracted text for attachment {childBates}.";
+                await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding);
+
+                await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff"));
+            }
 
             // Progress reporting
             if ((plan.Index + 1) % 1000 == 0 || plan.Index == request.Output.FileCount - 1)
@@ -120,30 +141,36 @@ internal static class ProductionSetGenerator
 
         Console.WriteLine();
 
+        long totalRecords = fileDataList.Count;
+        if (request.Metadata.WithFamilies && request.Output.IsEml)
+        {
+            totalRecords += fileDataList.Count(f => f.Attachment.HasValue);
+        }
+
         // Write DAT load file — build a fresh ChaosEngine per format (engines are stateful)
         var datPath = Path.Combine(dataDir, "loadfile.dat");
         var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
-        long datTotalLines = fileDataList.Count + 1; // header + data rows
+        long datTotalLines = totalRecords + 1; // header + data rows
         var datChaosEngine = ChaosEngineBuilder.Build(request, datTotalLines, LoadFileFormat.Dat);
         await using (var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
         {
             await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine);
         }
 
-        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, fileDataList.Count, datChaosEngine?.Anomalies);
+        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, totalRecords, datChaosEngine?.Anomalies);
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson);
 
         // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
         var optWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, LoadFiles.WriterMode.ProductionSet);
-        long optTotalLines = fileDataList.Count; // OPT has no header row
+        long optTotalLines = totalRecords; // OPT has no header row
         var optChaosEngine = ChaosEngineBuilder.Build(request, optTotalLines, LoadFileFormat.Opt);
         await using (var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
         {
             await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine);
         }
 
-        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, optTotalLines, optChaosEngine?.Anomalies);
+        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, totalRecords, optChaosEngine?.Anomalies);
 
         // Save OPT properties with a slightly different name to avoid overwriting DAT properties
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson);

--- a/src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj
+++ b/src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj
@@ -24,9 +24,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-  <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
-  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Zipper.Tests/IntegrationTests.cs
+++ b/src/Zipper.Tests/IntegrationTests.cs
@@ -208,5 +208,43 @@ namespace Zipper
                 }
             }
         }
+
+        [Fact]
+        public async Task Main_WithEmlFamiliesAndAttachments_ShouldCreateFamilyColumnsAndRows()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var args = new[] { "--type", "eml", "--count", "5", "--output-path", tempDir, "--attachment-rate", "100", "--with-families", "--seed", "42" };
+                var result = await Program.Main(args);
+
+                Assert.Equal(0, result);
+
+                var datFile = Directory.GetFiles(tempDir, "*.dat").FirstOrDefault();
+                Assert.NotNull(datFile);
+
+                var content = await File.ReadAllTextAsync(datFile!);
+
+                // Assert family columns are in header
+                var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                Assert.True(lines.Length > 0);
+                var header = lines[0];
+                Assert.Contains("BEGATTACH", header);
+                Assert.Contains("ENDATTACH", header);
+                Assert.Contains("PARENTDOCID", header);
+
+                // Assert there are more rows than emails since there are child attachment rows
+                Assert.True(lines.Length > 6);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
     }
 }

--- a/src/Zipper.Tests/LoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFileWriterTests.cs
@@ -967,5 +967,113 @@ namespace Zipper
             var content = System.Text.Encoding.GetEncoding(1252).GetString(bytes);
             Assert.Contains("Control Number", content);
         }
+
+        [Fact]
+        public async Task DatWriter_WithFamilies_StandardMode_IncludesFamilyColumnsAndRows()
+        {
+            var request = this.CreateTestRequest("eml");
+            request.Metadata = request.Metadata with { WithFamilies = true };
+
+            var fileData = new List<FileData>
+            {
+                new FileData
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FilePathInZip = "folder_001/00000001.eml"
+                    },
+                    Attachment = ("attachment.pdf", new byte[] { 1, 2, 3 }),
+                    DataLength = 100
+                }
+            };
+
+            var writer = new DatWriter();
+            var outputPath = Path.Combine(this.tempDir, "test_families_standard.dat");
+
+            await using (var stream = File.OpenWrite(outputPath))
+            {
+                await writer.WriteAsync(stream, request, fileData);
+            }
+
+            var content = await File.ReadAllTextAsync(outputPath);
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            // Assert Header + 1 Parent row + 1 Child row = 3 lines
+            Assert.Equal(3, lines.Length);
+
+            // Check that family columns are in header
+            Assert.Contains("BEGATTACH", lines[0]);
+            Assert.Contains("ENDATTACH", lines[0]);
+            Assert.Contains("PARENTDOCID", lines[0]);
+
+            // Parent row assertions (no parent doc id, begattach/endattach cover the family)
+            var parentLine = lines[1];
+            Assert.Contains("DOC00000001", parentLine);
+            Assert.Contains("DOC00000001_A001", parentLine); // ENDATTACH
+
+            // Child row assertions
+            var childLine = lines[2];
+            Assert.Contains("DOC00000001_A001", childLine); // Control Number
+            Assert.Contains("DOC00000001", childLine); // PARENTDOCID
+        }
+
+        [Fact]
+        public async Task DatWriter_WithFamilies_ProductionSetMode_IncludesFamilyColumnsAndRows()
+        {
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    FileCount = 1,
+                    FileType = "eml",
+                    OutputPath = this.tempDir,
+                },
+                Metadata = new MetadataConfig { Seed = 42, WithFamilies = true },
+                Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
+                Production = new ProductionConfig { VolumeSize = 5000 },
+                Bates = new BatesNumberConfig { Prefix = "TEST", Start = 1, Digits = 8 },
+                LoadFile = new LoadFileConfig { Encoding = "UTF-8" }
+            };
+
+            var fileData = new List<FileData>
+            {
+                new FileData
+                {
+                    WorkItem = new FileWorkItem
+                    {
+                        Index = 1,
+                        FolderNumber = 1,
+                        FolderName = "VOL001",
+                        FileName = "TEST00000001.eml",
+                        FilePathInZip = "NATIVES\\VOL001\\TEST00000001.eml"
+                    },
+                    Attachment = ("attachment.pdf", new byte[] { 1, 2, 3 }),
+                    DataLength = 100
+                }
+            };
+
+            var writer = new DatWriter(WriterMode.ProductionSet);
+            using var stream = new MemoryStream();
+            await writer.WriteAsync(stream, request, fileData);
+
+            stream.Position = 0;
+            var content = Encoding.UTF8.GetString(stream.ToArray());
+            var lines = content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Equal(3, lines.Length);
+            Assert.Contains("BEGATTACH", lines[0]);
+            Assert.Contains("ENDATTACH", lines[0]);
+            Assert.Contains("PARENTDOCID", lines[0]);
+
+            // Parent row
+            Assert.Contains("TEST00000001", lines[1]);
+            Assert.Contains("TEST00000001_A001", lines[1]); // ENDATTACH
+
+            // Child row
+            Assert.Contains("TEST00000001_A001", lines[2]);
+            Assert.Contains("TEST00000001", lines[2]); // PARENTDOCID
+        }
     }
 }

--- a/src/Zipper.Tests/packages.lock.json
+++ b/src/Zipper.Tests/packages.lock.json
@@ -105,6 +105,11 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Transitive",
+        "resolved": "8.0.27",
+        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.5.1",
@@ -210,6 +215,7 @@
         "dependencies": {
           "ClosedXML": "[0.105.0, )",
           "DocumentFormat.OpenXml": "[3.5.1, )",
+          "Microsoft.NET.ILLink.Tasks": "[8.0.27, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "System.Text.Encoding.CodePages": "[10.0.8, )"
         }

--- a/src/Zipper.csproj
+++ b/src/Zipper.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -30,6 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
## Summary

🤖 Generated with Antigravity https://www.google.com/

• Implemented dynamically inside DAT and OPT load files in both Standard and Production Set modes (REQ-060/061/062).
• Assured correct family columns (BEGATTACH, ENDATTACH, PARENTDOCID) are formatted and output cleanly with proper naming conventions.
• Attached child attachments using standard Bates/Control Number suffix convention to eliminate sequential number sequence collisions.
• Generated physical attachment files (Natives, Text, Images) on disk in Production Set mode.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing Done

- [x] Unit tests added and verified in `LoadFileWriterTests.cs` and `OptWriterTests.cs`
- [x] E2E integration tests added and verified in `IntegrationTests.cs`
- [x] Local StyleCop and dotnet format linting checks completely verified

## Affected Requirements

- **REQ-060**: `--with-families` shall generate parent-child document relationships
- **REQ-061**: Load File shall include BEGATTACH, ENDATTACH, and PARENT_DOCID columns
- **REQ-062**: Email Attachments shall be linked as children of their parent Email


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loadfile outputs now include attachment "child" rows for email attachments when families are enabled, with corresponding family columns added to DAT/OPT headers and production outputs; child native/text/image files are generated as needed and record totals reflect the expansion.

* **Tests**
  * Added integration and unit tests to verify family columns, parent/child rows, and updated record counts.

* **Chores**
  * Updated build dependencies and project metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->