### PR TITLE
feat: auto-generate OPT file alongside DAT for tiff/jpg (REQ-057)

### DIFF
--- a/src/LoadFiles/DatWriter.cs
+++ b/src/LoadFiles/DatWriter.cs
@@ -203,7 +203,9 @@ internal class DatWriter : LoadFileWriterBase
         for (long i = 1; i <= request.Output.FileCount; i++)
         {
             long lineNumber = i + 1;
-            string recordId = $"DOC{i:D8}";
+            string recordId = request.Bates != null
+                ? BatesNumberGenerator.Generate(request.Bates, i - 1)
+                : $"DOC{i:D8}";
             var line = BuildLoadfileOnlyRow(i, recordId, colDelim, quote, hasQuote, now, random);
 
             string interceptedLine = ApplyChaosInterception(chaosEngine, lineNumber, line, recordId);

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -153,7 +153,9 @@ internal class OptWriter : LoadFileWriterBase
 
         for (long i = 1; i <= request.Output.FileCount; i++)
         {
-            string batesId = $"IMG{i:D8}";
+            string batesId = request.Bates != null
+                ? BatesNumberGenerator.Generate(request.Bates, i - 1)
+                : $"IMG{i:D8}";
             string volume = "VOL001";
             string imagePath = $"IMAGES\\{batesId}.tif";
             int pageCount = random.Next(1, 11);

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -23,88 +23,106 @@ internal static class LoadfileOnlyGenerator
         Directory.CreateDirectory(request.Output.OutputPath);
 
         var baseFileName = $"loadfile_{DateTime.Now:yyyyMMdd_HHmmss}";
-        var extension = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? ".opt" : ".dat";
-        var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
 
-        var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.Delimiters.EndOfLine);
-        long totalLines = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt
-            ? request.Output.FileCount
-            : request.Output.FileCount + 1;
+        var formatsToGenerate = request.LoadFile.LoadFileFormats?.Any() == true
+            ? request.LoadFile.LoadFileFormats
+            : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
 
-        ChaosEngine? chaosEngine = null;
-        if (request.Chaos.ChaosMode)
+        string primaryLoadFilePath = string.Empty;
+        string primaryPropertiesPath = string.Empty;
+
+        foreach (var format in formatsToGenerate)
         {
-            string? resolvedTypes = request.Chaos.ChaosTypes;
-            string? resolvedAmount = request.Chaos.ChaosAmount;
+            var extension = format == LoadFileFormat.Opt ? ".opt" : ".dat";
+            var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
 
-            if (!string.IsNullOrEmpty(request.Chaos.ChaosScenario))
+            var eolString = LoadFiles.LoadFileWriterBase.GetEolString(request.Delimiters.EndOfLine);
+            long totalLines = format == LoadFileFormat.Opt
+                ? request.Output.FileCount
+                : request.Output.FileCount + 1;
+
+            ChaosEngine? chaosEngine = null;
+            if (request.Chaos.ChaosMode)
             {
-                var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
-                if (scenario != null)
+                string? resolvedTypes = request.Chaos.ChaosTypes;
+                string? resolvedAmount = request.Chaos.ChaosAmount;
+
+                if (!string.IsNullOrEmpty(request.Chaos.ChaosScenario))
                 {
-                    resolvedTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes;
-                    if (string.IsNullOrEmpty(resolvedAmount))
+                    var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
+                    if (scenario != null)
                     {
-                        resolvedAmount = scenario.DefaultAmount;
+                        resolvedTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes;
+                        if (string.IsNullOrEmpty(resolvedAmount))
+                        {
+                            resolvedAmount = scenario.DefaultAmount;
+                        }
+
+                        request.Chaos = request.Chaos with { ChaosAmount = resolvedAmount };
+                        request.Chaos = request.Chaos with { ChaosTypes = resolvedTypes };
+
+                        Console.WriteLine(string.Format("  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
                     }
-
-                    request.Chaos = request.Chaos with { ChaosAmount = resolvedAmount };
-                    request.Chaos = request.Chaos with { ChaosTypes = resolvedTypes };
-
-                    Console.WriteLine(string.Format("  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
                 }
+
+                string chaosColDelim = format == LoadFileFormat.Opt ? "," : request.Delimiters.ColumnDelimiter;
+                string chaosQuoteDelim = format == LoadFileFormat.Opt ? string.Empty : request.Delimiters.QuoteDelimiter;
+
+                chaosEngine = new ChaosEngine(
+                    totalLines,
+                    resolvedAmount,
+                    resolvedTypes,
+                    format,
+                    chaosColDelim,
+                    chaosQuoteDelim,
+                    eolString,
+                    request.Metadata.Seed);
             }
 
-            string chaosColDelim = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? "," : request.Delimiters.ColumnDelimiter;
-            string chaosQuoteDelim = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt ? string.Empty : request.Delimiters.QuoteDelimiter;
+            ILoadFileWriter writer = format == LoadFileFormat.Opt
+                ? LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, WriterMode.LoadfileOnly)
+                : request.Metadata.ColumnProfile != null
+                    ? new ProfileDrivenDatWriter()
+                    : LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, WriterMode.LoadfileOnly);
 
-            chaosEngine = new ChaosEngine(
-                totalLines,
-                resolvedAmount,
-                resolvedTypes,
-                request.LoadFile.LoadFileFormat,
-                chaosColDelim,
-                chaosQuoteDelim,
-                eolString,
-                request.Metadata.Seed);
-        }
-
-        ILoadFileWriter writer = request.LoadFile.LoadFileFormat == LoadFileFormat.Opt
-            ? LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, WriterMode.LoadfileOnly)
-            : request.Metadata.ColumnProfile != null
-                ? new ProfileDrivenDatWriter()
-                : LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, WriterMode.LoadfileOnly);
-
-        await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
-        {
-            await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine);
-        }
-
-        string propertiesPath;
-        try
-        {
-            propertiesPath = await LoadfileAuditWriter.WriteAsync(
-                loadFilePath,
-                request,
-                request.Output.FileCount,
-                chaosEngine?.Anomalies);
-        }
-        catch
-        {
-            if (File.Exists(loadFilePath))
+            await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
             {
-                File.Delete(loadFilePath);
+                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine);
             }
 
