### PR TITLE
fix: DatWriter standard mode respects empty QuoteDelimiter (#347)

### DIFF
--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -76,10 +76,11 @@ internal class DatWriter : LoadFileWriterBase
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles)
     {
         // Defensive guards to prevent IndexOutOfRangeException when delimiters are unset
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
         char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
-        char quote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
 
-        await writer.WriteLineAsync(BuildStandardHeader(request, colDelim, quote));
+        await writer.WriteLineAsync(BuildStandardHeader(request, colDelim, quote, hasQuote));
 
         var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
         var generator = GetEffectiveProfileGenerator(request, now);
@@ -90,7 +91,7 @@ internal class DatWriter : LoadFileWriterBase
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            foreach (var (_, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, profileValues))
+            foreach (var (_, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, hasQuote, profileValues))
             {
                 buffer.AppendLine(rowLine);
                 rowCount++;
@@ -137,20 +138,21 @@ internal class DatWriter : LoadFileWriterBase
 
         // Chaos path: build rows then delegate to shared WriteRowsWithChaosAsync
         var eolString = GetEolString(request.Delimiters.EndOfLine);
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
         char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
-        char quote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter) ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
 
         var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
         var generator = GetEffectiveProfileGenerator(request, now);
 
         var rows = new List<(long LineNumber, string RecordId, string Line)>();
-        rows.Add((1, "HEADER", BuildStandardHeader(request, colDelim, quote)));
+        rows.Add((1, "HEADER", BuildStandardHeader(request, colDelim, quote, hasQuote)));
 
         long currentLineNumber = 2;
         foreach (var fileData in processedFiles.OrderBy(f => f.WorkItem.Index))
         {
             var profileValues = generator?.GenerateRow(fileData.WorkItem, fileData);
-            foreach (var (recordId, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, profileValues))
+            foreach (var (recordId, rowLine) in BuildStandardRowsForFile(fileData, request, colDelim, quote, hasQuote, profileValues))
             {
                 rows.Add((currentLineNumber++, recordId, rowLine));
             }
@@ -345,12 +347,13 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
+        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues)
     {
         return BuildRowsForFile(
             fileData,
             request,
-            context => BuildStandardRow(fileData, request, colDelim, quote, profileValues, context),
+            context => BuildStandardRow(fileData, request, colDelim, quote, hasQuote, profileValues, context),
             context =>
             {
                 var attach = fileData.Attachment!.Value;
@@ -365,7 +368,7 @@ internal class DatWriter : LoadFileWriterBase
                     EndAttach = context.EndAttach,
                     ParentDocId = context.ParentDocId
                 };
-                return BuildStandardRow(fileData, request, colDelim, quote, profileValues, newContext);
+                return BuildStandardRow(fileData, request, colDelim, quote, hasQuote, profileValues, newContext);
             });
     }
 
@@ -500,41 +503,68 @@ internal class DatWriter : LoadFileWriterBase
     /// <param name="request">The file generation request.</param>
     /// <param name="colDelim">The column delimiter character.</param>
     /// <param name="quote">The quote character.</param>
+    /// <param name="hasQuote">A value indicating whether quote characters should be written around each field.</param>
     /// <returns>The formatted header string.</returns>
