### PR TITLE
fix: reject non-DAT/OPT formats in --loadfile-only (REQ-088)

### DIFF
--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -320,6 +320,20 @@ public static class CliValidator
             }
         }
 
+        if (!string.IsNullOrEmpty(parsed.LoadFileFormats))
+        {
+            var formats = parsed.LoadFileFormats.Split(',');
+            foreach (var fmt in formats)
+            {
+                var currentFormat = RequestBuilder.GetLoadFileFormat(fmt.Trim());
+                if (currentFormat.HasValue && currentFormat.Value != LoadFileFormat.Dat && currentFormat.Value != LoadFileFormat.Opt)
+                {
+                    Console.Error.WriteLine("Error: --loadfile-only mode is only supported for 'dat' and 'opt' load file formats.");
+                    return false;
+                }
+            }
+        }
+
         return true;
     }
 

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -493,5 +493,75 @@ namespace Zipper.Tests
                 }
             }
         }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithCsvFormat_ReturnsFalse()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormat = "csv";
+            Assert.False(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithEdrmXmlFormat_ReturnsFalse()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormat = "edrm-xml";
+            Assert.False(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithCsvFormatsPlural_ReturnsFalse()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormats = "csv";
+            Assert.False(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithCsvAndXmlFormatsPlural_ReturnsFalse()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormats = "csv,xml";
+            Assert.False(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithDatFormatsPlural_ReturnsTrue()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormats = "dat,opt";
+            Assert.True(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithDatFormat_ReturnsTrue()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormat = "dat";
+            Assert.True(CliValidator.Validate(args));
+        }
+
+        [Fact]
+        public void Validate_LoadfileOnly_WithOptFormat_ReturnsTrue()
+        {
+            var args = CreateValidArgs();
+            args.FileType = null;
+            args.LoadfileOnly = true;
+            args.LoadFileFormat = "opt";
+            Assert.True(CliValidator.Validate(args));
+        }
     }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Added validation to `CliValidator` to reject non-DAT/OPT formats in both singular `--load-file-format` and plural `--load-file-formats` when `--loadfile-only` is specified.
- Rejects invalid configurations with a clear error message as required by **REQ-088**.
- Covered plural format verification under `--loadfile-only` mode with comprehensive unit tests in `CliValidatorTests.cs`.

## Test Plan
- Verified unit test suite executes and passes successfully.
- Verified pre-push golden regression suites and E2E tests execute and pass successfully.

Share Nori with your team: https://www.npmjs.com/package/nori-ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced validation to support multiple comma-separated file formats in `--loadfile-only` mode. Only dat and opt formats are supported; other formats will be rejected with an error message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dwojtaszek/zipper/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->