-            throw;
+            string propertiesPath;
+            try
+            {
+                propertiesPath = await LoadfileAuditWriter.WriteAsync(
+                    loadFilePath,
+                    request,
+                    request.Output.FileCount,
+                    chaosEngine?.Anomalies,
+                    format);
+            }
+            catch
+            {
+                if (File.Exists(loadFilePath))
+                {
+                    File.Delete(loadFilePath);
+                }
+
+                throw;
+            }
+
+            if (format == request.LoadFile.LoadFileFormat || string.IsNullOrEmpty(primaryLoadFilePath))
+            {
+                primaryLoadFilePath = loadFilePath;
+                primaryPropertiesPath = propertiesPath;
+            }
         }
 
         stopwatch.Stop();
 
         return new LoadfileOnlyResult
         {
-            LoadFilePath = loadFilePath,
-            PropertiesFilePath = propertiesPath,
+            LoadFilePath = primaryLoadFilePath,
+            PropertiesFilePath = primaryPropertiesPath,
             TotalRecords = request.Output.FileCount,
             GenerationTime = stopwatch.Elapsed,
         };

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -456,6 +456,123 @@ namespace Zipper
             Assert.True(assertionStream.PeakMemoryUsage < 30 * 1024 * 1024, $"Peak memory usage {assertionStream.PeakMemoryUsage} bytes exceeded the 30MB streaming limit.");
         }
 
