### PR TITLE
ci: harden workflows — SHA-pin, fix no-op pkg check, dedup, perf methodology (#397)

### DIFF
--- a/.github/actions/coverage-gate/action.yml
+++ b/.github/actions/coverage-gate/action.yml
@@ -1,0 +1,35 @@
+name: Coverage gate
+description: >
+  Restore reportgenerator (cached), build the coverage report from the
+  cobertura output under TestResults/, and enforce the 80% line-coverage gate.
+  Shared by pr.yml and build-and-test.yml (#397). Assumes a prior step already
+  produced TestResults/*/coverage.cobertura.xml.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache reportgenerator tool
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        # dotnet tool restore installs into the per-repo tool home.
+        path: .dotnet-tools
+        key: ${{ runner.os }}-reportgen-${{ hashFiles('.config/dotnet-tools.json') }}
+        restore-keys: ${{ runner.os }}-reportgen-
+
+    - name: Coverage report + 80% gate
+      shell: bash
+      env:
+        DOTNET_CLI_HOME: ${{ github.workspace }}/.dotnet-tools
+      run: |
+        dotnet tool restore
+        dotnet reportgenerator \
+          -reports:TestResults/*/coverage.cobertura.xml \
+          -targetdir:TestResults/coverage-report \
+          -reporttypes:"Html;TextSummary"
+        cat TestResults/coverage-report/Summary.txt
+        COVERAGE=$(grep "Line coverage:" TestResults/coverage-report/Summary.txt | grep -oP '\d+(\.\d+)?%' | head -1 | sed 's/%//')
+        echo "Coverage: ${COVERAGE}%"
+        awk -v c="$COVERAGE" 'BEGIN { exit (c+0 < 80) ? 1 : 0 }' || {
+          echo "ERROR: coverage ${COVERAGE}% < 80%"
+          exit 1
+        }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - name: Set Version
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
           cache: true
@@ -79,9 +79,9 @@ jobs:
             platform: osx-arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
           cache: true
@@ -103,32 +103,9 @@ jobs:
             --collect:"XPlat Code Coverage" \
             --results-directory ./TestResults
 
-      - name: Cache reportgenerator tool (Linux)
-        if: runner.os == 'Linux'
-        uses: actions/cache@v5.0.5
-        with:
-          # dotnet tool restore installs into the per-repo tool home.
-          path: .dotnet-tools
-          key: ${{ runner.os }}-reportgen-${{ hashFiles('.config/dotnet-tools.json') }}
-          restore-keys: ${{ runner.os }}-reportgen-
-
       - name: Coverage report + 80% gate (Linux)
         if: runner.os == 'Linux'
-        env:
-          DOTNET_CLI_HOME: ${{ github.workspace }}/.dotnet-tools
-        run: |
-          dotnet tool restore
-          dotnet reportgenerator \
-            -reports:TestResults/*/coverage.cobertura.xml \
-            -targetdir:TestResults/coverage-report \
-            -reporttypes:"Html;TextSummary"
-          cat TestResults/coverage-report/Summary.txt
-          COVERAGE=$(grep "Line coverage:" TestResults/coverage-report/Summary.txt | grep -oP '\d+(\.\d+)?%' | head -1 | sed 's/%//')
-          echo "Coverage: ${COVERAGE}%"
-          awk -v c="$COVERAGE" 'BEGIN { exit (c+0 < 80) ? 1 : 0 }' || {
-            echo "ERROR: coverage ${COVERAGE}% < 80%"
-            exit 1
-          }
+        uses: ./.github/actions/coverage-gate
 
       - name: Unit tests (non-Linux)
         if: runner.os != 'Linux'
@@ -159,7 +136,7 @@ jobs:
             bash ./tests/run-tests.sh
           fi
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: zipper-${{ matrix.platform }}
           path: publish/${{ matrix.platform }}
@@ -173,11 +150,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 

--- a/.github/workflows/perf-baseline-refresh.yml
+++ b/.github/workflows/perf-baseline-refresh.yml
@@ -12,9 +12,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
 
@@ -53,8 +53,14 @@ jobs:
               rsss = [r[sc]["rss_kb"] for r in runs]
               results[sc] = {"wall_s": median(walls), "rss_kb": median(rsss)}
 
-          # Compare
-          wall_threshold = 1.25
+          # Compare.
+          # NOTE: wall_s on shared GitHub runners swings 15-40% run-to-run with
+          # no code change (rotating host CPUs, noisy neighbours), and baselines
+          # are captured on a *different* runner than each PR is measured on — so
+          # the wall ratio mixes hardware delta with code delta. It is reported
+          # for visibility but does NOT gate. rss_kb is stable across runners and
+          # remains the hard gate. (#397)
+          wall_threshold = 1.25  # informational only — does not fail the job
           rss_threshold = 1.20
           failed = False
           rows = []
@@ -66,9 +72,9 @@ jobs:
               mr = results[sc]["rss_kb"]
               rw = mw / bw if bw > 0 else 0
               rr = mr / br if br > 0 else 0
-              sw = "✅" if rw <= wall_threshold else "❌"
+              sw = "ℹ️" if rw <= wall_threshold else "⚠️"  # informational, never fails
               sr = "✅" if rr <= rss_threshold else "❌"
-              if rw > wall_threshold or rr > rss_threshold:
+              if rr > rss_threshold:
                   failed = True
               rows.append(f"| {sc} | wall_s | {bw:.2f} | {mw:.2f} | {rw:.2f}× | {sw} |")
               rows.append(f"| {sc} | rss_kb | {br} | {mr:.0f} | {rr:.2f}× | {sr} |")
@@ -95,14 +101,14 @@ jobs:
 
       - name: Upload measurement artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-measurements
           path: results/
 
       - name: Post PR comment
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const table = `${{ steps.compare.outputs.table }}`;
@@ -111,7 +117,8 @@ jobs:
               ? '## ❌ Performance Regression Detected'
               : '## ✅ Performance Guard Passed';
             const body = `${header}\n\n${table}\n\n` +
-              `_Thresholds: wall ≤ 1.25×, RSS ≤ 1.20× baseline. Median of 5 runs._`;
+              `_Gate: RSS ≤ 1.20× baseline (median of 5 runs). ` +
+              `wall_s is informational only — shared-runner timing is noise-dominated and not comparable across runners._`;
             const marker = '<!-- perf-guard-comment -->';
             const fullBody = `${marker}\n${body}`;
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       only_docs: ${{ steps.check.outputs.only_docs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - id: check
@@ -58,38 +58,19 @@ jobs:
             echo "only_docs=false" >> "$GITHUB_OUTPUT"
           fi
 
-  validate-agents-md:
-    needs: docs-only
-    if: needs.docs-only.outputs.only_docs != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5
-        with:
-          global-json-file: global.json
-          cache: true
-          cache-dependency-path: '**/packages.lock.json'
-      - name: Verify AGENTS.md commands work
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Validating commands documented in AGENTS.md..."
-          dotnet restore zipper.sln --locked-mode
-          dotnet build zipper.sln -c Release --no-restore
-          dotnet format --verify-no-changes --no-restore src/
-          dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --list-tests > /dev/null
-          echo "All AGENTS.md commands validated successfully."
-
+  # Note: the previously-separate `validate-agents-md` job was folded in (#397).
+  # Its checks (restore, build, format, test) are fully covered by `lint`
+  # (restore + format) and `build-and-test` (restore + build + test), so a
+  # dedicated job was redundant CI minutes.
   lint:
     needs: docs-only
     if: needs.docs-only.outputs.only_docs != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: eifinger/actionlint-action@v1.10.2
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: eifinger/actionlint-action@1fc89649be682d16ec5cf65ea16e269eb88d3982 # v1.10.2
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
           cache: true
@@ -112,7 +93,7 @@ jobs:
           echo "No oversized files detected (limit: ${MAX_BYTES} bytes)."
 
   build-and-test:
-    needs: [docs-only, lint, validate-agents-md]
+    needs: [docs-only, lint]
     if: needs.docs-only.outputs.only_docs != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
@@ -131,9 +112,9 @@ jobs:
             coverage: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
           cache: true
@@ -156,9 +137,28 @@ jobs:
             --collect:"XPlat Code Coverage" \
             --results-directory ./TestResults
 
-      - name: Check for unused NuGet packages (Linux)
+      - name: Check for deprecated/vulnerable NuGet packages (Linux)
         if: matrix.coverage == true
-        run: dotnet list package --unused --include-transitive || true
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `--unused` is not a valid `dotnet list package` option (it was a
+          # silent no-op masked by `|| true`). Use the real checks instead.
+          #
+          # Deprecated: informational only — xunit v2 is flagged "Legacy" by
+          # design, which would otherwise break every build.
+          echo "::group::Deprecated packages (informational)"
+          dotnet list package --deprecated --include-transitive
+          echo "::endgroup::"
+          # Vulnerable: hard gate. The tool prints finding rows prefixed with
+          # `>`; a clean project prints "has no vulnerable packages".
+          vuln=$(dotnet list package --vulnerable --include-transitive)
+          echo "$vuln"
+          if echo "$vuln" | grep -qE '^[[:space:]]*>'; then
+            echo "ERROR: vulnerable packages detected." >&2
+            exit 1
+          fi
+          echo "No vulnerable packages detected."
 
       - name: Test timing report (Linux)
         if: matrix.coverage == true
@@ -177,32 +177,9 @@ jobs:
             '''))"
           fi
 
-      - name: Cache reportgenerator tool (Linux)
-        if: matrix.coverage == true
-        uses: actions/cache@v5.0.5
-        with:
-          # dotnet tool restore installs into the per-repo tool home.
-          path: .dotnet-tools
-          key: ${{ runner.os }}-reportgen-${{ hashFiles('.config/dotnet-tools.json') }}
-          restore-keys: ${{ runner.os }}-reportgen-
-
       - name: Coverage report + 80% gate (Linux)
         if: matrix.coverage == true
-        env:
-          DOTNET_CLI_HOME: ${{ github.workspace }}/.dotnet-tools
-        run: |
-          dotnet tool restore
-          dotnet reportgenerator \
-            -reports:TestResults/*/coverage.cobertura.xml \
-            -targetdir:TestResults/coverage-report \
-            -reporttypes:"Html;TextSummary"
-          cat TestResults/coverage-report/Summary.txt
-          COVERAGE=$(grep "Line coverage:" TestResults/coverage-report/Summary.txt | grep -oP '\d+(\.\d+)?%' | head -1 | sed 's/%//')
-          echo "Coverage: ${COVERAGE}%"
-          awk -v c="$COVERAGE" 'BEGIN { exit (c+0 < 80) ? 1 : 0 }' || {
-            echo "ERROR: coverage ${COVERAGE}% < 80%"
-            exit 1
-          }
+        uses: ./.github/actions/coverage-gate
 
       - name: Unit tests (non-Linux)
         if: matrix.coverage != true
@@ -217,28 +194,41 @@ jobs:
             bash ./tests/run-tests.sh
           fi
 
+      # Publish the CLI once on Linux and hand it to the `goldens` job as an
+      # artifact, so goldens does not re-restore + re-publish (#397).
+      - name: Publish CLI for goldens (Linux)
+        if: matrix.coverage == true
+        run: dotnet publish src/Zipper.csproj -c Release -o ./publish-bin --no-restore
+
+      - name: Upload CLI artifact for goldens (Linux)
+        if: matrix.coverage == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: zipper-cli-linux
+          path: publish-bin/
+          retention-days: 1
+
   goldens:
     needs: [docs-only, build-and-test]
     if: needs.docs-only.outputs.only_docs != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-dotnet@v5
+      # Runtime only — the binary is framework-dependent; no restore/build here.
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
-          cache: true
-          cache-dependency-path: '**/packages.lock.json'
 
-      - name: Restore (locked)
-        run: dotnet restore zipper.sln --locked-mode
-
-      - name: Publish CLI (Release)
-        run: dotnet publish src/Zipper.csproj -c Release -o ./publish-bin
+      - name: Download CLI artifact (built by the Linux build-and-test leg)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: zipper-cli-linux
+          path: publish-bin
 
       - name: Run golden scenarios
         run: |
-          chmod +x ./tests/goldens/run-goldens.sh
+          chmod +x ./publish-bin/Zipper ./tests/goldens/run-goldens.sh
           ZIPPER_CLI="$(pwd)/publish-bin/Zipper" bash ./tests/goldens/run-goldens.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ TODO.md
 
 # Coverage
 coverage*
+# ...but keep the CI composite action whose dir name collides with coverage*
+!.github/actions/coverage-gate/
+!.github/actions/coverage-gate/**
 publish-bin/
 
 # OS files

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -6,7 +6,8 @@ Automated performance regression detection for Zipper.
 
 1. `measure.sh` runs three scenarios and emits wall time + peak RSS as JSON.
 2. `perf-guard.yml` runs on PRs that touch `src/**`, takes the median of 5 runs, and compares against `baselines.json`.
-3. If wall time exceeds 1.25× baseline or RSS exceeds 1.20× baseline, the check fails.
+3. **RSS is the hard gate:** if peak RSS exceeds 1.20× baseline, the check fails.
+4. **Wall time is informational only.** Shared GitHub runners vary 15–40% run-to-run with no code change, and baselines are captured on a different runner than each PR is measured on, so the wall ratio mixes hardware delta with code delta. It is reported (1.25× reference line) but never fails the job.
 
 ## Scenarios
 
@@ -43,8 +44,9 @@ The perf-guard workflow posts a markdown table on the PR:
 | pdf_50k | wall_s | 1.86 | 2.10 | 1.13× | ✅ |
 | pdf_50k | rss_kb | 110116 | 115000 | 1.04× | ✅ |
 
-- **✅** = within threshold
-- **❌** = exceeds threshold (wall > 1.25× or RSS > 1.20×)
+- **✅** = RSS within threshold (≤ 1.20×) — gating
+- **❌** = RSS exceeds 1.20× — fails the job
+- **ℹ️ / ⚠️** = wall_s reference marker (≤ / > 1.25×) — informational only, never fails
 
 ## When to Re-capture
 

--- a/tests/test-artifact-handling.bat
+++ b/tests/test-artifact-handling.bat
@@ -20,7 +20,7 @@ REM Check build-and-test.yml for artifact patterns
 echo 1. Analyzing %WORKFLOW_FILE% artifact patterns...
 
 REM Check for artifact upload steps
-findstr /C:"actions/upload-artifact@v" "%WORKFLOW_FILE%" >nul
+findstr /C:"actions/upload-artifact@" "%WORKFLOW_FILE%" >nul
 if !errorlevel! equ 0 (
     echo [OK] Uses actions/upload-artifact
 ) else (
@@ -80,7 +80,7 @@ if !errorlevel! equ 0 (
 
 echo 3. Analyzing caching strategy...
 
-findstr /C:"actions/cache@v" "%WORKFLOW_FILE%" >nul
+findstr /S /C:"actions/cache@" ".github\*.yml" >nul
 if !errorlevel! equ 0 (
     echo [OK] Uses actions/cache
 ) else (
@@ -108,7 +108,7 @@ if !errorlevel! equ 0 (
 
 echo 5. Checking release job artifact handling...
 
-findstr /C:"actions/download-artifact@v" "%WORKFLOW_FILE%" >nul
+findstr /C:"actions/download-artifact@" "%WORKFLOW_FILE%" >nul
 if !errorlevel! equ 0 (
     echo [OK] Uses actions/download-artifact
 ) else (

--- a/tests/test-artifact-handling.sh
+++ b/tests/test-artifact-handling.sh
@@ -21,7 +21,7 @@ fi
 echo "1. Analyzing $WORKFLOW_FILE artifact patterns..."
 
 # Check for artifact upload steps
-if grep -q "actions/upload-artifact@v" "$WORKFLOW_FILE"; then
+if grep -q "actions/upload-artifact@" "$WORKFLOW_FILE"; then
     echo "✓ Uses actions/upload-artifact"
 else
     echo "✗ Missing actions/upload-artifact"
@@ -60,18 +60,24 @@ for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
     fi
 done
 
-# Check for caching strategy
+# Check for caching strategy. The reportgenerator cache lives in the shared
+# composite action (.github/actions/coverage-gate); setup-dotnet caching lives
+# in the workflow itself. Match a tag or SHA-pinned `actions/cache@` ref
+# anywhere under .github/.
 echo "3. Analyzing caching strategy..."
-if grep -q "actions/cache@v" "$WORKFLOW_FILE"; then
+if grep -rq "actions/cache@" .github/; then
     echo "✓ Uses actions/cache"
 else
     echo "✗ Missing actions/cache"
     exit 1
 fi
 
-# Check cache keys (setup-dotnet cache: true counts as implicit cache key)
-IMPLICIT_KEYS=$(grep -c "cache: true" "$WORKFLOW_FILE" || echo 0)
-EXPLICIT_KEYS=$(grep -c "key:" "$WORKFLOW_FILE" || echo 0)
+# Check cache keys (setup-dotnet `cache: true` is an implicit key in the
+# workflows; the explicit reportgenerator `key:` lives in the composite action).
+# Count across .github/ and use `wc -l` so a zero count is a clean 0 (avoids the
+# `grep -c ... || echo 0` multiline pitfall when there are no matches).
+IMPLICIT_KEYS=$(grep -rh "cache: true" .github/ | wc -l)
+EXPLICIT_KEYS=$(grep -rh "key:" .github/ | wc -l)
 CACHE_KEYS=$((IMPLICIT_KEYS + EXPLICIT_KEYS))
 if [ "$CACHE_KEYS" -ge 2 ]; then
     echo "✓ Found sufficient cache keys ($CACHE_KEYS total)"
@@ -101,7 +107,7 @@ fi
 
 # Check for artifact download in release job
 echo "5. Checking release job artifact handling..."
-if grep -q "actions/download-artifact@v" "$WORKFLOW_FILE"; then
+if grep -q "actions/download-artifact@" "$WORKFLOW_FILE"; then
     echo "✓ Uses actions/download-artifact"
 else
     echo "✗ Missing actions/download-artifact"

--- a/tests/test-unified-workflow.bat
+++ b/tests/test-unified-workflow.bat
@@ -105,7 +105,7 @@ for %%P in (%PLATFORMS%) do (
 REM Check for artifact handling
 echo.
 echo 8. Checking artifact handling...
-findstr /C:"actions/upload-artifact@v" ".github\workflows\build-and-test.yml" > nul
+findstr /C:"actions/upload-artifact@" ".github\workflows\build-and-test.yml" > nul
 if errorlevel 1 (
     echo [FAIL] Missing upload-artifact
     exit /b 1
@@ -113,7 +113,7 @@ if errorlevel 1 (
     echo [OK] Uses upload-artifact
 )
 
-findstr /C:"actions/download-artifact@v" ".github\workflows\build-and-test.yml" > nul
+findstr /C:"actions/download-artifact@" ".github\workflows\build-and-test.yml" > nul
 if errorlevel 1 (
     echo [FAIL] Missing download-artifact
     exit /b 1
@@ -184,7 +184,7 @@ if errorlevel 1 (
 REM Check for caching
 echo.
 echo 13. Checking caching configuration...
-findstr /C:"actions/cache@v" ".github\workflows\build-and-test.yml" > nul
+findstr /S /C:"actions/cache@" ".github\*.yml" > nul
 if errorlevel 1 (
     echo [FAIL] Missing caching
     exit /b 1

--- a/tests/test-unified-workflow.sh
+++ b/tests/test-unified-workflow.sh
@@ -93,14 +93,14 @@ done
 
 # Check for artifact handling
 echo "8. Checking artifact handling..."
-if grep -q "actions/upload-artifact@v" .github/workflows/build-and-test.yml; then
+if grep -q "actions/upload-artifact@" .github/workflows/build-and-test.yml; then
     echo "✓ Uses upload-artifact"
 else
     echo "✗ Missing upload-artifact"
     exit 1
 fi
 
-if grep -q "actions/download-artifact@v" .github/workflows/build-and-test.yml; then
+if grep -q "actions/download-artifact@" .github/workflows/build-and-test.yml; then
     echo "✓ Uses download-artifact"
 else
     echo "✗ Missing download-artifact"
@@ -157,9 +157,11 @@ else
     exit 1
 fi
 
-# Check for caching
+# Check for caching. The reportgenerator cache moved into the shared composite
+# action (.github/actions/coverage-gate); match a tag or SHA-pinned
+# `actions/cache@` ref anywhere under .github/.
 echo "13. Checking caching configuration..."
-if grep -q "actions/cache@v" .github/workflows/build-and-test.yml; then
+if grep -rq "actions/cache@" .github/; then
     echo "✓ Uses caching"
 else
     echo "✗ Missing caching"


### PR DESCRIPTION
Closes #397.

CI/CD hardening + speed/correctness fixes across all four workflows.

## Changes

**Security**
- **SHA-pin every GitHub Action** (`pr.yml`, `build-and-test.yml`, `perf-guard.yml`, `perf-baseline-refresh.yml`) — were mutable `@vN` tags, contradicting CI.md's pinning policy. Each carries a `# vN` comment for Dependabot. Third-party `eifinger/actionlint-action` included.

**Correctness**
- **Fix silent no-op:** `dotnet list package --unused` is not a valid option (confirmed `Unrecognized command or argument` on .NET 10) and was masked by `|| true`. Replaced with `--vulnerable` as a **hard gate** and `--deprecated` as **informational** (xunit v2 is flagged `Legacy`, which would otherwise break every build).
- **perf-guard methodology:** `wall_s` demoted to **informational** — shared-runner wall time swings 15–40% run-to-run and baselines are captured on a different runner than each PR is measured on, so the ratio mixes hardware delta with code delta. `rss_kb` (stable across runners) remains the hard gate. PR-comment footer updated.

**Speed / dedup**
- Delete redundant `validate-agents-md` job (its restore/build/format/test are covered by `lint` + `build-and-test`); **ungate the matrix** from it.
- Extract the byte-identical reportgenerator + 80% coverage gate into a local composite action **`.github/actions/coverage-gate`**, shared by both workflows.
- **goldens artifact reuse:** the Linux `build-and-test` leg publishes + uploads the CLI; `goldens` downloads it instead of re-restoring + re-publishing — trims the sequential tail.
- `.gitignore`: negate `coverage*` for the new action dir (name collision).

## Note on artifact "skew" (finding #4)
`upload-artifact@v7` and `download-artifact@v8` are each the **latest of their independently-versioned action** (no `upload-artifact@v8` exists) and are compatible in practice. Pinned both to SHA; no downgrade needed.

## Verification (local)
- `actionlint` clean on all workflows
- `dotnet build` 0 errors / 0 warnings
- New publish→artifact→goldens flow exercised locally: **goldens 13/13**
- perf gating logic unit-checked: wall never fails, rss gates
- `dotnet list package --vulnerable` confirmed clean (no `>` finding rows)

Real CI verification happens on this PR's run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated coverage threshold enforcement (80% line coverage) to CI pipeline.
  * Pinned GitHub Actions to specific commit SHAs across CI workflows for enhanced security.
  * Added vulnerable package detection as a build failure condition.
  * Consolidated CI validation responsibilities to streamline workflow structure.
  * Optimized test artifact handling to reduce redundant build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->