### PR TITLE
fix: resolve weighted distribution bias when weights exceed values

### DIFF
--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -179,6 +179,21 @@ public static class ColumnProfileLoader
                 throw new InvalidOperationException($"Column '{column.Name}' has invalid truePercentage {column.TruePercentage}. Must be 0-100.");
             }
         }
+
+        // Validate data source weights
+        foreach (var (name, cfg) in profile.DataSources)
+        {
+            if (cfg.Weights != null && cfg.Weights.Count > 0)
+            {
+                var valCount = (cfg.Values != null && cfg.Values.Count > 0) ? cfg.Values.Count : cfg.Count;
+                if (cfg.Weights.Count > valCount)
+                {
+                    throw new InvalidOperationException(
+                        $"Data source '{name}' has an invalid configuration: it has more weights than values " +
+                        $"({cfg.Weights.Count} weights specified, but only {valCount} values exist).");
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -139,14 +139,21 @@ internal class DataGenerator
             {
                 var r = this.random.Next(total);
                 var cum = 0;
+                var assigned = false;
                 for (int j = 0; j < cfg.Weights.Count && j < count; j++)
                 {
                     cum += cfg.Weights[j];
                     if (r < cum)
                     {
                         indices[i] = j;
+                        assigned = true;
                         break;
                     }
+                }
+
+                if (!assigned && count > 0)
+                {
+                    indices[i] = count - 1;
                 }
             }
         }

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -531,6 +531,46 @@ namespace Zipper
             }
         }
 
+        [Fact]
+        public void Validate_WithWeightsCountExceedingValuesCount_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var profile = CreateMinimalProfile();
+            profile.DataSources["testDS"] = new DataSourceConfig
+            {
+                Values = new List<string> { "A", "B" },
+                Weights = new List<int> { 1, 1, 1 }, // 3 weights, but only 2 values
+                Distribution = "weighted"
+            };
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ColumnProfileLoader.Validate(profile));
+
+            Assert.Contains("testDS", exception.Message);
+            Assert.Contains("more weights than values", exception.Message);
+        }
+
+        [Fact]
+        public void Validate_WithWeightsCountExceedingCount_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var profile = CreateMinimalProfile();
+            profile.DataSources["testDS"] = new DataSourceConfig
+            {
+                Count = 2,
+                Weights = new List<int> { 1, 1, 1 }, // 3 weights, but Count = 2
+                Distribution = "weighted"
+            };
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                ColumnProfileLoader.Validate(profile));
+
+            Assert.Contains("testDS", exception.Message);
+            Assert.Contains("more weights than values", exception.Message);
+        }
+
         private static ColumnProfile CreateMinimalProfile()
         {
             return new ColumnProfile

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -362,4 +362,59 @@ public class DataGeneratorTests
             Assert.InRange(observed, emptyPct - 5.0, emptyPct + 5.0);
         }
     }
+
+    /// <summary>
+    /// Test that when weight count exceeds values count, the precomputed indices do not silently bias to 0.
+    /// </summary>
+    [Fact]
+    public void PrecomputeIndices_WeightsCountExceedingValuesCount_DoesNotBiasToIndexZero()
+    {
+        // Arrange
+        var profile = new ColumnProfile
+        {
+            Name = "test-weighted-bias",
+            DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>
+            {
+                ["weightedDS"] = new DataSourceConfig
+                {
+                    Values = new List<string> { "A", "B" },
+                    Weights = new List<int> { 1, 1, 100 }, // 3 weights for 2 values
+                    Distribution = "weighted"
+                }
+            },
+            Columns = new System.Collections.Generic.List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+                new() { Name = "WEIGHTEDFIELD", Type = "text", Required = true, DataSource = "weightedDS" }
+            }
+        };
+
+        // Note: ColumnProfileLoader.Validate is bypassed by instantiating DataGenerator directly.
+        var generator = new DataGenerator(profile, seed: 12345);
+        int sampleSize = 1000;
+        int aCount = 0;
+        int bCount = 0;
+
+        for (int i = 1; i <= sampleSize; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"Folder/doc{i}.pdf" };
+            var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            var value = row["WEIGHTEDFIELD"];
+            if (value == "A")
+            {
+                aCount++;
+            }
+            else if (value == "B")
+            {
+                bCount++;
+            }
+        }
+
+        // Without the fix, "A" is heavily biased (approx 99%) because all out-of-bounds fallbacks default to 0 ("A").
+        // With the fix, out-of-bounds fallbacks are mapped to count - 1 ("B"), so "B" should dominate (~99%).
+        Assert.True(bCount > aCount, $"Expected B count ({bCount}) to be greater than A count ({aCount}) due to fallback to index 1.");
+        Assert.True(bCount > sampleSize * 0.9, $"Expected B count ({bCount}) to be close to 99% of sample size ({sampleSize}).");
+    }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- **Validation**: Added profile validation in `ColumnProfileLoader.Validate` that checks that any data source with weights does not define more weights than values.
- **Fallback Assignment**: Added a fallback in `DataGenerator.PrecomputeIndices` that maps out-of-bounds random choices (due to excess weights) to the last valid value index rather than defaulting to `0`.
- **Unit Tests**: Added robust unit and statistical bias tests verifying that incorrect configurations are blocked by the loader, and that manual config bypassing validation is fallback-mapped correctly without silent index 0 bias.

## Test Plan
- [x] Run full unit test suite: all 1,000 unit tests passed.
- [x] Basic E2E smoke tests and golden regression suite passed in pre-push check.