### PR TITLE
fix: --custodian-count override not applied when using --column-profile (#349)

### DIFF
--- a/src/LoadFiles/ProfileDrivenDatWriter.cs
+++ b/src/LoadFiles/ProfileDrivenDatWriter.cs
@@ -32,7 +32,7 @@ internal sealed class ProfileDrivenDatWriter : LoadFileWriterBase
             ? request.Delimiters.QuoteDelimiter[0] : '\u00fe';
         bool hasQuote = !string.IsNullOrEmpty(request.Delimiters.QuoteDelimiter);
 
-        var generator = new DataGenerator(profile, request.Metadata.Seed);
+        var generator = new DataGenerator(profile, request.Metadata.Seed, custodianCountOverride: request.Metadata.CustodianCountOverride);
         var columnNames = generator.GetColumnNames().ToList();
 
         // Write header row

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -7,6 +7,8 @@ namespace Zipper.Profiles;
 /// </summary>
 internal class DataGenerator
 {
+    private const string CustodianDataSourceName = "custodians";
+
     private readonly ColumnProfile profile;
     private readonly Random random;
     private readonly Dictionary<string, string[]> dataSources;
@@ -15,9 +17,11 @@ internal class DataGenerator
     private readonly DateTime now;
     private int documentIndex;
 
-    public DataGenerator(ColumnProfile profile, int? seed = null, DateTime? now = null)
+    public DataGenerator(ColumnProfile profile, int? seed = null, DateTime? now = null, int? custodianCountOverride = null)
     {
-        this.profile = profile;
+        this.profile = custodianCountOverride.HasValue
+            ? ApplyCustodianCountOverride(profile, custodianCountOverride.Value)
+            : profile;
 #pragma warning disable S2245
         this.random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
 #pragma warning restore S2245
@@ -27,6 +31,58 @@ internal class DataGenerator
         this.now = now ?? DateTime.UtcNow;
         this.InitializeDataSources();
         this.InitializeColumnGenerators();
+    }
+
+    private static ColumnProfile ApplyCustodianCountOverride(ColumnProfile profile, int count)
+    {
+        if (!profile.DataSources.TryGetValue(CustodianDataSourceName, out var custodianSource))
+        {
+            return profile;
+        }
+
+        var effectiveCount = Math.Max(1, count);
+        DataSourceConfig overriddenSource;
+
+        if (custodianSource.Values?.Count > 0)
+        {
+            // Static value list: truncate to the requested count
+            overriddenSource = new DataSourceConfig
+            {
+                Count = effectiveCount,
+                Distribution = custodianSource.Distribution,
+                Prefix = custodianSource.Prefix,
+                Values = custodianSource.Values.Take(effectiveCount).ToList(),
+                Weights = custodianSource.Weights,
+            };
+        }
+        else
+        {
+            // Generated names (Count + Prefix): replace the count
+            overriddenSource = new DataSourceConfig
+            {
+                Count = effectiveCount,
+                Distribution = custodianSource.Distribution,
+                Prefix = custodianSource.Prefix,
+                Values = null,
+                Weights = custodianSource.Weights,
+            };
+        }
+
+        var newDataSources = new Dictionary<string, DataSourceConfig>(profile.DataSources)
+        {
+            [CustodianDataSourceName] = overriddenSource,
+        };
+
+        return new ColumnProfile
+        {
+            Name = profile.Name,
+            Description = profile.Description,
+            Version = profile.Version,
+            FieldNamingConvention = profile.FieldNamingConvention,
+            Settings = profile.Settings,
+            DataSources = newDataSources,
+            Columns = profile.Columns,
+        };
     }
 
     public Dictionary<string, string> GenerateRow(FileWorkItem workItem, FileData fileData)

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -33,6 +33,13 @@ internal class DataGenerator
         this.InitializeColumnGenerators();
     }
 
+    /// <summary>
+    /// Returns a copy of <paramref name="profile"/> whose <c>custodians</c> data source is
+    /// adjusted to produce at most <paramref name="count"/> distinct custodian values.
+    /// For generated (Count+Prefix) sources the count is replaced directly.
+    /// For static Values lists both the values and any associated weights are truncated.
+    /// If the profile has no <c>custodians</c> data source the original profile is returned unchanged.
+    /// </summary>
     private static ColumnProfile ApplyCustodianCountOverride(ColumnProfile profile, int count)
     {
         if (!profile.DataSources.TryGetValue(CustodianDataSourceName, out var custodianSource))
@@ -45,14 +52,14 @@ internal class DataGenerator
 
         if (custodianSource.Values?.Count > 0)
         {
-            // Static value list: truncate to the requested count
+            // Static value list: truncate values and corresponding weights to the requested count
             overriddenSource = new DataSourceConfig
             {
                 Count = effectiveCount,
                 Distribution = custodianSource.Distribution,
                 Prefix = custodianSource.Prefix,
                 Values = custodianSource.Values.Take(effectiveCount).ToList(),
-                Weights = custodianSource.Weights,
+                Weights = custodianSource.Weights?.Take(effectiveCount).ToList(),
             };
         }
         else

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -531,4 +531,55 @@ public class DataGeneratorTests
             Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value: {v}");
         }
     }