+        [Fact]
+        public async Task GenerateAsync_TiffAndJpgWithoutExplicitFormat_CreatesBothDatAndOpt()
+        {
+            // TIFF
+            var tiffRequest = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = this.tempDir,
+                    FileCount = 5,
+                    FileType = "tiff",
+                },
+                LoadFile = new LoadFileConfig
+                {
+                    LoadFileFormat = LoadFileFormat.Dat,
+                    LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
+                    Encoding = "UTF-8",
+                },
+                Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
+                Metadata = new MetadataConfig { Seed = 42 },
+                LoadfileOnly = true,
+            };
+
+            var tiffResult = await LoadfileOnlyGenerator.GenerateAsync(tiffRequest);
+
+            var datFiles = Directory.GetFiles(this.tempDir, "*.dat");
+            var optFiles = Directory.GetFiles(this.tempDir, "*.opt");
+
+            Assert.Single(datFiles);
+            Assert.Single(optFiles);
+
+            // Delete all files in tempDir
+            foreach (var f in Directory.GetFiles(this.tempDir))
+            {
+                File.Delete(f);
+            }
+
+            // JPG
+            var jpgRequest = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = this.tempDir,
+                    FileCount = 5,
+                    FileType = "jpg",
+                },
+                LoadFile = new LoadFileConfig
+                {
+                    LoadFileFormat = LoadFileFormat.Dat,
+                    LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
+                    Encoding = "UTF-8",
+                },
+                Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
+                Metadata = new MetadataConfig { Seed = 42 },
+                LoadfileOnly = true,
+            };
+
+            var jpgResult = await LoadfileOnlyGenerator.GenerateAsync(jpgRequest);
+
+            datFiles = Directory.GetFiles(this.tempDir, "*.dat");
+            optFiles = Directory.GetFiles(this.tempDir, "*.opt");
+
+            Assert.Single(datFiles);
+            Assert.Single(optFiles);
+        }
+
+        [Fact]
+        public async Task GenerateAsync_TiffWithBates_ProducesCorrectPageSuffixes()
+        {
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = this.tempDir,
+                    FileCount = 2,
+                    FileType = "tiff",
+                },
+                LoadFile = new LoadFileConfig
+                {
+                    LoadFileFormat = LoadFileFormat.Opt,
+                    Encoding = "UTF-8",
+                },
+                Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
+                Metadata = new MetadataConfig { Seed = 42 },
+                Bates = new BatesNumberConfig
+                {
+                    Prefix = "ABC001_",
+                    Start = 1,
+                    Digits = 5,
+                },
+                LoadfileOnly = true,
+            };
+
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+
+            Assert.True(File.Exists(result.LoadFilePath));
+            var lines = await File.ReadAllLinesAsync(result.LoadFilePath);
+
+            // Verify first page of first document
+            var parts1 = lines[0].Split(',');
+            Assert.StartsWith("ABC001_00001", parts1[0]);
+            if (parts1[0].Contains("_"))
+            {
+                Assert.Equal("ABC001_00001_001", parts1[0]);
+            }
+
+            Assert.Equal("Y", parts1[3]); // doc break
+
+            // If there's a second page for first document, verify no doc break
+            if (lines.Length > 1 && lines[1].StartsWith("ABC001_00001"))
+            {
+                var parts2 = lines[1].Split(',');
+                Assert.Equal("ABC001_00001_002", parts2[0]);
+                Assert.Equal(string.Empty, parts2[3]); // no doc break
+            }
+        }
+
         private class StreamingAssertionStream : Stream
         {
             private readonly Stream inner;

--- a/tests/test-load-file-formats.bat
+++ b/tests/test-load-file-formats.bat
@@ -312,6 +312,76 @@ if errorlevel 1 (
 
 echo [ SUCCESS ] Test Case 9: Delimiter override passed
 
+:: --- Test Case 10: Auto OPT generation for tiff/jpg types ---
+
+echo [ INFO ] Test Case 10: Auto OPT generation for tiff and jpg
+
+:: Run for tiff in loadfile-only mode
+%ZIPPER_CMD% ^
+  --type tiff ^
+  --count 3 ^
+  --output-path "%TEST_OUTPUT_DIR%\test10_tiff" ^
+  --loadfile-only ^
+  --bates-prefix "TIFF" ^
+  --bates-start 1 ^
+  --bates-digits 5
+
+if errorlevel 1 (
+  echo [ ERROR ] Test 10 failed during execution for tiff
+  exit /b 1
+)
+
+dir /b /s "%TEST_OUTPUT_DIR%\test10_tiff\*.dat" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: No .dat file found for tiff
+  exit /b 1
+)
+
+dir /b /s "%TEST_OUTPUT_DIR%\test10_tiff\*.opt" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: No .opt file found for tiff
+  exit /b 1
+)
+
+:: Verify Bates prefix in OPT
+for %%f in ("%TEST_OUTPUT_DIR%\test10_tiff\*.opt") do set OPT_FILE=%%f
+findstr /C:"TIFF00001" "!OPT_FILE!" >nul
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: Base Bates number 'TIFF00001' not found in tiff OPT file
+  exit /b 1
+)
+
+:: Run for jpg in standard mode
+%ZIPPER_CMD% ^
+  --type jpg ^
+  --count 3 ^
+  --output-path "%TEST_OUTPUT_DIR%\test10_jpg"
+
+if errorlevel 1 (
+  echo [ ERROR ] Test 10 failed during execution for jpg
+  exit /b 1
+)
+
+dir /b /s "%TEST_OUTPUT_DIR%\test10_jpg\*.zip" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: No .zip file found for jpg
+  exit /b 1
+)
+
+dir /b /s "%TEST_OUTPUT_DIR%\test10_jpg\*.dat" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: No .dat file found for jpg
+  exit /b 1
+)
+
+dir /b /s "%TEST_OUTPUT_DIR%\test10_jpg\*.opt" >nul 2>&1
+if errorlevel 1 (
+  echo [ ERROR ] Test 10: No .opt file found for jpg
+  exit /b 1
+)
+
+echo [ SUCCESS ] Test Case 10: Auto OPT generation passed
+
 :: --- All Tests Passed ---
 
 echo [ SUCCESS ] All Load File Formats E2E tests passed!