-    private static string BuildStandardHeader(FileGenerationRequest request, char colDelim, char quote)
+    private static string BuildStandardHeader(FileGenerationRequest request, char colDelim, char quote, bool hasQuote)
     {
         var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
         var sb = new StringBuilder();
-        sb.Append($"{quote}{NamingConventionHelper.ApplyConvention("Control Number", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("File Path", namingConvention)}{quote}");
+        AppendField(sb, NamingConventionHelper.ApplyConvention("Control Number", namingConvention), quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, NamingConventionHelper.ApplyConvention("File Path", namingConvention), quote, hasQuote);
 
         if (request.Metadata.ShouldIncludeMetadataColumns(request.Output))
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Custodian", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Date Sent", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Author", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("File Size", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Custodian", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Date Sent", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Author", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("File Size", namingConvention), quote, hasQuote);
         }
 
         if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("To", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("From", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Subject", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Sent Date", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Attachment", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("To", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("From", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Subject", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Sent Date", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Attachment", namingConvention), quote, hasQuote);
         }
 
         if (request.Bates != null)
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Bates Number", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Bates Number", namingConvention), quote, hasQuote);
         }
 
         if (request.Tiff.ShouldIncludePageCount(request.Output))
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Page Count", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Page Count", namingConvention), quote, hasQuote);
         }
 
         if (request.Output.WithText)
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("Extracted Text", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("Extracted Text", namingConvention), quote, hasQuote);
         }
 
         if (request.Metadata.WithFamilies)
         {
-            sb.Append($"{colDelim}{quote}{NamingConventionHelper.ApplyConvention("BEGATTACH", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("ENDATTACH", namingConvention)}{quote}{colDelim}{quote}{NamingConventionHelper.ApplyConvention("PARENTDOCID", namingConvention)}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("BEGATTACH", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("ENDATTACH", namingConvention), quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, NamingConventionHelper.ApplyConvention("PARENTDOCID", namingConvention), quote, hasQuote);
         }
 
         return sb.ToString();
@@ -547,6 +577,7 @@ internal class DatWriter : LoadFileWriterBase
     /// <param name="request">The file generation request.</param>
     /// <param name="colDelim">The column delimiter character.</param>
     /// <param name="quote">The quote character.</param>
+    /// <param name="hasQuote">A value indicating whether quote characters should be written around each field.</param>
     /// <param name="profileValues">The custom metadata profile values.</param>
     /// <param name="context">The row context containing optional overrides and family boundaries.</param>
     /// <returns>A formatted DAT row string.</returns>
@@ -555,6 +586,7 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
+        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
         RowBuildContext context)
     {
@@ -563,28 +595,37 @@ internal class DatWriter : LoadFileWriterBase
         var filePath = context.FilePathOverride ?? EscapeDatField(workItem.FilePathInZip, quote, request.Delimiters.NewlineDelimiter);
 
         var sb = new StringBuilder();
-        sb.Append($"{quote}{docId}{quote}{colDelim}{quote}{filePath}{quote}");
+        AppendField(sb, docId, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, filePath, quote, hasQuote);
 
-        AppendMetadataColumns(sb, fileData, request, colDelim, quote, profileValues, context);
-        AppendEmailColumns(sb, fileData, request, colDelim, quote, profileValues, context);
+        AppendMetadataColumns(sb, fileData, request, colDelim, quote, hasQuote, profileValues, context);
+        AppendEmailColumns(sb, fileData, request, colDelim, quote, hasQuote, profileValues, context);
 
         if (request.Bates != null)
         {
             var batesVal = context.IdOverride ?? BatesNumberGenerator.Generate(request.Bates, workItem.Index - 1);
-            sb.Append($"{colDelim}{quote}{batesVal}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, batesVal, quote, hasQuote);
         }
 
         if (request.Tiff.ShouldIncludePageCount(request.Output))
         {
             var pageCount = context.IsChild ? 1 : fileData.PageCount;
-            sb.Append($"{colDelim}{quote}{pageCount}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, pageCount.ToString(), quote, hasQuote);
         }
 
-        AppendTextColumn(sb, fileData, request, colDelim, quote, context);
+        AppendTextColumn(sb, fileData, request, colDelim, quote, hasQuote, context);
 
         if (request.Metadata.WithFamilies)
         {
-            sb.Append($"{colDelim}{quote}{context.BegAttach ?? string.Empty}{quote}{colDelim}{quote}{context.EndAttach ?? string.Empty}{quote}{colDelim}{quote}{context.ParentDocId ?? string.Empty}{quote}");
+            sb.Append(colDelim);
+            AppendField(sb, context.BegAttach ?? string.Empty, quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, context.EndAttach ?? string.Empty, quote, hasQuote);
+            sb.Append(colDelim);
+            AppendField(sb, context.ParentDocId ?? string.Empty, quote, hasQuote);
         }
 
         return sb.ToString();
@@ -599,6 +640,7 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
+        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
         RowBuildContext context)
     {
@@ -612,7 +654,14 @@ internal class DatWriter : LoadFileWriterBase
         var author = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("AUTHOR") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
         var fileSize = context.FileSizeOverride ?? (profileValues?.GetValueOrDefault("FILESIZE") ?? fileData.DataLength.ToString());
 
-        sb.Append($"{colDelim}{quote}{custodian}{quote}{colDelim}{quote}{dateSent}{quote}{colDelim}{quote}{author}{quote}{colDelim}{quote}{fileSize}{quote}");
+        sb.Append(colDelim);
+        AppendField(sb, custodian, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, dateSent, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, author, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, fileSize, quote, hasQuote);
     }
 
     /// <summary>
@@ -624,6 +673,7 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
+        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
         RowBuildContext context)
     {
@@ -639,7 +689,16 @@ internal class DatWriter : LoadFileWriterBase
         var sentDate = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty);
         var attachment = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
 
-        sb.Append($"{colDelim}{quote}{to}{quote}{colDelim}{quote}{from}{quote}{colDelim}{quote}{subject}{quote}{colDelim}{quote}{sentDate}{quote}{colDelim}{quote}{attachment}{quote}");
+        sb.Append(colDelim);
+        AppendField(sb, to, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, from, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, subject, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, sentDate, quote, hasQuote);
+        sb.Append(colDelim);
+        AppendField(sb, attachment, quote, hasQuote);
     }
 
     /// <summary>