+
+    /// <summary>
+    /// Regression test: when a Values-based custodian source also has Weights,
+    /// both must be truncated to effectiveCount so PrecomputeIndices works correctly.
+    /// Before the fix, the full Weights list was kept, causing index misalignment.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WithCustodianCountOverride_WeightedValuesBasedSource_TruncatesBothValuesAndWeights()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "weighted-values-custodians",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            DataSources = new Dictionary<string, DataSourceConfig>
+            {
+                ["custodians"] = new DataSourceConfig
+                {
+                    Values = new List<string> { "Alice", "Bob", "Carol", "Dave", "Eve" },
+                    Weights = new List<int> { 50, 30, 10, 5, 5 },
+                    Distribution = "weighted",
+                },
+            },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+                new() { Name = "CUSTODIAN", Type = "coded", DataSource = "custodians", EmptyPercentage = 0 },
+            },
+        };
+
+        // Override to 2: only "Alice" (weight 50) and "Bob" (weight 30) should appear.
+        // If Weights was NOT truncated, PrecomputeIndices would sum all 5 weights (100)
+        // but only 2 values exist, causing index-out-of-range fallback to the last value.
+        var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
+        var custodianValues = new HashSet<string>();
+
+        for (int i = 1; i <= 200; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"NATIVES/001/DOC{i:D8}.pdf" };
+            var fileData = new FileData { Data = new byte[1024], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+            custodianValues.Add(row["CUSTODIAN"]);
+        }
+
+        Assert.True(
+            custodianValues.Count <= 2,
+            $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+        foreach (var v in custodianValues)
+        {
+            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value after weight truncation: {v}");
+        }
+    }
 }

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -417,4 +417,118 @@ public class DataGeneratorTests
         Assert.True(bCount > aCount, $"Expected B count ({bCount}) to be greater than A count ({aCount}) due to fallback to index 1.");
         Assert.True(bCount > sampleSize * 0.9, $"Expected B count ({bCount}) to be close to 99% of sample size ({sampleSize}).");
     }
