### PR TITLE
fix: deterministic file hashes for target-zip-size under seed

### DIFF
--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -227,17 +227,27 @@ namespace Zipper
 
                 if (effectivePadding > 0)
                 {
-                    var padding = new byte[Math.Min(effectivePadding, 1024 * 1024)];
-                    RandomNumberGenerator.Fill(padding);
-
-                    int offset = fileContent.Length;
-                    long remaining = effectivePadding;
-                    while (remaining > 0)
+                    if (request.Metadata.Seed.HasValue)
                     {
-                        int toCopy = (int)Math.Min(remaining, padding.Length);
-                        Buffer.BlockCopy(padding, 0, data, offset, toCopy);
-                        offset += toCopy;
-                        remaining -= toCopy;
+                        var fileSeed = unchecked((int)(request.Metadata.Seed.Value + workItem.Index));
+                        var rng = new DeterministicPaddingRng(fileSeed);
+                        var paddingSpan = data.AsSpan(fileContent.Length, (int)effectivePadding);
+                        rng.Fill(paddingSpan);
+                    }
+                    else
+                    {
+                        var padding = new byte[Math.Min(effectivePadding, 1024 * 1024)];
+                        RandomNumberGenerator.Fill(padding);
+
+                        int offset = fileContent.Length;
+                        long remaining = effectivePadding;
+                        while (remaining > 0)
+                        {
+                            int toCopy = (int)Math.Min(remaining, padding.Length);
+                            Buffer.BlockCopy(padding, 0, data, offset, toCopy);
+                            offset += toCopy;
+                            remaining -= toCopy;
+                        }
                     }
                 }
 
@@ -265,7 +275,16 @@ namespace Zipper
                 if (effectivePadding > 0)
                 {
                     var paddingSpan = memoryOwner.Memory.Span.Slice(fileContent.Length, (int)effectivePadding);
-                    RandomNumberGenerator.Fill(paddingSpan);
+                    if (request.Metadata.Seed.HasValue)
+                    {
+                        var fileSeed = unchecked((int)(request.Metadata.Seed.Value + workItem.Index));
+                        var rng = new DeterministicPaddingRng(fileSeed);
+                        rng.Fill(paddingSpan);
+                    }
+                    else
+                    {
+                        RandomNumberGenerator.Fill(paddingSpan);
+                    }
                 }
 
                 var finalMemory = memoryOwner.Memory[..(int)totalSize];
@@ -325,6 +344,32 @@ namespace Zipper
             if (ex is not null)
             {
                 ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+        }
+
+        private struct DeterministicPaddingRng
+        {
+            private uint state;
+
+            public DeterministicPaddingRng(int seed)
+            {
+                // Use a mixer to avoid poor randomness if seed is small
+                uint s = (uint)seed;
+                s ^= s >> 16;
+                s *= 0x7feb352dU;
+                s ^= s >> 15;
+                s *= 0x846ca68bU;
+                s ^= s >> 16;
+                this.state = s == 0 ? 0x12345678U : s;
+            }
+
+            public void Fill(Span<byte> buffer)
+            {
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    this.state = unchecked((this.state * 1664525U) + 1013904223U);
+                    buffer[i] = (byte)(this.state >> 24);
+                }
             }
         }
     }

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -608,7 +608,15 @@ namespace Zipper
             var fileData1 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
             var fileData2 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
 
-            Assert.Equal(fileData1.Hash, fileData2.Hash);
+            try
+            {
+                Assert.Equal(fileData1.Hash, fileData2.Hash);
+            }
+            finally
+            {
+                fileData1.MemoryOwner?.Dispose();
+                fileData2.MemoryOwner?.Dispose();
+            }
         }
 
         [Fact]
@@ -635,7 +643,15 @@ namespace Zipper
             var fileData1 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
             var fileData2 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
 
-            Assert.Equal(fileData1.Hash, fileData2.Hash);
+            try
+            {
+                Assert.Equal(fileData1.Hash, fileData2.Hash);
+            }
+            finally
+            {
+                fileData1.MemoryOwner?.Dispose();
+                fileData2.MemoryOwner?.Dispose();
+            }
         }
     }
 }

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -583,5 +583,59 @@ namespace Zipper
             Assert.False(fileData.Data.IsEmpty);
             Assert.Equal(fileData.DataLength, fileData.Data.Length);
         }
+
+        [Fact]
+        public void GenerateFileData_WithSeedAndTargetZipSize_PooledPath_ProducesDeterministicHash()
+        {
+            var generator = new ParallelFileGenerator();
+            var workItem = new FileWorkItem { Index = 1 };
+            var paddingPerFile = 1000; // Small padding -> pooled path
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = "dummy",
+                    FileType = "docx",
+                    FileCount = 1,
+                },
+                Metadata = new MetadataConfig
+                {
+                    Seed = 42
+                }
+            };
+            var fileGenerator = new OfficeFileGenerator("docx");
+
+            var fileData1 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+            var fileData2 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+
+            Assert.Equal(fileData1.Hash, fileData2.Hash);
+        }
+
+        [Fact]
+        public void GenerateFileData_WithSeedAndTargetZipSize_NonPooledPath_ProducesDeterministicHash()
+        {
+            var generator = new ParallelFileGenerator();
+            var workItem = new FileWorkItem { Index = 1 };
+            var paddingPerFile = PerformanceConstants.MaxPaddingPerFile; // Max padding -> non-pooled path
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = "dummy",
+                    FileType = "docx",
+                    FileCount = 1,
+                },
+                Metadata = new MetadataConfig
+                {
+                    Seed = 42
+                }
+            };
+            var fileGenerator = new OfficeFileGenerator("docx");
+
+            var fileData1 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+            var fileData2 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+
+            Assert.Equal(fileData1.Hash, fileData2.Hash);
+        }
     }
 }