@@ -651,6 +710,7 @@ internal class DatWriter : LoadFileWriterBase
         FileGenerationRequest request,
         char colDelim,
         char quote,
+        bool hasQuote,
         RowBuildContext context)
     {
         if (!request.Output.WithText)
@@ -673,7 +733,8 @@ internal class DatWriter : LoadFileWriterBase
                 : workItem.FilePathInZip;
         }
 
-        sb.Append($"{colDelim}{quote}{textPath}{quote}");
+        sb.Append(colDelim);
+        AppendField(sb, textPath, quote, hasQuote);
     }
 
     /// <summary>

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -340,6 +340,7 @@ internal class DatWriter : LoadFileWriterBase
     /// <param name="request">The file generation request.</param>
     /// <param name="colDelim">The column delimiter character.</param>
     /// <param name="quote">The quote character.</param>
+    /// <param name="hasQuote">A value indicating whether quote characters should be written around each field.</param>
     /// <param name="profileValues">The custom metadata profile values.</param>
     /// <returns>A collection of generated load file rows containing record ID and row string.</returns>
     private static IEnumerable<(string RecordId, string Line)> BuildStandardRowsForFile(

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -600,8 +600,8 @@ internal class DatWriter : LoadFileWriterBase
         sb.Append(colDelim);
         AppendField(sb, filePath, quote, hasQuote);
 
-        AppendMetadataColumns(sb, fileData, request, colDelim, quote, hasQuote, profileValues, context);
-        AppendEmailColumns(sb, fileData, request, colDelim, quote, hasQuote, profileValues, context);
+        AppendMetadataColumns(sb, fileData, request, profileValues, context);
+        AppendEmailColumns(sb, fileData, request, profileValues, context);
 
         if (request.Bates != null)
         {
@@ -617,7 +617,7 @@ internal class DatWriter : LoadFileWriterBase
             AppendField(sb, pageCount.ToString(), quote, hasQuote);
         }
 
-        AppendTextColumn(sb, fileData, request, colDelim, quote, hasQuote, context);
+        AppendTextColumn(sb, fileData, request, context);
 
         if (request.Metadata.WithFamilies)
         {
@@ -639,9 +639,6 @@ internal class DatWriter : LoadFileWriterBase
         StringBuilder sb,
         FileData fileData,
         FileGenerationRequest request,
-        char colDelim,
-        char quote,
-        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
         RowBuildContext context)
     {
@@ -649,6 +646,10 @@ internal class DatWriter : LoadFileWriterBase
         {
             return;
         }
+
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
+        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
 
         var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
         var dateSent = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
@@ -672,9 +673,6 @@ internal class DatWriter : LoadFileWriterBase
         StringBuilder sb,
         FileData fileData,
         FileGenerationRequest request,
-        char colDelim,
-        char quote,
-        bool hasQuote,
         System.Collections.Generic.Dictionary<string, string>? profileValues,
         RowBuildContext context)
     {
@@ -682,6 +680,10 @@ internal class DatWriter : LoadFileWriterBase
         {
             return;
         }
+
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
+        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
 
         var workItem = fileData.WorkItem;
         var to = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
@@ -709,15 +711,16 @@ internal class DatWriter : LoadFileWriterBase
         StringBuilder sb,
         FileData fileData,
         FileGenerationRequest request,
-        char colDelim,
-        char quote,
-        bool hasQuote,
         RowBuildContext context)
     {
         if (!request.Output.WithText)
         {
             return;
         }
+
+        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
+        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
 
         var workItem = fileData.WorkItem;
         string textPath;

--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -76,9 +76,7 @@ internal class DatWriter : LoadFileWriterBase
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles)
     {
         // Defensive guards to prevent IndexOutOfRangeException when delimiters are unset
-        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
-        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
-        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        var (hasQuote, quote, colDelim) = ResolveStandardDelimiters(request.Delimiters);
 
         await writer.WriteLineAsync(BuildStandardHeader(request, colDelim, quote, hasQuote));
 
@@ -138,9 +136,7 @@ internal class DatWriter : LoadFileWriterBase
 
         // Chaos path: build rows then delegate to shared WriteRowsWithChaosAsync
         var eolString = GetEolString(request.Delimiters.EndOfLine);
-        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
-        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
-        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
+        var (hasQuote, quote, colDelim) = ResolveStandardDelimiters(request.Delimiters);
 
         var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
         var generator = GetEffectiveProfileGenerator(request, now);
@@ -647,9 +643,7 @@ internal class DatWriter : LoadFileWriterBase
             return;
         }
 
-        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
-        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
-        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
+        var (hasQuote, quote, colDelim) = ResolveStandardDelimiters(request.Delimiters);
 
         var custodian = EscapeDatField(profileValues?.GetValueOrDefault("CUSTODIAN") ?? string.Empty, quote, request.Delimiters.NewlineDelimiter);
         var dateSent = context.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("DATESENT") ?? string.Empty);
