### PR TITLE
feat: validate --with-families requires EML and positive attachment-rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--date-format <format>`: Override the default date format (e.g., "yyyy-MM-dd", "MM/dd/yyyy")
 - `--empty-percentage <0-100>`: Override the default empty value percentage for optional fields
 - `--custodian-count <1-1000>`: Override the number of custodians in the data pool. Maximum 1000
-- `--with-families`: Generate parent-child document relationships (BEGATTACH, ENDATTACH, PARENTDOCID columns)
+- `--with-families`: Generate parent-child document relationships (BEGATTACH, ENDATTACH, PARENTDOCID columns). Only meaningful with `--type eml` and `--attachment-rate` > 0 (emits a soft warning to stderr otherwise)
 
 **Loadfile-Only Options:**
 - `--loadfile-only`: Generate standalone Load Files directly to disk without creating Archives or Native Files. Produces a companion `_properties.json` audit file. `--type` becomes optional (defaults to `pdf` for schema). Conflicts with `--target-zip-size` and `--include-load-file`
@@ -231,6 +231,7 @@ Compatibility checklist:
 | `--column-profile` + `--with-metadata` | Column profile takes precedence; `--with-metadata` is ignored with a warning |
 | `--target-zip-size` | Requires `--count` to be specified |
 | `--attachment-rate` | Only meaningful when `--type eml` (Email File Type) |
+| `--with-families` | Only meaningful when `--type eml` and `--attachment-rate > 0` (emits a soft warning to stderr otherwise) |
 | `--tiff-pages` | Only meaningful when `--type tiff` |
 | `--bates-start`, `--bates-digits` | Only meaningful when `--bates-prefix` is specified |
 | `--date-format`, `--empty-percentage`, `--custodian-count` | Only meaningful when `--column-profile` is specified |

--- a/Requirements.md
+++ b/Requirements.md
@@ -364,6 +364,7 @@ Based on the above research, the following requirements apply to the Zipper Load
 - **REQ-060**: A new argument `--with-families` shall generate parent-child document relationships.
 - **REQ-061**: When `--with-families` is specified, the Load File shall include `BEGATTACH`, `ENDATTACH`, and `PARENT_DOCID` columns.
 - **REQ-062**: Email Attachments (when using `--attachment-rate`) shall be properly linked as children of their parent Email documents.
+- **REQ-122**: When `--with-families` is specified without `--type eml` or with `--attachment-rate 0`, a soft warning shall be emitted to stderr, but the execution shall not be rejected.
 
 #### FR-014: Column Profile System
 

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -68,7 +68,23 @@ public static class CliValidator
                ValidateLoadFileOnly(parsed) &&
                ValidateChaos(parsed) &&
                ValidateProduction(parsed) &&
-               ValidateDelimiters(parsed);
+               ValidateDelimiters(parsed) &&
+               ValidateFamilies(parsed);
+    }
+
+    private static bool ValidateFamilies(ParsedArguments parsed)
+    {
+        if (parsed.WithFamilies)
+        {
+            if (string.IsNullOrEmpty(parsed.FileType) ||
+                !parsed.FileType.Equals("eml", StringComparison.OrdinalIgnoreCase) ||
+                parsed.AttachmentRate <= 0)
+            {
+                Console.Error.WriteLine("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.");
+            }
+        }
+
+        return true;
     }
 
     private static bool ValidateBasicLimits(ParsedArguments parsed)

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -72,6 +72,11 @@ public static class CliValidator
                ValidateFamilies(parsed);
     }
 
+    /// <summary>
+    /// Validates the --with-families option and warns if used in unsupported contexts.
+    /// </summary>
+    /// <param name="parsed">The parsed command-line arguments.</param>
+    /// <returns>True since it emits a soft warning but does not reject execution.</returns>
     private static bool ValidateFamilies(ParsedArguments parsed)
     {
         if (parsed.WithFamilies)

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -76,7 +76,11 @@ public static class CliValidator
     {
         if (parsed.WithFamilies)
         {
-            if (string.IsNullOrEmpty(parsed.FileType) ||
+            if (parsed.LoadfileOnly)
+            {
+                Console.Error.WriteLine("Warning: --with-families has no effect in --loadfile-only mode.");
+            }
+            else if (string.IsNullOrEmpty(parsed.FileType) ||
                 !parsed.FileType.Equals("eml", StringComparison.OrdinalIgnoreCase) ||
                 parsed.AttachmentRate <= 0)
             {

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -390,5 +390,83 @@ namespace Zipper.Tests
             Assert.False(CliValidator.IsValidChaosAmount("0%"));
             Assert.False(CliValidator.IsValidChaosAmount("-5"));
         }
+
+        [Fact]
+        public void Validate_WithFamiliesWithoutEml_EmitsWarning()
+        {
+            var args = CreateValidArgs();
+            args.FileType = "pdf";
+            args.WithFamilies = true;
+            args.AttachmentRate = 50;
+
+            var originalError = Console.Error;
+            using (var errWriter = new StringWriter())
+            {
+                Console.SetError(errWriter);
+                try
+                {
+                    var result = CliValidator.Validate(args);
+                    Assert.True(result);
+                    var output = errWriter.ToString();
+                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                }
+                finally
+                {
+                    Console.SetError(originalError);
+                }
+            }
+        }
+
+        [Fact]
+        public void Validate_WithFamiliesWithEmlAndAttachmentRateZero_EmitsWarning()
+        {
+            var args = CreateValidArgs();
+            args.FileType = "eml";
+            args.WithFamilies = true;
+            args.AttachmentRate = 0;
+
+            var originalError = Console.Error;
+            using (var errWriter = new StringWriter())
+            {
+                Console.SetError(errWriter);
+                try
+                {
+                    var result = CliValidator.Validate(args);
+                    Assert.True(result);
+                    var output = errWriter.ToString();
+                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                }
+                finally
+                {
+                    Console.SetError(originalError);
+                }
+            }
+        }
+
+        [Fact]
+        public void Validate_WithFamiliesWithEmlAndAttachmentRatePositive_DoesNotEmitWarning()
+        {
+            var args = CreateValidArgs();
+            args.FileType = "eml";
+            args.WithFamilies = true;
+            args.AttachmentRate = 50;
+
+            var originalError = Console.Error;
+            using (var errWriter = new StringWriter())
+            {
+                Console.SetError(errWriter);
+                try
+                {
+                    var result = CliValidator.Validate(args);
+                    Assert.True(result);
+                    var output = errWriter.ToString();
+                    Assert.DoesNotContain("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                }
+                finally
+                {
+                    Console.SetError(originalError);
+                }
+            }
+        }
     }
 }

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -468,5 +468,30 @@ namespace Zipper.Tests
                 }
             }
         }
+
+        [Fact]
+        public void Validate_WithFamiliesAndLoadfileOnly_EmitsWarning()
+        {
+            var args = CreateValidArgs();
+            args.WithFamilies = true;
+            args.LoadfileOnly = true;
+
+            var originalError = Console.Error;
+            using (var errWriter = new StringWriter())
+            {
+                Console.SetError(errWriter);
+                try
+                {
+                    var result = CliValidator.Validate(args);
+                    Assert.True(result);
+                    var output = errWriter.ToString();
+                    Assert.Contains("Warning: --with-families has no effect in --loadfile-only mode.", output);
+                }
+                finally
+                {
+                    Console.SetError(originalError);
+                }
+            }
+        }
     }
 }

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -108,7 +108,17 @@ if not errorlevel 1 (
     echo [ ERROR ] FAIL: --with-families warning not emitted for attachment-rate 0
     set /a FAILED+=1
 )
-del "%TEMP%\warn2.txt" 2>nul
+echo [ INFO ] Test: --with-families warning emitted with --loadfile-only
+%ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn3" --with-families --attachment-rate 50 --loadfile-only 2> "%TEMP%\warn3.txt" >nul
+findstr /C:"Warning: --with-families has no effect" "%TEMP%\warn3.txt" >nul 2>&1
+if not errorlevel 1 (
+    echo [ INFO ] PASS: --with-families warning emitted for loadfile-only mode
+    set /a PASSED+=1
+) else (
+    echo [ ERROR ] FAIL: --with-families warning not emitted for loadfile-only mode
+    set /a FAILED+=1
+)
+del "%TEMP%\warn3.txt" 2>nul
 
 REM --- Cleanup ---
 if exist "%TEST_OUTPUT_DIR%" rmdir /s /q "%TEST_OUTPUT_DIR%"

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -69,6 +69,47 @@ if exist "%TEST_OUTPUT_DIR%\edrm_xml\*.xml" (
     set /a FAILED+=1
 )
 
+echo [ INFO ] Test: --with-families accepted with EML + attachments
+%ZIPPER_CMD% --type eml --count 10 --output-path "%TEST_OUTPUT_DIR%\families" --with-families --attachment-rate 50 2> "%TEMP%\no_warn.txt" >nul
+findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\no_warn.txt" >nul 2>&1
+if errorlevel 1 (
+    if exist "%TEST_OUTPUT_DIR%\families\*.dat" (
+        echo [ INFO ] PASS: --with-families accepted without warning
+        set /a PASSED+=1
+    ) else (
+        echo [ ERROR ] FAIL: --with-families (no output produced)
+        set /a FAILED+=1
+    )
+) else (
+    echo [ ERROR ] FAIL: --with-families incorrectly emitted warning for valid config
+    set /a FAILED+=1
+)
+del "%TEMP%\no_warn.txt" 2>nul
+
+echo [ INFO ] Test: --with-families warning emitted without --type eml
+%ZIPPER_CMD% --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn1" --with-families 2> "%TEMP%\warn1.txt" >nul
+findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn1.txt" >nul 2>&1
+if not errorlevel 1 (
+    echo [ INFO ] PASS: --with-families warning emitted for non-eml type
+    set /a PASSED+=1
+) else (
+    echo [ ERROR ] FAIL: --with-families warning not emitted for non-eml type
+    set /a FAILED+=1
+)
+del "%TEMP%\warn1.txt" 2>nul
+
+echo [ INFO ] Test: --with-families warning emitted with --attachment-rate 0
+%ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn2" --with-families --attachment-rate 0 2> "%TEMP%\warn2.txt" >nul
+findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn2.txt" >nul 2>&1
+if not errorlevel 1 (
+    echo [ INFO ] PASS: --with-families warning emitted for attachment-rate 0
+    set /a PASSED+=1
+) else (
+    echo [ ERROR ] FAIL: --with-families warning not emitted for attachment-rate 0
+    set /a FAILED+=1
+)
+del "%TEMP%\warn2.txt" 2>nul
+
 REM --- Cleanup ---
 if exist "%TEST_OUTPUT_DIR%" rmdir /s /q "%TEST_OUTPUT_DIR%"
 

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -71,51 +71,77 @@ if exist "%TEST_OUTPUT_DIR%\edrm_xml\*.xml" (
 
 echo [ INFO ] Test: --with-families accepted with EML + attachments
 %ZIPPER_CMD% --type eml --count 10 --output-path "%TEST_OUTPUT_DIR%\families" --with-families --attachment-rate 50 2> "%TEMP%\no_warn.txt" >nul
-findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\no_warn.txt" >nul 2>&1
-if errorlevel 1 (
-    if exist "%TEST_OUTPUT_DIR%\families\*.dat" (
-        echo [ INFO ] PASS: --with-families accepted without warning
-        set /a PASSED+=1
+set ZIPPER_EXIT=!ERRORLEVEL!
+if !ZIPPER_EXIT! equ 0 (
+    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\no_warn.txt" >nul 2>&1
+    if errorlevel 1 (
+        if exist "%TEST_OUTPUT_DIR%\families\*.dat" (
+            echo [ INFO ] PASS: --with-families accepted without warning
+            set /a PASSED+=1
+        ) else (
+            echo [ ERROR ] FAIL: --with-families (no output produced)
+            set /a FAILED+=1
+        )
     ) else (
-        echo [ ERROR ] FAIL: --with-families (no output produced)
+        echo [ ERROR ] FAIL: --with-families incorrectly emitted warning for valid config
         set /a FAILED+=1
     )
 ) else (
-    echo [ ERROR ] FAIL: --with-families incorrectly emitted warning for valid config
+    echo [ ERROR ] FAIL: --with-families command failed with exit code !ZIPPER_EXIT!
     set /a FAILED+=1
 )
 del "%TEMP%\no_warn.txt" 2>nul
 
 echo [ INFO ] Test: --with-families warning emitted without --type eml
 %ZIPPER_CMD% --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn1" --with-families 2> "%TEMP%\warn1.txt" >nul
-findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn1.txt" >nul 2>&1
-if not errorlevel 1 (
-    echo [ INFO ] PASS: --with-families warning emitted for non-eml type
-    set /a PASSED+=1
+set ZIPPER_EXIT=!ERRORLEVEL!
+if !ZIPPER_EXIT! equ 0 (
+    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn1.txt" >nul 2>&1
+    if not errorlevel 1 (
+        echo [ INFO ] PASS: --with-families warning emitted for non-eml type
+        set /a PASSED+=1
+    ) else (
+        echo [ ERROR ] FAIL: --with-families warning not emitted for non-eml type
+        set /a FAILED+=1
+    )
 ) else (
-    echo [ ERROR ] FAIL: --with-families warning not emitted for non-eml type
+    echo [ ERROR ] FAIL: --with-families command failed with exit code !ZIPPER_EXIT!
     set /a FAILED+=1
 )
 del "%TEMP%\warn1.txt" 2>nul
 
 echo [ INFO ] Test: --with-families warning emitted with --attachment-rate 0
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn2" --with-families --attachment-rate 0 2> "%TEMP%\warn2.txt" >nul
-findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn2.txt" >nul 2>&1
-if not errorlevel 1 (
-    echo [ INFO ] PASS: --with-families warning emitted for attachment-rate 0
-    set /a PASSED+=1
+set ZIPPER_EXIT=!ERRORLEVEL!
+if !ZIPPER_EXIT! equ 0 (
+    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn2.txt" >nul 2>&1
+    if not errorlevel 1 (
+        echo [ INFO ] PASS: --with-families warning emitted for attachment-rate 0
+        set /a PASSED+=1
+    ) else (
+        echo [ ERROR ] FAIL: --with-families warning not emitted for attachment-rate 0
+        set /a FAILED+=1
+    )
 ) else (
-    echo [ ERROR ] FAIL: --with-families warning not emitted for attachment-rate 0
+    echo [ ERROR ] FAIL: --with-families command failed with exit code !ZIPPER_EXIT!
     set /a FAILED+=1
 )
+del "%TEMP%\warn2.txt" 2>nul
+
 echo [ INFO ] Test: --with-families warning emitted with --loadfile-only
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn3" --with-families --attachment-rate 50 --loadfile-only 2> "%TEMP%\warn3.txt" >nul
-findstr /C:"Warning: --with-families has no effect" "%TEMP%\warn3.txt" >nul 2>&1
-if not errorlevel 1 (
-    echo [ INFO ] PASS: --with-families warning emitted for loadfile-only mode
-    set /a PASSED+=1
+set ZIPPER_EXIT=!ERRORLEVEL!
+if !ZIPPER_EXIT! equ 0 (
+    findstr /C:"Warning: --with-families has no effect" "%TEMP%\warn3.txt" >nul 2>&1
+    if not errorlevel 1 (
+        echo [ INFO ] PASS: --with-families warning emitted for loadfile-only mode
+        set /a PASSED+=1
+    ) else (
+        echo [ ERROR ] FAIL: --with-families warning not emitted for loadfile-only mode
+        set /a FAILED+=1
+    )
 ) else (
-    echo [ ERROR ] FAIL: --with-families warning not emitted for loadfile-only mode
+    echo [ ERROR ] FAIL: --with-families command failed with exit code !ZIPPER_EXIT!
     set /a FAILED+=1
 )
 del "%TEMP%\warn3.txt" 2>nul

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -222,6 +222,18 @@ if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn2" \
 else
     fail "--with-families attachment-rate 0 command failed"
 fi
+print_info "Test: --with-families warning emitted with --loadfile-only"
+err_file=$(mktemp)
+if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn3" \
+    --with-families --attachment-rate 50 --loadfile-only 2> "$err_file"; then
+    if grep -q "Warning: --with-families has no effect in --loadfile-only mode." "$err_file"; then
+        pass "--with-families warning emitted for --loadfile-only mode"
+    else
+        fail "--with-families warning NOT emitted for --loadfile-only mode"
+    fi
+else
+    fail "--with-families loadfile-only command failed"
+fi
 rm -f "$err_file"
 
 # --- Summary ---

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -178,17 +178,51 @@ fi
 # --- --with-families flag ---
 
 print_info "Test: --with-families accepted with EML + attachments"
+err_file=$(mktemp)
 if zipper --type eml --count 10 --output-path "$TEST_OUTPUT_DIR/families" \
-    --with-families --attachment-rate 50 > /dev/null 2>&1; then
+    --with-families --attachment-rate 50 2> "$err_file"; then
     dat_file=$(find "$TEST_OUTPUT_DIR/families" -name "*.dat" -print -quit)
     if [[ -n "$dat_file" && -s "$dat_file" ]]; then
-        pass "--with-families accepted and produces output"
+        if ! grep -q "Warning: --with-families is only meaningful" "$err_file"; then
+            pass "--with-families accepted and does not emit warning"
+        else
+            fail "--with-families incorrectly emitted warning for valid config"
+        fi
     else
         fail "--with-families: no .dat file produced"
     fi
 else
     fail "--with-families command failed"
 fi
+rm -f "$err_file"
+
+print_info "Test: --with-families warning emitted without --type eml"
+err_file=$(mktemp)
+if zipper --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn1" \
+    --with-families 2> "$err_file"; then
+    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
+        pass "--with-families warning emitted for non-eml type"
+    else
+        fail "--with-families warning NOT emitted for non-eml type"
+    fi
+else
+    fail "--with-families non-eml type command failed"
+fi
+rm -f "$err_file"
+
+print_info "Test: --with-families warning emitted with --attachment-rate 0"
+err_file=$(mktemp)
+if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn2" \
+    --with-families --attachment-rate 0 2> "$err_file"; then
+    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
+        pass "--with-families warning emitted for attachment-rate 0"
+    else
+        fail "--with-families warning NOT emitted for attachment-rate 0"
+    fi
+else
+    fail "--with-families attachment-rate 0 command failed"
+fi
+rm -f "$err_file"
 
 # --- Summary ---
 

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -222,6 +222,8 @@ if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn2" \
 else
     fail "--with-families attachment-rate 0 command failed"
 fi
+rm -f "$err_file"
+
 print_info "Test: --with-families warning emitted with --loadfile-only"
 err_file=$(mktemp)
 if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn3" \


### PR DESCRIPTION
## Description

This PR implements GitHub issue #335. It introduces command-line option validation and safety warnings for the `--with-families` option. 

Specifically:
1. Emits a soft warning to `stderr` when `--with-families` is used without `--type eml` or when `--attachment-rate` is not specified or is equal to `0` (per REQ-122).
2. Emits a soft warning to `stderr` when `--with-families` is specified in standalone `--loadfile-only` mode, as family relationship metadata columns are ignored during standalone schemas.
3. Does not reject execution in either warning scenario.
4. Added comprehensive Unit and E2E integration test coverage to verify warning output across both Windows and Linux platforms.
5. Resolved all CodeRabbit automated feedback on PR reviews to ensure robust E2E checks and clean temp file handling.
6. Handled docstring coverage pre-merge checks by writing proper XML docstrings.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Test coverage
- [x] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Affected Requirements

- **REQ-122**: When `--with-families` is specified without `--type eml` or with `--attachment-rate 0`, a soft warning shall be emitted to stderr, but the execution shall not be rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--with-families` flag behavior and conditions for use

* **Improvements**
  * Enhanced validation to emit soft warnings when `--with-families` is used without `--type eml`, with `--attachment-rate 0`, or with `--loadfile-only`

* **Tests**
  * Added comprehensive unit and end-to-end test coverage for `--with-families` validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->