--- a/src/Zipper.Tests/ProgramTests.cs
+++ b/src/Zipper.Tests/ProgramTests.cs
@@ -253,5 +253,97 @@ namespace Zipper
                 }
             }
         }
+
+        [Fact]
+        public async Task Main_WithSeedAndTargetZipSize_ProducesIdenticalOutputAndHashes()
+        {
+            // Arrange
+            string tempPath1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            try
+            {
+                string[] args1 =
+                {
+                    "--output-path", tempPath1,
+                    "--count", "5",
+                    "--type", "pdf",
+                    "--seed", "123",
+                    "--target-zip-size", "1MB",
+                    "--with-metadata"
+                };
+
+                string[] args2 =
+                {
+                    "--output-path", tempPath2,
+                    "--count", "5",
+                    "--type", "pdf",
+                    "--seed", "123",
+                    "--target-zip-size", "1MB",
+                    "--with-metadata"
+                };
+
+                // Act
+                int exitCode1 = await RunWithRedirectedConsole(() => Program.Main(args1));
+                int exitCode2 = await RunWithRedirectedConsole(() => Program.Main(args2));
+
+                // Assert
+                Assert.Equal(0, exitCode1);
+                Assert.Equal(0, exitCode2);
+
+                // Find the load file in both outputs
+                var datFile1 = Directory.GetFiles(tempPath1, "*.dat").FirstOrDefault();
+                var datFile2 = Directory.GetFiles(tempPath2, "*.dat").FirstOrDefault();
+
+                Assert.NotNull(datFile1);
+                Assert.NotNull(datFile2);
+
+                var content1 = await File.ReadAllTextAsync(datFile1);
+                var content2 = await File.ReadAllTextAsync(datFile2);
+
+                // Entire load file contents must be identical, including columns
+                Assert.Equal(content1, content2);
+
+                var zipFile1 = Directory.GetFiles(tempPath1, "*.zip").FirstOrDefault();
+                var zipFile2 = Directory.GetFiles(tempPath2, "*.zip").FirstOrDefault();
+
+                Assert.NotNull(zipFile1);
+                Assert.NotNull(zipFile2);
+
+                using (var archive1 = System.IO.Compression.ZipFile.OpenRead(zipFile1))
+                using (var archive2 = System.IO.Compression.ZipFile.OpenRead(zipFile2))
+                {
+                    Assert.Equal(archive1.Entries.Count, archive2.Entries.Count);
+                    for (int i = 0; i < archive1.Entries.Count; i++)
+                    {
+                        var entry1 = archive1.Entries[i];
+                        var entry2 = archive2.Entries[i];
+
+                        Assert.Equal(entry1.FullName, entry2.FullName);
+                        Assert.Equal(entry1.Length, entry2.Length);
+
+                        using var stream1 = entry1.Open();
+                        using var stream2 = entry2.Open();
+
+                        var hash1 = System.Security.Cryptography.MD5.HashData(stream1);
+                        var hash2 = System.Security.Cryptography.MD5.HashData(stream2);
+
+                        Assert.Equal(hash1, hash2);
+                    }
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(tempPath1))
+                {
+                    Directory.Delete(tempPath1, true);
+                }
+
+                if (Directory.Exists(tempPath2))
+                {
+                    Directory.Delete(tempPath2, true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the non-determinism of MD5/SHA file hashes when `--seed` and `--target-zip-size` are set simultaneously by introducing a stack-allocated, zero-allocation custom `DeterministicPaddingRng` pseudo-random generator.
- Replaces the use of the unseeded cryptographically strong `RandomNumberGenerator.Fill` (which is inherently non-deterministic) with `DeterministicPaddingRng.Fill` seeded on a compound seed value of `(seed + Index)` for each file.
- Standardizes both the pooled and non-pooled buffer padding paths to generate identical padding byte streams, removing divergent compressibility profiles.
- Optimizes the non-pooled path to write directly to sliced spans, eliminating redundant 1MB heap allocations and copying loops.
- Adds regression unit and integration tests confirming deterministic hashing across runs.

## Test Plan
- Run unit and integration tests: `dotnet test src/Zipper.Tests/Zipper.Tests.csproj`
- Run E2E verification: `./tests/run-tests.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deterministic file generation when using a seed value in metadata, enabling reproducible output across multiple runs with identical results.

* **Tests**
  * Added unit tests verifying deterministic hash generation with seeds in both memory pooling scenarios.
  * Added integration tests validating that identical outputs are produced when running with the same seed and configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->