@@ -681,9 +675,7 @@ internal class DatWriter : LoadFileWriterBase
             return;
         }
 
-        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
-        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
-        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
+        var (hasQuote, quote, colDelim) = ResolveStandardDelimiters(request.Delimiters);
 
         var workItem = fileData.WorkItem;
         var to = context.IsChild ? string.Empty : EscapeDatField(profileValues?.GetValueOrDefault("EMAILTO") ?? $"recipient{workItem.Index}@example.com", quote, request.Delimiters.NewlineDelimiter);
@@ -718,9 +710,7 @@ internal class DatWriter : LoadFileWriterBase
             return;
         }
 
-        bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
-        char quote = hasQuote ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
-        char colDelim = !string.IsNullOrEmpty(request.Delimiters.ColumnDelimiter) ? request.Delimiters.ColumnDelimiter[0] : '\u0014';
+        var (hasQuote, quote, colDelim) = ResolveStandardDelimiters(request.Delimiters);
 
         var workItem = fileData.WorkItem;
         string textPath;
@@ -739,6 +729,20 @@ internal class DatWriter : LoadFileWriterBase
 
         sb.Append(colDelim);
         AppendField(sb, textPath, quote, hasQuote);
+    }
+
+    /// <summary>
+    /// Resolves the standard column delimiter, quote character, and hasQuote flag from the configured
+    /// delimiter settings, applying fallback sentinel values when a delimiter is unset.
+    /// </summary>
+    /// <param name="delimiters">The delimiter configuration.</param>
+    /// <returns>A tuple of (hasQuote, quoteChar, columnDelimChar).</returns>
+    private static (bool HasQuote, char Quote, char ColDelim) ResolveStandardDelimiters(Config.DelimiterConfig delimiters)
+    {
+        bool hasQuote = !string.IsNullOrEmpty(delimiters.QuoteDelimiter);
+        char quote = hasQuote ? delimiters.QuoteDelimiter[0] : '\u00fe';
+        char colDelim = !string.IsNullOrEmpty(delimiters.ColumnDelimiter) ? delimiters.ColumnDelimiter[0] : '\u0014';
+        return (hasQuote, quote, colDelim);
     }
 
     /// <summary>

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -260,9 +260,10 @@ namespace Zipper
         [Fact]
         public async Task WriteAsync_DefaultDelimiters_UseNonPrintingChars()
         {
+            // DefaultRequest() already has QuoteDelimiter = "\u00fe" (the default).
+            // We force them to explicit non-printing chars to verify they appear wrapped.
             var request = DefaultRequest();
-            request.Delimiters = request.Delimiters with { ColumnDelimiter = null! };
-            request.Delimiters = request.Delimiters with { QuoteDelimiter = null! };
+            request.Delimiters = request.Delimiters with { ColumnDelimiter = "\u0014", QuoteDelimiter = "\u00fe" };
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
@@ -330,6 +331,37 @@ namespace Zipper
             Assert.IsAssignableFrom<LoadFileWriterBase>(writer);
             Assert.Equal("DAT", writer.FormatName);
             Assert.Equal(".dat", writer.FileExtension);
+        }
+
+        [Fact]
+        public async Task WriteAsync_StandardMode_EmptyQuoteDelimiter_OmitsQuoteCharactersInHeader()
+        {
+            var request = DefaultRequest();
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            var (_, lines) = await WriteAndCapture(request, files);
+            var header = lines[0];
+
+            // With no quote delimiter, fields must NOT be wrapped in any quote character
+            Assert.DoesNotContain("þ", header);
+            Assert.Contains("Control Number", header);
+            Assert.Contains("File Path", header);
+        }
+
+        [Fact]
+        public async Task WriteAsync_StandardMode_EmptyQuoteDelimiter_OmitsQuoteCharactersInDataRows()
+        {
+            var request = DefaultRequest();
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            var (_, lines) = await WriteAndCapture(request, files);
+            var dataRow = lines[1];
+
+            // DOC00000001 must appear unquoted — no þ wrapper
+            Assert.DoesNotContain("þ", dataRow);
+            Assert.Contains("DOC00000001", dataRow);
         }
 
         [Fact]

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -365,6 +365,51 @@ namespace Zipper
         }
 
         [Fact]
