### PR TITLE
fix: refresh packages.lock.json — ILLink.Tasks 8.0.27 → 8.0.25

### DIFF
--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.27, )",
-        "resolved": "8.0.27",
-        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
NU1004 locked-mode restore failed on main because `Microsoft.NET.ILLink.Tasks` drifted from 8.0.27 to 8.0.25. The `packages.lock.json` was out of sync with resolved dependencies.

Fix: ran `dotnet restore zipper.sln --force-evaluate` to sync the lock file.

Note: 3 PathValidator tests fail in the worktree due to different path depth (`/tmp/` vs `/home/`), not related to this change. These pass on the main checkout.