### PR TITLE
fix: resolve PrecomputeIndices weighted distribution bias when weights.Count > values.Count

### DIFF
--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -214,6 +214,8 @@ internal class DataGenerator
                     }
                 }
 
+                // Defensive fallback: unreachable since the 'r' < 'total' check is guaranteed to be satisfied within the cumulative loop range,
+                // making 'assigned' always true when 'count' > 0. Intentionally retained as a safety net for 'indices' robustness.
                 if (!assigned && count > 0)
                 {
                     indices[i] = count - 1;

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -64,14 +64,14 @@ internal class DataGenerator
         }
         else
         {
-            // Generated names (Count + Prefix): replace the count
+            // Generated names (Count + Prefix): replace the count and truncate weights to match
             overriddenSource = new DataSourceConfig
             {
                 Count = effectiveCount,
                 Distribution = custodianSource.Distribution,
                 Prefix = custodianSource.Prefix,
                 Values = null,
-                Weights = custodianSource.Weights,
+                Weights = custodianSource.Weights?.Take(effectiveCount).ToList(),
             };
         }
 
@@ -187,7 +187,7 @@ internal class DataGenerator
         var indices = new int[1000];
         if (cfg.Distribution == "weighted" && cfg.Weights?.Count > 0)
         {
-            var total = cfg.Weights.Sum();
+            var total = cfg.Weights.Take(count).Sum();
             if (total <= 0)
             {
                 for (int i = 0; i < 1000; i++)

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -364,10 +364,10 @@ public class DataGeneratorTests
     }
 
     /// <summary>
-    /// Test that when weight count exceeds values count, the precomputed indices do not silently bias to 0.
+    /// Test that when weight count exceeds values count, the distribution is proportional to the values' weights.
     /// </summary>
     [Fact]
-    public void PrecomputeIndices_WeightsCountExceedingValuesCount_DoesNotBiasToIndexZero()
+    public void GenerateRow_WeightsCountExceedingValuesCount_ShouldDistributeProportionally()
     {
         // Arrange
         var profile = new ColumnProfile
@@ -412,10 +412,12 @@ public class DataGeneratorTests
             }
         }
 
-        // Without the fix, "A" is heavily biased (approx 99%) because all out-of-bounds fallbacks default to 0 ("A").
-        // With the fix, out-of-bounds fallbacks are mapped to count - 1 ("B"), so "B" should dominate (~99%).
-        Assert.True(bCount > aCount, $"Expected B count ({bCount}) to be greater than A count ({aCount}) due to fallback to index 1.");
-        Assert.True(bCount > sampleSize * 0.9, $"Expected B count ({bCount}) to be close to 99% of sample size ({sampleSize}).");
+        // With the fix, we ignore the extra weight (100) and only use the first two weights (1, 1).
+        // This should result in a 50/50 proportional distribution between A and B, within a standard tolerance.
+        double aPercent = (double)aCount / sampleSize * 100;
+        double bPercent = (double)bCount / sampleSize * 100;
+        Assert.InRange(aPercent, 45.0, 55.0);
+        Assert.InRange(bPercent, 45.0, 55.0);
     }
 
     /// <summary>
@@ -581,5 +583,65 @@ public class DataGeneratorTests
         {
             Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value after weight truncation: {v}");
         }
+    }
+
+    /// <summary>
+    /// Test that when custodianCountOverride is applied to a weighted, generated-names source,
+    /// the weights are correctly truncated and the output is distributed proportionally among remaining options.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WithCustodianCountOverride_WeightedGeneratedSource_ShouldDistributeProportionally()
+    {
+        // Arrange
+        var profile = new ColumnProfile
+        {
+            Name = "generated-weighted-custodians",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            DataSources = new Dictionary<string, DataSourceConfig>
+            {
+                ["custodians"] = new DataSourceConfig
+                {
+                    Count = 5,
+                    Prefix = "Cust_",
+                    Weights = new List<int> { 1, 1, 100, 100, 100 }, // 5 weights
+                    Distribution = "weighted",
+                },
+            },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+                new() { Name = "CUSTODIAN", Type = "coded", DataSource = "custodians", EmptyPercentage = 0 },
+            },
+        };
+
+        // Override count to 2. This leaves us with Cust_1 (weight 1) and Cust_2 (weight 1).
+        // The remaining weights (100, 100, 100) must be ignored / truncated.
+        var generator = new DataGenerator(profile, seed: 12345, custodianCountOverride: 2);
+        int sampleSize = 1000;
+        int cust1Count = 0;
+        int cust2Count = 0;
+
+        for (int i = 1; i <= sampleSize; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"Folder/doc{i}.pdf" };
+            var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            var value = row["CUSTODIAN"];
+            if (value == "Cust_1")
+            {
+                cust1Count++;
+            }
+            else if (value == "Cust_2")
+            {
+                cust2Count++;
+            }
+        }
+
+        // Output should be ~50% Cust_1 and ~50% Cust_2.
+        double cust1Percent = (double)cust1Count / sampleSize * 100;
+        double cust2Percent = (double)cust2Count / sampleSize * 100;
+        Assert.InRange(cust1Percent, 45.0, 55.0);
+        Assert.InRange(cust2Percent, 45.0, 55.0);
     }
 }


### PR DESCRIPTION
## Summary

Resolves #402.

- Updated `DataGenerator.PrecomputeIndices` to calculate the total weights using `cfg.Weights.Take(count).Sum()` rather than summing all weights. This ensures that the random index falls within the valid bounds of the active subset of weights corresponding to the value list, avoiding fallback index-out-of-bounds mapping bias.
- Retained `ColumnProfileLoader` validation as a defense-in-depth measure.
- Truncated `Weights` to `effectiveCount` for generated-names custodian sources in `ApplyCustodianCountOverride` to prevent inconsistent config objects when `custodianCountOverride` is applied.
- Updated `PrecomputeIndices_WeightsCountExceedingValuesCount_DoesNotBiasToIndexZero` to `GenerateRow_WeightsCountExceedingValuesCount_ShouldDistributeProportionally` in `DataGeneratorTests.cs` and asserted proportional distribution instead of last-index fallback bias.
- Added a new unit test `GenerateRow_WithCustodianCountOverride_WeightedGeneratedSource_ShouldDistributeProportionally` in `DataGeneratorTests.cs` to cover the actual integration path of overridden generated-names custodian sources.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Done

- [x] Unit tests added and verified in `DataGeneratorTests.cs`
- [x] All 973 unit tests passed
- [x] E2E integration tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight distribution calculations for custodian selection when custodian count is overridden, ensuring random selection probabilities accurately reflect the active custodian set.
  * Updated test coverage to validate proportional distribution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->