--- a/tests/test-load-file-formats.sh
+++ b/tests/test-load-file-formats.sh
@@ -371,6 +371,57 @@ fi
 
 print_success "Test Case 9: Delimiter override passed"
 
+# --- Test Case 10: Auto OPT generation for tiff/jpg types ---
+
+print_info "Test Case 10: Auto OPT generation for tiff and jpg"
+
+# Run for tiff in loadfile-only mode
+zipper \
+  --type tiff \
+  --count 3 \
+  --output-path "$TEST_OUTPUT_DIR/test10_tiff" \
+  --loadfile-only \
+  --bates-prefix "TIFF" \
+  --bates-start 1 \
+  --bates-digits 5
+
+dat_file=$(find "$TEST_OUTPUT_DIR/test10_tiff" -name "*.dat" -print -quit)
+opt_file=$(find "$TEST_OUTPUT_DIR/test10_tiff" -name "*.opt" -print -quit)
+
+if [[ -z "$dat_file" ]]; then
+  print_error "Test 10: No .dat file found for tiff"
+fi
+if [[ -z "$opt_file" ]]; then
+  print_error "Test 10: No .opt file found for tiff"
+fi
+
+# Verify Bates prefix and suffixes in OPT
+if ! grep -q "TIFF00001" "$opt_file"; then
+  print_error "Test 10: Base Bates number 'TIFF00001' not found in tiff OPT file"
+fi
+
+# Run for jpg in standard mode
+zipper \
+  --type jpg \
+  --count 3 \
+  --output-path "$TEST_OUTPUT_DIR/test10_jpg"
+
+zip_file=$(find "$TEST_OUTPUT_DIR/test10_jpg" -name "*.zip" -print -quit)
+dat_file=$(find "$TEST_OUTPUT_DIR/test10_jpg" -name "*.dat" -print -quit)
+opt_file=$(find "$TEST_OUTPUT_DIR/test10_jpg" -name "*.opt" -print -quit)
+
+if [[ -z "$zip_file" ]]; then
+  print_error "Test 10: No .zip file found for jpg"
+fi
+if [[ -z "$dat_file" ]]; then
+  print_error "Test 10: No .dat file found for jpg"
+fi
+if [[ -z "$opt_file" ]]; then
+  print_error "Test 10: No .opt file found for jpg"
+fi
+
+print_success "Test Case 10: Auto OPT generation passed"
+
 # --- All Tests Passed ---
 
 print_success "All Load File Formats E2E tests passed!"


### PR DESCRIPTION
This PR implements GitHub issue #334, resolving REQ-057 and REQ-058. Closes #334

### Key Changes:
1. **Multi-Format Generation in Loadfile-Only Mode**: Refactored [LoadfileOnlyGenerator](file:///home/dom/Downloads/repos/zipper/.worktrees/issue-334/src/LoadfileOnlyGenerator.cs) to process and generate all formats specified in `LoadFileFormats` (similar to standard mode).
2. **Bates Support in Standalone Loadfiles**: Updated [OptWriter](file:///home/dom/Downloads/repos/zipper/.worktrees/issue-334/src/LoadFiles/OptWriter.cs) and [DatWriter](file:///home/dom/Downloads/repos/zipper/.worktrees/issue-334/src/LoadFiles/DatWriter.cs) loadfile-only row builders to respect the Bates prefix, start, and digits configurations when generating control numbers.
3. **Tests**: Added target unit tests in [LoadfileOnlyGeneratorTests](file:///home/dom/Downloads/repos/zipper/.worktrees/issue-334/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs) and a new E2E Test Case 10 in E2E validation scripts for both Linux and Windows. All tests build and pass successfully.