### PR TITLE
test: implement E2E stability fixes and rename IntegrationTests

### DIFF
--- a/src/Zipper.Tests/SmokeTests.cs
+++ b/src/Zipper.Tests/SmokeTests.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace Zipper;
 
-public class IntegrationTests
+public class SmokeTests
 {
     [Fact]
     public async Task Main_WithParallelGeneration_ShouldCreateValidArchive()

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -303,7 +303,7 @@ call :verify_output "%TEST_OUTPUT_DIR%\pdf_with_text_and_metadata" 10 "Control N
 call :print_success "Test Case 9 passed."
 
 REM Test Case 10: EML generation with attachments
-call :run_test_case "Test Case 10: EML generation with attachments" --type eml --count 20 --output-path "%TEST_OUTPUT_DIR%\eml_attachments" --attachment-rate 50
+call :run_test_case "Test Case 10: EML generation with attachments" --type eml --count 20 --output-path "%TEST_OUTPUT_DIR%\eml_attachments" --attachment-rate 50 --seed 42
 call :verify_eml_output "%TEST_OUTPUT_DIR%\eml_attachments" 20 "Control Number,File Path,To,From,Subject,Sent Date,Attachment" "eml" "false" "UTF-8"
 call :print_success "Test Case 10 passed."
 
@@ -333,7 +333,7 @@ call :verify_load_file_included "%TEST_OUTPUT_DIR%\pdf_include_load" 10 "Control
 call :print_success "Test Case 15 passed."
 
 REM Test Case 16: EML attachments with metadata and text (comprehensive attachment test)
-call :run_test_case "Test Case 16: EML attachments with metadata and text" --type eml --count 15 --output-path "%TEST_OUTPUT_DIR%\eml_attachments_full" --attachment-rate 60 --with-metadata --with-text
+call :run_test_case "Test Case 16: EML attachments with metadata and text" --type eml --count 15 --output-path "%TEST_OUTPUT_DIR%\eml_attachments_full" --attachment-rate 60 --with-metadata --with-text --seed 42
 call :verify_eml_output "%TEST_OUTPUT_DIR%\eml_attachments_full" 15 "Control Number,File Path,To,From,Subject,Custodian,Author,Sent Date,Date Sent,File Size,Attachment,Extracted Text" "eml" "true" "UTF-8"
 call :print_success "Test Case 16 passed."
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -374,7 +374,7 @@ verify_output "$TEST_OUTPUT_DIR/pdf_with_text_and_metadata" 10 "Control Number,F
 print_success "Test Case 9 passed."
 
 # Test Case 10: EML generation with attachments
-run_test_case "Test Case 10: EML generation with attachments" --type eml --count 20 --output-path "$TEST_OUTPUT_DIR/eml_attachments" --attachment-rate 50
+run_test_case "Test Case 10: EML generation with attachments" --type eml --count 20 --output-path "$TEST_OUTPUT_DIR/eml_attachments" --attachment-rate 50 --seed 42
 verify_eml_output "$TEST_OUTPUT_DIR/eml_attachments" 20 "Control Number,File Path,To,From,Subject,Sent Date,Attachment" "eml" "false" "UTF-8"
 print_success "Test Case 10 passed."
 
@@ -404,7 +404,7 @@ verify_load_file_included "$TEST_OUTPUT_DIR/pdf_include_load" 10 "Control Number
 print_success "Test Case 15 passed."
 
 # Test Case 16: EML attachments with metadata and text (comprehensive attachment test)
-run_test_case "Test Case 16: EML attachments with metadata and text" --type eml --count 15 --output-path "$TEST_OUTPUT_DIR/eml_attachments_full" --attachment-rate 60 --with-metadata --with-text
+run_test_case "Test Case 16: EML attachments with metadata and text" --type eml --count 15 --output-path "$TEST_OUTPUT_DIR/eml_attachments_full" --attachment-rate 60 --with-metadata --with-text --seed 42
 verify_eml_output "$TEST_OUTPUT_DIR/eml_attachments_full" 15 "Control Number,File Path,To,From,Subject,Custodian,Author,Sent Date,Date Sent,File Size,Attachment,Extracted Text" "eml" "true" "UTF-8"
 print_success "Test Case 16 passed."
 

--- a/tests/test-argument-interactions.bat
+++ b/tests/test-argument-interactions.bat
@@ -26,6 +26,9 @@ call :assert_rejected "--target-zip-size without --count" --type pdf --output-pa
 call :assert_accepted "valid standard --loadfile-only" --loadfile-only --count 5 --output-path "%TEMP%\zi_test"
 call :assert_accepted "valid standard --loadfile-only with --col-delim" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --col-delim "char:|"
 call :assert_accepted "valid standard --production-set" --production-set --count 5 --bates-prefix TEST --type pdf --output-path "%TEMP%\zi_test"
+call :assert_accepted "--loadfile-only + --chaos-mode + --chaos-amount" --loadfile-only --count 5 --chaos-mode --chaos-amount "5%%" --output-path "%TEMP%\zi_test"
+call :assert_accepted "--production-set + --bates-prefix + --volume-size" --production-set --count 5 --bates-prefix TEST --volume-size 100 --output-path "%TEMP%\zi_test"
+call :assert_accepted "--loadfile-only + --col-delim + --quote-delim" --loadfile-only --count 5 --col-delim "char:|" --quote-delim "char:\"" --output-path "%TEMP%\zi_test"
 
 call :assert_rejected "--loadfile-only + --load-file-format csv" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --load-file-format csv
 call :assert_rejected "--loadfile-only + --load-file-format xml" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --load-file-format xml
@@ -45,14 +48,23 @@ exit /b 0
 set "DESC=%~1"
 set "ARGS=%*"
 set "ARGS=!ARGS:%1 =!"
-%ZIPPER_CMD% !ARGS! >nul 2>&1
+set "STDERR_FILE=%TEMP%\stderr_!PASSED!_!FAILED!.txt"
+%ZIPPER_CMD% !ARGS! >nul 2>"!STDERR_FILE!"
 if errorlevel 1 (
-    echo [ INFO ] PASS: %DESC%
-    set /a PASSED+=1
+    findstr /i /c:"Unhandled exception" /c:"NullReferenceException" /c:"Exception:" "!STDERR_FILE!" >nul
+    if not errorlevel 1 (
+        echo [ ERROR ] FAIL: %DESC% ^(expected validation error, got crash^)
+        type "!STDERR_FILE!"
+        set /a FAILED+=1
+    ) else (
+        echo [ INFO ] PASS: %DESC%
+        set /a PASSED+=1
+    )
 ) else (
     echo [ ERROR ] FAIL: %DESC% ^(expected rejection^)
     set /a FAILED+=1
 )
+del /f /q "!STDERR_FILE!" 2>nul
 goto :eof
 
 :assert_accepted

--- a/tests/test-argument-interactions.sh
+++ b/tests/test-argument-interactions.sh
@@ -23,14 +23,19 @@ assert_rejected() {
     local desc="$1"
     shift
     local out_path="$TEMP_DIR/out_${PASSED}_${FAILED}"
-    if zipper "$@" --output-path "$out_path" > /dev/null 2>&1; then
+    local err_file="$TEMP_DIR/err_${PASSED}_${FAILED}"
+    if zipper "$@" --output-path "$out_path" > /dev/null 2>"$err_file"; then
         print_error "FAIL: $desc (expected rejection, got success)"
+        FAILED=$((FAILED + 1))
+    elif grep -qE "Unhandled exception|NullReferenceException|Exception:" "$err_file"; then
+        print_error "FAIL: $desc (expected validation error, got crash)"
+        cat "$err_file"
         FAILED=$((FAILED + 1))
     else
         print_info "PASS: $desc"
         PASSED=$((PASSED + 1))
     fi
-    rm -rf "$out_path" 2>/dev/null || true
+    rm -rf "$out_path" "$err_file" 2>/dev/null || true
 }
 
 # Assert command exits zero (accepted)
@@ -115,6 +120,15 @@ assert_accepted "valid standard --loadfile-only with --col-delim" \
 
 assert_accepted "valid standard --production-set" \
     --production-set --count 5 --bates-prefix TEST --type pdf
+
+assert_accepted "--loadfile-only + --chaos-mode + --chaos-amount" \
+    --loadfile-only --count 5 --chaos-mode --chaos-amount "5%"
+
+assert_accepted "--production-set + --bates-prefix + --volume-size" \
+    --production-set --count 5 --bates-prefix TEST --volume-size 100
+
+assert_accepted "--loadfile-only + --col-delim + --quote-delim" \
+    --loadfile-only --count 5 --col-delim "char:|" --quote-delim "char:\""
 
 # --- Negative E2E tests for --loadfile-only formats ---
 

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -96,7 +96,7 @@ echo [ INFO ] Test: --with-families warning emitted without --type eml
 %ZIPPER_CMD% --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn1" --with-families 2> "%TEMP%\warn1.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /i /c:"warning: --with-families" "%TEMP%\warn1.txt" >nul 2>&1
+    findstr /i /c:"Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "%TEMP%\warn1.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for non-eml type
         set /a PASSED+=1
@@ -114,7 +114,7 @@ echo [ INFO ] Test: --with-families warning emitted with --attachment-rate 0
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn2" --with-families --attachment-rate 0 2> "%TEMP%\warn2.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /i /c:"warning: --with-families" "%TEMP%\warn2.txt" >nul 2>&1
+    findstr /i /c:"Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "%TEMP%\warn2.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for attachment-rate 0
         set /a PASSED+=1
@@ -132,7 +132,7 @@ echo [ INFO ] Test: --with-families warning emitted with --loadfile-only
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn3" --with-families --attachment-rate 50 --loadfile-only 2> "%TEMP%\warn3.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /i /c:"warning: --with-families" "%TEMP%\warn3.txt" >nul 2>&1
+    findstr /i /c:"Warning: --with-families has no effect in --loadfile-only mode." "%TEMP%\warn3.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for loadfile-only mode
         set /a PASSED+=1

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -73,7 +73,7 @@ echo [ INFO ] Test: --with-families accepted with EML + attachments
 %ZIPPER_CMD% --type eml --count 10 --output-path "%TEST_OUTPUT_DIR%\families" --with-families --attachment-rate 50 2> "%TEMP%\no_warn.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\no_warn.txt" >nul 2>&1
+    findstr /i /c:"warning: --with-families" "%TEMP%\no_warn.txt" >nul 2>&1
     if errorlevel 1 (
         if exist "%TEST_OUTPUT_DIR%\families\*.dat" (
             echo [ INFO ] PASS: --with-families accepted without warning
@@ -96,7 +96,7 @@ echo [ INFO ] Test: --with-families warning emitted without --type eml
 %ZIPPER_CMD% --type pdf --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn1" --with-families 2> "%TEMP%\warn1.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn1.txt" >nul 2>&1
+    findstr /i /c:"warning: --with-families" "%TEMP%\warn1.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for non-eml type
         set /a PASSED+=1
@@ -114,7 +114,7 @@ echo [ INFO ] Test: --with-families warning emitted with --attachment-rate 0
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn2" --with-families --attachment-rate 0 2> "%TEMP%\warn2.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /C:"Warning: --with-families is only meaningful" "%TEMP%\warn2.txt" >nul 2>&1
+    findstr /i /c:"warning: --with-families" "%TEMP%\warn2.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for attachment-rate 0
         set /a PASSED+=1
@@ -132,7 +132,7 @@ echo [ INFO ] Test: --with-families warning emitted with --loadfile-only
 %ZIPPER_CMD% --type eml --count 5 --output-path "%TEST_OUTPUT_DIR%\families-warn3" --with-families --attachment-rate 50 --loadfile-only 2> "%TEMP%\warn3.txt" >nul
 set ZIPPER_EXIT=!ERRORLEVEL!
 if !ZIPPER_EXIT! equ 0 (
-    findstr /C:"Warning: --with-families has no effect" "%TEMP%\warn3.txt" >nul 2>&1
+    findstr /i /c:"warning: --with-families" "%TEMP%\warn3.txt" >nul 2>&1
     if not errorlevel 1 (
         echo [ INFO ] PASS: --with-families warning emitted for loadfile-only mode
         set /a PASSED+=1

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -205,7 +205,7 @@ print_info "Test: --with-families warning emitted without --type eml"
 err_file=$(mktemp)
 if zipper --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn1" \
     --with-families 2> "$err_file"; then
-    if grep -qi "warning: --with-families" "$err_file"; then
+    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
         pass "--with-families warning emitted for non-eml type"
     else
         fail "--with-families warning NOT emitted for non-eml type"
@@ -219,7 +219,7 @@ print_info "Test: --with-families warning emitted with --attachment-rate 0"
 err_file=$(mktemp)
 if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn2" \
     --with-families --attachment-rate 0 2> "$err_file"; then
-    if grep -qi "warning: --with-families" "$err_file"; then
+    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
         pass "--with-families warning emitted for attachment-rate 0"
     else
         fail "--with-families warning NOT emitted for attachment-rate 0"

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -188,7 +188,7 @@ if zipper --type eml --count 10 --output-path "$TEST_OUTPUT_DIR/families" \
     --with-families --attachment-rate 50 2> "$err_file"; then
     dat_file=$(find "$TEST_OUTPUT_DIR/families" -name "*.dat" -print -quit)
     if [[ -n "$dat_file" && -s "$dat_file" ]]; then
-        if ! grep -q "Warning: --with-families is only meaningful" "$err_file"; then
+        if ! grep -qi "warning: --with-families" "$err_file"; then
             pass "--with-families accepted and does not emit warning"
         else
             fail "--with-families incorrectly emitted warning for valid config"
@@ -205,7 +205,7 @@ print_info "Test: --with-families warning emitted without --type eml"
 err_file=$(mktemp)
 if zipper --type pdf --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn1" \
     --with-families 2> "$err_file"; then
-    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
+    if grep -qi "warning: --with-families" "$err_file"; then
         pass "--with-families warning emitted for non-eml type"
     else
         fail "--with-families warning NOT emitted for non-eml type"
@@ -219,7 +219,7 @@ print_info "Test: --with-families warning emitted with --attachment-rate 0"
 err_file=$(mktemp)
 if zipper --type eml --count 5 --output-path "$TEST_OUTPUT_DIR/families-warn2" \
     --with-families --attachment-rate 0 2> "$err_file"; then
-    if grep -q "Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified." "$err_file"; then
+    if grep -qi "warning: --with-families" "$err_file"; then
         pass "--with-families warning emitted for attachment-rate 0"
     else
         fail "--with-families warning NOT emitted for attachment-rate 0"


### PR DESCRIPTION
Addresses Phase 1 improvements from testing audit. Adds --seed 42 to EML attachment generation tests to prevent flakiness, strengthens `assert_rejected` logic to correctly fail on application crashes, adds missing positive checks, softens brittle grep assertions, and renames IntegrationTests to SmokeTests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by making EML test cases deterministic.
  * Expanded test coverage to validate additional argument combination scenarios.
  * Improved test robustness with better error detection logic and case-insensitive warning message matching.
  * Reorganized test class structure for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->