### PR TITLE
fix: use CultureInfo.InvariantCulture for DateTime parsing and formatting

### DIFF
--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 namespace Zipper.Profiles;
@@ -145,12 +146,12 @@ public static class ColumnProfileLoader
         // Validate date ranges
         foreach (var column in profile.Columns.Where(c => c.DateRange != null))
         {
-            if (!DateTime.TryParse(column.DateRange!.Min, out var minDate))
+            if (!DateTime.TryParse(column.DateRange!.Min, CultureInfo.InvariantCulture, DateTimeStyles.None, out var minDate))
             {
                 throw new InvalidOperationException($"Column '{column.Name}' has invalid DateRange.Min '{column.DateRange.Min}'. Must be a valid date string.");
             }
 
-            if (!DateTime.TryParse(column.DateRange.Max, out var maxDate))
+            if (!DateTime.TryParse(column.DateRange.Max, CultureInfo.InvariantCulture, DateTimeStyles.None, out var maxDate))
             {
                 throw new InvalidOperationException($"Column '{column.Name}' has invalid DateRange.Max '{column.DateRange.Max}'. Must be a valid date string.");
             }

--- a/src/Profiles/Generation/DateGenerator.cs
+++ b/src/Profiles/Generation/DateGenerator.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Zipper.Profiles.Generation;
 
 internal sealed class DateGenerator : IColumnValueGenerator
@@ -8,8 +10,8 @@ internal sealed class DateGenerator : IColumnValueGenerator
 
     public DateGenerator(ColumnDefinition col, ProfileSettings settings)
     {
-        this.minDate = DateTime.Parse(col.DateRange?.Min ?? "2020-01-01");
-        this.maxDate = DateTime.Parse(col.DateRange?.Max ?? "2024-12-31");
+        this.minDate = DateTime.Parse(col.DateRange?.Min ?? "2020-01-01", CultureInfo.InvariantCulture);
+        this.maxDate = DateTime.Parse(col.DateRange?.Max ?? "2024-12-31", CultureInfo.InvariantCulture);
         this.format = col.Format ?? settings.DateFormat;
     }
 
@@ -17,6 +19,6 @@ internal sealed class DateGenerator : IColumnValueGenerator
     {
         var range = (this.maxDate - this.minDate).Days;
         var date = range <= 0 ? this.minDate : this.minDate.AddDays(context.Seeded.Next(range + 1));
-        return date.ToString(this.format);
+        return date.ToString(this.format, CultureInfo.InvariantCulture);
     }
 }

--- a/src/Profiles/Generation/DateTimeColumnGenerator.cs
+++ b/src/Profiles/Generation/DateTimeColumnGenerator.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Zipper.Profiles.Generation;
 
 internal sealed class DateTimeColumnGenerator : IColumnValueGenerator
@@ -8,8 +10,8 @@ internal sealed class DateTimeColumnGenerator : IColumnValueGenerator
 
     public DateTimeColumnGenerator(ColumnDefinition col, ProfileSettings settings)
     {
-        this.minDate = DateTime.Parse(col.DateRange?.Min ?? "2020-01-01");
-        this.maxDate = DateTime.Parse(col.DateRange?.Max ?? "2024-12-31");
+        this.minDate = DateTime.Parse(col.DateRange?.Min ?? "2020-01-01", CultureInfo.InvariantCulture);
+        this.maxDate = DateTime.Parse(col.DateRange?.Max ?? "2024-12-31", CultureInfo.InvariantCulture);
         this.format = col.Format ?? settings.DateTimeFormat;
     }
 
@@ -19,6 +21,6 @@ internal sealed class DateTimeColumnGenerator : IColumnValueGenerator
         var date = range <= 0
             ? this.minDate.AddHours(context.Seeded.Next(24)).AddMinutes(context.Seeded.Next(60))
             : this.minDate.AddDays(context.Seeded.Next(range + 1)).AddHours(context.Seeded.Next(24)).AddMinutes(context.Seeded.Next(60));