+        public async Task WriteAsync_StandardMode_EmptyQuoteDelimiter_WithMetadata_OmitsQuotes()
+        {
+            var request = DefaultRequest();
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            request.Metadata = request.Metadata with { WithMetadata = true };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            var output = await WriteAndCaptureOutput(request, files);
+
+            // Metadata columns (Custodian, Date Sent, Author, File Size) must appear unquoted
+            Assert.DoesNotContain("þ", output);
+            Assert.Contains("Custodian", output);
+        }
+
+        [Fact]
+        public async Task WriteAsync_StandardMode_EmptyQuoteDelimiter_WithText_OmitsQuotes()
+        {
+            var request = DefaultRequest();
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            request.Output = request.Output with { WithText = true, FileType = "pdf" };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            var output = await WriteAndCaptureOutput(request, files);
+
+            // Extracted Text column must appear unquoted
+            Assert.DoesNotContain("þ", output);
+            Assert.Contains(".txt", output);
+        }
+
+        [Fact]
+        public async Task WriteAsync_StandardMode_EmptyQuoteDelimiter_WithBates_OmitsQuotes()
+        {
+            var request = DefaultRequest();
+            request.Delimiters = request.Delimiters with { QuoteDelimiter = string.Empty };
+            request.Bates = new BatesNumberConfig { Prefix = "TEST", Start = 1, Digits = 6, Increment = 1 };
+            var files = new List<FileData> { MakeFileData(1) };
+
+            var output = await WriteAndCaptureOutput(request, files);
+
+            // Bates Number column must appear unquoted
+            Assert.DoesNotContain("þ", output);
+            Assert.Contains("TEST", output);
+        }
+
+        [Fact]
         public async Task WriteAsync_LeavesUnderlyingStreamOpen()
         {
             var request = DefaultRequest();


### PR DESCRIPTION
## Summary

Fixes #347. `DatWriter` standard mode unconditionally wrapped every field in `{quote}...{quote}` via string interpolation, ignoring the `hasQuote` flag derived from an empty/null `QuoteDelimiter`. The loadfile-only mode already handled this correctly via `AppendField(sb, value, quote, hasQuote)`.

## Changes

- **`WriteContentAsync`** and **`WriteStandardAsync`** (chaos path): compute `hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter)` and thread it through
- **`BuildStandardHeader`**: replace single-expression interpolation with per-field `AppendField(sb, name, quote, hasQuote)` calls; add `hasQuote` param + XML doc
- **`BuildStandardRow`**: replace `$"{quote}{val}{quote}"` interpolation with `AppendField`; add `hasQuote` param + XML doc
- **`AppendMetadataColumns`**, **`AppendEmailColumns`**, **`AppendTextColumn`**: same pattern; add `hasQuote` param + XML doc
- **`BuildStandardRowsForFile`**: add `hasQuote` param + XML doc

**Test updates:**
- Replaced pre-existing `WriteAsync_DefaultDelimiters_UseNonPrintingChars` which tested the buggy null-fallback path with an equivalent test using explicit `QuoteDelimiter = "\u00fe"` (the `DelimiterConfig` default) — same behavioral contract, valid delimiter value
- Added **5 new tests** (RED first, then GREEN):
  - `WriteAsync_StandardMode_EmptyQuoteDelimiter_OmitsQuoteCharactersInHeader`
  - `WriteAsync_StandardMode_EmptyQuoteDelimiter_OmitsQuoteCharactersInDataRows`
  - `WriteAsync_StandardMode_EmptyQuoteDelimiter_WithMetadata_OmitsQuotes`
  - `WriteAsync_StandardMode_EmptyQuoteDelimiter_WithText_OmitsQuotes`
  - `WriteAsync_StandardMode_EmptyQuoteDelimiter_WithBates_OmitsQuotes`

## Acceptance Criteria

- [x] Standard mode respects `hasQuote=false` by omitting quote characters
- [x] Unit test verifies unquoted output in standard mode when quote delimiter is empty

## Test Plan

- [x] 962 unit tests pass (up from 959)
- [x] `dotnet format --verify-no-changes` passes
- [x] 13 E2E smoke scenarios pass (pre-push hook)

## Known Related Issues (out of scope for this PR)

- **ProductionSet mode** (`WriteProductionSetAsync`, `BuildProductionSetRow`) has the identical quote-wrapping bug — not fixed here as the issue body explicitly scopes to standard mode; recommend filing a follow-up
- **`EscapeDatField` with sentinel `'\u00fe'`**: when `hasQuote=false` the fallback sentinel char is still passed to `EscapeDatField`, which would double any `þ` character in field values. This is pre-existing behaviour (identical in the old standard mode and in loadfile-only mode today); not introduced by this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DAT exports now respect the configured quote delimiter: when no quote delimiter is provided, header and data fields are emitted without quote characters (including in the chaos-injection export path).

* **Tests**
  * Added tests to verify omission of quote characters across headers, data rows, metadata, extracted text references, and bates number fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->