+
+    /// <summary>
+    /// Test that custodianCountOverride replaces the profile's custodians data source Count,
+    /// producing only values within the override range.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WithCustodianCountOverride_LimitsDistinctCustodians()
+    {
+        // Standard profile has 25 custodians by default.
+        // We override to 3 — so every generated custodian value must be within Custodian_1..Custodian_3.
+        // Use 500 rows (seeded) to ensure all 3 values appear given pareto distribution.
+        var profile = BuiltInProfiles.Standard;
+        var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 3);
+        var validValues = new HashSet<string> { "Custodian_1", "Custodian_2", "Custodian_3" };
+
+        var custodianValues = new HashSet<string>();
+
+        for (int i = 1; i <= 500; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"NATIVES/001/DOC{i:D8}.pdf" };
+            var fileData = new FileData { Data = new byte[1024], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            if (!string.IsNullOrEmpty(row["CUSTODIAN"]))
+            {
+                custodianValues.Add(row["CUSTODIAN"]);
+            }
+        }
+
+        // Upper bound: no value outside the 3 allowed
+        Assert.True(
+            custodianValues.Count <= 3,
+            $"Expected at most 3 distinct custodians but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+        foreach (var v in custodianValues)
+        {
+            Assert.Contains(v, validValues);
+        }
+
+        // Lower bound: at least Custodian_1 must appear (it gets 80%+ under pareto)
+        Assert.Contains("Custodian_1", custodianValues);
+    }
+
+    /// <summary>
+    /// Test that custodianCountOverride is a no-op for profiles that have no "custodians" data source.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WithCustodianCountOverride_NoCustodiansDataSource_NoOp()
+    {
+        // Minimal profile has a custodians source; build a custom profile that does NOT
+        var profile = new ColumnProfile
+        {
+            Name = "no-custodians",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            DataSources = new Dictionary<string, DataSourceConfig>(),
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+            },
+        };
+
+        // Should not throw; the override should be silently ignored
+        var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 5);
+        var workItem = new FileWorkItem { Index = 1, FilePathInZip = "NATIVES/001/DOC00000001.pdf" };
+        var fileData = new FileData { Data = new byte[1024], WorkItem = workItem };
+
+        var row = generator.GenerateRow(workItem, fileData);
+        Assert.Single(row); // Only DOCID
+    }
+
+    /// <summary>
+    /// Test that custodianCountOverride truncates a static Values-based custodians data source.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WithCustodianCountOverride_ValuesBasedSource_TruncatesToOverrideCount()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "values-custodians",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            DataSources = new Dictionary<string, DataSourceConfig>
+            {
+                ["custodians"] = new DataSourceConfig
+                {
+                    Values = new List<string> { "Alice", "Bob", "Carol", "Dave", "Eve" },
+                    Distribution = "uniform",
+                },
+            },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+                new() { Name = "CUSTODIAN", Type = "coded", DataSource = "custodians", EmptyPercentage = 0 },
+            },
+        };
+
+        // Override to 2: only "Alice" and "Bob" should ever appear
+        var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
+        var custodianValues = new HashSet<string>();
+
+        for (int i = 1; i <= 200; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"NATIVES/001/DOC{i:D8}.pdf" };
+            var fileData = new FileData { Data = new byte[1024], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+            custodianValues.Add(row["CUSTODIAN"]);
+        }
+
+        Assert.True(
+            custodianValues.Count <= 2,
+            $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+        foreach (var v in custodianValues)
+        {
+            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value: {v}");
+        }
+    }
 }

--- a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+++ b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
@@ -22,12 +22,12 @@ namespace Zipper
             };
         }
 
