### PR TITLE
fix: conform XmlLoadFileWriter output to EDRM XML v1.2 schema

### DIFF
--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -44,7 +44,6 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
             await writer.WriteAttributeStringAsync(null, "MinorVersion", null, "2");
 
             await writer.WriteStartElementAsync(null, "Batch", null);
-            await writer.WriteStartElementAsync(null, "Documents", null);
 
 #pragma warning disable S2245
             var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
@@ -57,7 +56,6 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
                 await element.WriteToAsync(writer, CancellationToken.None);
             }
 
-            await writer.WriteEndElementAsync(); // </Documents>
             await writer.WriteEndElementAsync(); // </Batch>
             await writer.WriteEndElementAsync(); // </Root>
             await writer.WriteEndDocumentAsync();

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -44,7 +44,7 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
         Assert.Equal("Root", root.Name.LocalName);
         Assert.Equal("Export", root.Attribute("DataInterchangeType")?.Value);
 
-        var document = root.Element("Batch")?.Element("Documents")?.Element("Document");
+        var document = root.Element("Batch")?.Element("Document");
         Assert.NotNull(document);
         Assert.Equal("DOC00000001", document.Attribute("DocID")?.Value);
 
@@ -75,7 +75,8 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
         Assert.Contains("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>", content.ToLowerInvariant());
         Assert.Contains("<Root DataInterchangeType=\"Export\" MajorVersion=\"1\" MinorVersion=\"2\">", content);
         Assert.Contains("<Batch>", content);
-        Assert.Contains("<Documents>", content);
+        Assert.DoesNotContain("<Documents>", content);
+        Assert.DoesNotContain("</Documents>", content);
         Assert.Contains("<Document DocID=\"DOC00000001\">", content);
         Assert.Contains("<Files>", content);
         Assert.Contains("<File FileType=\"Native\">", content);
@@ -85,7 +86,6 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
         Assert.Contains("<Fields>", content);
         Assert.Contains("<Field Name=\"Custodian\">Custodian 1</Field>", content);
         Assert.Contains("</Document>", content);
-        Assert.Contains("</Documents>", content);
         Assert.Contains("</Batch>", content);
         Assert.Contains("</Root>", content);
     }

--- a/tests/test-load-file-formats.bat
+++ b/tests/test-load-file-formats.bat
@@ -111,8 +111,8 @@ if errorlevel 1 (
 )
 
 findstr /C:"<Documents>" "!XML_FILE!" >nul
-if errorlevel 1 (
-  echo [ ERROR ] Test 3: Plural wrapper ^<Documents^> not found
+if not errorlevel 1 (
+  echo [ ERROR ] Test 3: Plural wrapper ^<Documents^> element should not be present
   exit /b 1
 )
 

--- a/tests/test-load-file-formats.sh
+++ b/tests/test-load-file-formats.sh
@@ -158,8 +158,8 @@ if ! grep -q "<Batch>" "$xml_file"; then
   print_error "Test 3: <Batch> element not found"
 fi
 
-if ! grep -q "<Documents>" "$xml_file"; then
-  print_error "Test 3: Plural wrapper <Documents> element not found"
+if grep -q "<Documents>" "$xml_file"; then
+  print_error "Test 3: Plural wrapper <Documents> element should not be present"
 fi
 
 if ! grep -q "<Document DocID=" "$xml_file"; then


### PR DESCRIPTION
Conforms XmlLoadFileWriter output to the EDRM XML v1.2 schema as specified by REQ-052.

- Uses the correct <Root>/<Batch>/<Document> hierarchy by removing the non-conforming <Documents> element wrapper.
- Retains the required FileName attribute on ExternalFile elements per standard.
- Updates unit and E2E tests to reflect this change.

Closes #336