### PR TITLE
fix: #432 persist-credentials hardening + #433 flaky-test root cause

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set Version
         id: version
         shell: bash
@@ -53,6 +54,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           global-json-file: global.json
@@ -80,6 +83,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -12,6 +12,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: check
         shell: bash
         run: |
@@ -69,6 +70,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: eifinger/actionlint-action@1fc89649be682d16ec5cf65ea16e269eb88d3982 # v1.10.2
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
@@ -113,6 +116,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
@@ -215,6 +220,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # Runtime only — the binary is framework-dependent; no restore/build here.
       - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5

--- a/src/Zipper.Tests/Zipper.Tests.csproj
+++ b/src/Zipper.Tests/Zipper.Tests.csproj
@@ -12,8 +12,15 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA0001;EnableGenerateDocumentationFile</NoWarn>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <!-- Test isolation: parallelize across test classes by default -->
-    <ParallelizeTestCollections>true</ParallelizeTestCollections>
+    <!--
+      Tests must run serially: ProgramTests.RunWithRedirectedConsole performs a
+      process-global Console.SetOut/SetError, which races if collections run in
+      parallel (rare, load-dependent flake in Main_WithSeedAndTargetZipSize...,
+      issue #433). The assembly attribute [CollectionBehavior(DisableTest-
+      Parallelization = true)] in LoadfileOnlyGeneratorTests.cs enforces this;
+      do NOT re-add <ParallelizeTestCollections> here — under the MTP runner it
+      can override that attribute and re-enable the race.
+    -->
     <!-- Test performance: emit detailed timing via JUnit logger -->
     <VSTestResultsDirectory>$(MSBuildProjectDirectory)/TestResults</VSTestResultsDirectory>
   </PropertyGroup>


### PR DESCRIPTION
Closes #432, closes #433.

## #433 — flaky `Main_WithSeedAndTargetZipSize_ProducesIdenticalOutputAndHashes`
**Root cause:** the test csproj set `<ParallelizeTestCollections>true>` while `LoadfileOnlyGeneratorTests.cs` sets `[assembly: CollectionBehavior(DisableTestParallelization = true)]` — a direct contradiction. Under the MTP runner (`xunit.runner.visualstudio` 3.x) the MSBuild property can override the assembly attribute and intermittently enable parallel collections. `ProgramTests.RunWithRedirectedConsole` performs a **process-global `Console.SetOut/SetError`**, which then races across collections — a rare, load-dependent flake that only appears under the full suite, never in isolation.

**Fix:** remove the contradictory property so the serial intent holds. Generator output was verified byte-deterministic for a fixed seed across time boundaries — this is a test-harness race, not a generator bug. (The deeper concurrency/leak concerns in #411 are separate.)

Verified: full suite green 4× (1013 passed); generator output identical across a 3s wall-clock boundary.

## #432 — persist-credentials hardening
`actions/checkout` persists `GITHUB_TOKEN` into `.git/config` by default; push-free jobs don't need it. Added `persist-credentials: false` to:
- `pr.yml`: docs-only, lint, build-and-test, goldens
- `perf-guard.yml`: checkout
- `build-and-test.yml`: prepare, lint, build-and-test matrix

**Kept default** (these write): `tag-and-release` (git tag/push) and `perf-baseline-refresh` (`contents: write`, opens baseline PR).

actionlint clean on all workflows.

## Honesty note
The #433 flake could not be reproduced locally (33 green runs before the fix, 4 after). The fix targets the demonstrable config contradiction + global-Console race, which is the strongest root-cause candidate — not a reproduced-then-fixed failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions security by disabling credential persistence across build and test workflows.
  * Updated test execution to run sequentially for improved reliability and conflict prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->