-        private static FileGenerationRequest MakeRequest(ColumnProfile profile, int fileCount = 3)
+        private static FileGenerationRequest MakeRequest(ColumnProfile profile, int fileCount = 3, int? custodianCountOverride = null)
         {
             return new FileGenerationRequest
             {
                 Output = new OutputConfig { FileCount = fileCount, FileType = "pdf" },
-                Metadata = new MetadataConfig { ColumnProfile = profile, Seed = 42 },
+                Metadata = new MetadataConfig { ColumnProfile = profile, Seed = 42, CustodianCountOverride = custodianCountOverride },
                 LoadFile = new LoadFileConfig { Encoding = "UTF-8" },
                 Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
             };
@@ -94,6 +94,53 @@ namespace Zipper
 
             // \u00fe inside the field value must be doubled to \u00fe\u00fe per Concordance escaping
             Assert.Contains("val\u00fe\u00feSpecial", content);
+        }
+
+        /// <summary>
+        /// When CustodianCountOverride is set on the request, ProfileDrivenDatWriter
+        /// must pass it to DataGenerator so custodian values are bounded to that count.
+        /// </summary>
+        [Fact]
+        public async Task WriteAsync_WithCustodianCountOverride_LimitsCustodianValuesToOverrideCount()
+        {
+            // Standard profile has 25 custodians; we override to 2
+            var profile = BuiltInProfiles.Standard;
+            var request = MakeRequest(profile, fileCount: 200, custodianCountOverride: 2);
+            var content = await CaptureOutputAsync(request);
+
+            // Parse CUSTODIAN column values from all data rows
+            var lines = content.Split('\r', '\n', StringSplitOptions.RemoveEmptyEntries);
+            var headerLine = lines[0];
+            var colDelim = '\u0014';
+            var quote = '\u00fe';
+            var headers = headerLine.Split(colDelim)
+                .Select(h => h.Trim(quote))
+                .ToList();
+            var custodianIdx = headers.IndexOf("CUSTODIAN");
+            Assert.True(custodianIdx >= 0, "CUSTODIAN column not found in profile output");
+
+            var custodianValues = new HashSet<string>();
+            foreach (var line in lines.Skip(1))
+            {
+                var fields = line.Split(colDelim);
+                if (custodianIdx < fields.Length)
+                {
+                    var val = fields[custodianIdx].Trim(quote);
+                    if (!string.IsNullOrEmpty(val))
+                    {
+                        custodianValues.Add(val);
+                    }
+                }
+            }
+
+            // With override=2, must only see Custodian_1 and/or Custodian_2
+            Assert.True(
+                custodianValues.Count <= 2,
+                $"Expected at most 2 distinct custodians but found {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+            foreach (var v in custodianValues)
+            {
+                Assert.Matches(@"^Custodian_[12]$", v);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #349. When `--custodian-count` was combined with `--column-profile`, the override was silently ignored. `ProfileDrivenDatWriter` constructed `DataGenerator` without forwarding `CustodianCountOverride` from the request metadata — so only the legacy `DatWriter` path respected the flag.

## Root Cause

`ProfileDrivenDatWriter.cs:35` called `new DataGenerator(profile, request.Metadata.Seed)` without the custodian count argument.

## Changes

### `src/Profiles/DataGenerator.cs`
- Added optional `custodianCountOverride` parameter to constructor
- Added `private const string CustodianDataSourceName = "custodians"` (extracted magic string)
- Added `ApplyCustodianCountOverride` which creates a modified copy of the profile's `custodians` data source:
  - **Count-based sources** (all built-in profiles): replaces `Count` with the override value
  - **Values-based sources** (custom profiles with static lists): truncates the `Values` list to the override count

### `src/LoadFiles/ProfileDrivenDatWriter.cs`
- Forwards `request.Metadata.CustodianCountOverride` to `DataGenerator`

## Tests Added

| Test | Coverage |
|------|----------|
| `GenerateRow_WithCustodianCountOverride_LimitsDistinctCustodians` | Count-based source: 25→3, verifies upper and lower bounds |
| `GenerateRow_WithCustodianCountOverride_NoCustodiansDataSource_NoOp` | No-op when profile has no custodians source |
| `GenerateRow_WithCustodianCountOverride_ValuesBasedSource_TruncatesToOverrideCount` | Static Values list truncated to override count |
| `WriteAsync_WithCustodianCountOverride_LimitsCustodianValuesToOverrideCount` | End-to-end: override propagates through ProfileDrivenDatWriter |

## Acceptance Criteria

- [x] `DataGenerator` accepts optional custodian count override
- [x] `ProfileDrivenDatWriter` passes `request.Metadata.CustodianCount` to `DataGenerator`
- [x] Unit test verifies custodian count override with column profile

## Out of Scope (noted for follow-up)

- **`ProfileDrivenDatWriter` date pinning** (#HIGH-3 from review): `now` is not pinned when seeded, unlike `DatWriter`. Pre-existing issue, separate from this fix.
- **Pareto skew documentation at small counts**: expected behaviour, not a bug.
- **Format parity** (`"Custodian 1"` vs `"Custodian_1"`): pre-existing difference between legacy and profile modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custodian count override capability to control the number of distinct custodians in generated DAT files using profile-driven data generation

* **Tests**
  * Added test coverage validating custodian count override behavior with standard profiles, custom value-based sources, and profiles without custodian data sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->