### PR TITLE
fix(cli): enforce PathValidator directory traversal checks

### DIFF
--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -52,7 +52,13 @@ public static class CliParser
                 case "--output-path":
                     if (TryGetValue(args, i, out var pathArg))
                     {
-                        parsed.OutputDirectory = PathValidator.ValidateAndCreateDirectory(pathArg);
+                        var dir = PathValidator.ValidateAndCreateDirectory(pathArg, Path.IsPathRooted(pathArg) ? null : Directory.GetCurrentDirectory());
+                        if (dir == null)
+                        {
+                            return null;
+                        }
+
+                        parsed.OutputDirectory = dir;
                         i++;
                     }
                     else

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -192,5 +192,45 @@ namespace Zipper.Tests
             var result = CliParser.Parse(new[] { "--type", "--benchmark" });
             Assert.Null(result);
         }
+
+        /// <summary>
+        /// REQ-106: A relative path containing ".." that resolves outside CWD must be rejected by
+        /// the CLI layer. Before the fix, CliParser called ValidateAndCreateDirectory with no
+        /// baseDirectory, bypassing the traversal check entirely.
+        /// </summary>
+        [Fact]
+        public void Parse_OutputPathWithParentTraversal_RejectsPathOutsideCwd()
+        {
+            // "../escape" resolves to the parent of CWD — outside the allowed base directory.
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "../escape" });
+
+            // Parse must return null (error path) so the caller exits with a non-zero code.
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// REQ-106: A path that stays inside CWD must still be accepted after the fix.
+        /// Regression guard: adding the base-directory check must not block safe relative paths.
+        /// </summary>
+        [Fact]
+        public void Parse_OutputPathWithinCwd_IsAccepted()
+        {
+            var uniqueDirName = "output_" + Guid.NewGuid().ToString("N");
+            try
+            {
+                // uniqueDirName is a safe relative subdirectory of CWD and must be accepted.
+                var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", uniqueDirName });
+
+                Assert.NotNull(result);
+                Assert.NotNull(result!.OutputDirectory);
+            }
+            finally
+            {
+                if (Directory.Exists(uniqueDirName))
+                {
+                    Directory.Delete(uniqueDirName, recursive: true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

During functional testing, the path traversal validation described in **REQ-106** was found to be ineffective at the CLI layer.

## Root Cause

In `src/Cli/CliParser.cs`, the parsing logic for `--output-path` called `PathValidator.ValidateAndCreateDirectory` without passing a base directory. As a result, the directory traversal validation check was skipped entirely.

Furthermore, if the validation returned `null` due to a validation error, the CLI parser continued execution instead of failing and returning `null`.

## Fix

1. Pass the current working directory (`Directory.GetCurrentDirectory()`) as the base directory to `PathValidator.ValidateAndCreateDirectory` for relative paths, while allowing absolute (rooted) paths to resolve normally.
2. Terminate command parsing and return `null` immediately if the path validation fails (returns `null`), ensuring the CLI layer correctly rejects invalid paths.

## Verification Results

### Unit & Integration Tests

All 969 unit and integration tests (including the new TDD tests checking relative path directory traversal rejection and CWD safety) passed successfully:

```
Passed!  - Failed:     0, Passed:   969, Skipped:     0, Total:   969, Duration: 12 s - Zipper.Tests.dll (net8.0)
```

### Pre-Push Basic E2E Smoke Tests

All E2E scenarios completed successfully:

```
ran=13  failed=0  total=13
✓ All pre-push checks passed
```

Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `--output-path` handling for absolute and relative paths.

* **Tests**
  * Added validation tests for output path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->