-        return date.ToString(this.format);
+        return date.ToString(this.format, CultureInfo.InvariantCulture);
     }
 }

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -500,6 +500,37 @@ namespace Zipper
             ColumnProfileLoader.Validate(profile); // Should not throw
         }
 
+        [Fact]
+        public void Validate_WithNonUsCulture_ParsesIsoDateRangesCorrectly()
+        {
+            var originalCulture = System.Globalization.CultureInfo.CurrentCulture;
+            var originalUiCulture = System.Globalization.CultureInfo.CurrentUICulture;
+
+            try
+            {
+                var nonUsCulture = (System.Globalization.CultureInfo)System.Globalization.CultureInfo.GetCultureInfo("ar-SA").Clone();
+                nonUsCulture.DateTimeFormat.Calendar = new System.Globalization.UmAlQuraCalendar();
+                System.Globalization.CultureInfo.CurrentCulture = nonUsCulture;
+                System.Globalization.CultureInfo.CurrentUICulture = nonUsCulture;
+
+                var profile = CreateMinimalProfile();
+                profile.Columns.Add(new ColumnDefinition
+                {
+                    Name = "ValidDateRange",
+                    Type = "date",
+                    DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" }
+                });
+
+                // Act & Assert - Should not throw FormatException or InvalidOperationException
+                ColumnProfileLoader.Validate(profile);
+            }
+            finally
+            {
+                System.Globalization.CultureInfo.CurrentCulture = originalCulture;
+                System.Globalization.CultureInfo.CurrentUICulture = originalUiCulture;
+            }
+        }
+
         private static ColumnProfile CreateMinimalProfile()
         {
             return new ColumnProfile

--- a/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using Xunit;
+using Zipper.Profiles;
+using Zipper.Profiles.Generation;
+
+namespace Zipper.Tests.Profiles.Generation;
+
+public class DateGeneratorTests
+{
+    [Fact]
+    public void DateGenerator_WithNonUsCulture_ParsesIsoDatesCorrectly()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            // Create a custom culture using ar-SA but explicitly set to UmAlQuraCalendar
+            var nonUsCulture = (CultureInfo)CultureInfo.GetCultureInfo("ar-SA").Clone();
+            nonUsCulture.DateTimeFormat.Calendar = new UmAlQuraCalendar();
+            CultureInfo.CurrentCulture = nonUsCulture;
+            CultureInfo.CurrentUICulture = nonUsCulture;
+
+            var col = new ColumnDefinition
+            {
+                Name = "TestDate",
+                Type = "date",
+                DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2020-01-10" }
+            };
+            var settings = new ProfileSettings { DateFormat = "yyyy-MM-dd" };
+
+            // Act & Assert
+            // This should parse the date correctly as Gregorian year 2020
+            var generator = new DateGenerator(col, settings);
+            var context = new ColumnGenerationContext
+            {
+                NativeFileIndex = 0,
+                FolderNumber = 1,
+                DocumentIndex = 0,
+                Seeded = new Random(42),
+                Now = DateTime.UtcNow
+            };
+
+            var value = generator.Generate(context);
+            Assert.NotNull(value);
+
+            // Verify it generates a valid date within the range in invariant culture
+            var parsed = DateTime.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            Assert.InRange(parsed, new DateTime(2020, 1, 1), new DateTime(2020, 1, 10));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Fact]
+    public void DateTimeColumnGenerator_WithNonUsCulture_ParsesIsoDatesCorrectly()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var nonUsCulture = (CultureInfo)CultureInfo.GetCultureInfo("ar-SA").Clone();
+            nonUsCulture.DateTimeFormat.Calendar = new UmAlQuraCalendar();
+            CultureInfo.CurrentCulture = nonUsCulture;
+            CultureInfo.CurrentUICulture = nonUsCulture;
+
+            var col = new ColumnDefinition
+            {
+                Name = "TestDateTime",
+                Type = "datetime",
+                DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2020-01-10" }
+            };
+            var settings = new ProfileSettings { DateTimeFormat = "yyyy-MM-dd HH:mm" };
+
+            // Act
+            var generator = new DateTimeColumnGenerator(col, settings);
+            var context = new ColumnGenerationContext
+            {
+                NativeFileIndex = 0,
+                FolderNumber = 1,
+                DocumentIndex = 0,
+                Seeded = new Random(42),
+                Now = DateTime.UtcNow
+            };
+
+            var value = generator.Generate(context);
+            Assert.NotNull(value);
+            var parsed = DateTime.ParseExact(value, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+            Assert.InRange(parsed, new DateTime(2020, 1, 1), new DateTime(2020, 1, 10, 23, 59, 59));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+}

--- a/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
@@ -5,17 +5,16 @@ using Zipper.Profiles.Generation;
 
 namespace Zipper.Tests.Profiles.Generation;
 
-public class DateGeneratorTests
+public class DateTimeColumnGeneratorTests
 {
     [Fact]
-    public void DateGenerator_WithNonUsCulture_ParsesIsoDatesCorrectly()
+    public void DateTimeColumnGenerator_WithNonUsCulture_ParsesIsoDatesCorrectly()
     {
         var originalCulture = CultureInfo.CurrentCulture;
         var originalUiCulture = CultureInfo.CurrentUICulture;
 
         try
         {
-            // Create a custom culture using ar-SA but explicitly set to UmAlQuraCalendar
             var nonUsCulture = (CultureInfo)CultureInfo.GetCultureInfo("ar-SA").Clone();
             nonUsCulture.DateTimeFormat.Calendar = new UmAlQuraCalendar();
             CultureInfo.CurrentCulture = nonUsCulture;
@@ -23,15 +22,14 @@ public class DateGeneratorTests
 
             var col = new ColumnDefinition
             {
-                Name = "TestDate",
-                Type = "date",
+                Name = "TestDateTime",
+                Type = "datetime",
                 DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2020-01-10" }
             };
-            var settings = new ProfileSettings { DateFormat = "yyyy-MM-dd" };
+            var settings = new ProfileSettings { DateTimeFormat = "yyyy-MM-dd HH:mm" };
 
-            // Act & Assert
-            // This should parse the date correctly as Gregorian year 2020
-            var generator = new DateGenerator(col, settings);
+            // Act
+            var generator = new DateTimeColumnGenerator(col, settings);
             var context = new ColumnGenerationContext
             {
                 NativeFileIndex = 0,
@@ -43,10 +41,8 @@ public class DateGeneratorTests
 
             var value = generator.Generate(context);
             Assert.NotNull(value);
-
-            // Verify it generates a valid date within the range in invariant culture
-            var parsed = DateTime.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            Assert.InRange(parsed, new DateTime(2020, 1, 1), new DateTime(2020, 1, 10));
+            var parsed = DateTime.ParseExact(value, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+            Assert.InRange(parsed, new DateTime(2020, 1, 1), new DateTime(2020, 1, 10, 23, 59, 59));
         }
         finally
         {


### PR DESCRIPTION
## Summary
🤖 Generated with Antigravity

- Fixed locale-dependent `DateTime.Parse` in `DateGenerator` and `DateTimeColumnGenerator` by specifying `CultureInfo.InvariantCulture`.
- Fixed locale-dependent `DateTime.TryParse` in `ColumnProfileLoader.Validate` by specifying `CultureInfo.InvariantCulture` and `DateTimeStyles.None`.
- Fixed `date.ToString` in both generators to output standard invariant-formatted dates, ensuring compatibility regardless of regional/thread culture.
- Added comprehensive unit tests in `DateGeneratorTests.cs` and `ColumnProfileLoaderTests.cs` validating correct behavior under non-US/Hijri culture (`ar-SA` with `UmAlQuraCalendar`).

## Test Plan
- Run existing and new unit tests: `dotnet test`
- All 938 tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date range parsing and generation now consistently use invariant culture formatting, ensuring dates are processed correctly regardless of system regional settings.

* **Tests**
  * Added validation tests confirming date parsing works correctly across different regional cultures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->