### PR TITLE
Reconcile Requirements.md with implementation + 5 code fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,12 @@ Verify behavior changes against Requirements.md before committing. Run `grep -n 
 8. Commit and create PR
 9. Monitor CI until all checks pass; fix failures before requesting review. If a CI failure appears flaky (same test passes locally, or failure is in an unrelated component), re-run once. If it fails again, document the flake in the PR and proceed to request review. Push fixes via `git commit --amend --no-edit && git push --force-with-lease`.
 10. Check SonarCloud issues on the PR after CI completes (see [CI.md](CI.md#sonarcloud)). Fix all BLOCKER and MAJOR issues before merge
-11. Address CodeRabbit review comments (blocking issues required, nitpicks optional)
+11. Address review comments from **all** bots/reviewers (CodeRabbit, Gemini Code Assist, Codex, SonarCloud, human). Blocking/major issues required, nitpicks optional. Bots post to three *separate* endpoints — you must query all three to discover every comment (the PR web view and `gh pr view` alone miss inline threads):
+    - **Inline review comments** (code-anchored): `gh api repos/<owner>/<repo>/pulls/<N>/comments --paginate`
+    - **Review summary bodies** (verdict + overview): `gh api repos/<owner>/<repo>/pulls/<N>/reviews --paginate`
+    - **Issue-level PR comments** (CodeRabbit walkthrough, SonarCloud gate, perf guard): `gh api repos/<owner>/<repo>/issues/<N>/comments --paginate`
+
+    For each finding: verify it against current code, fix if still valid, or skip with a brief reason (e.g. conflicts with an explicit design decision). If a suggestion contradicts a deliberate choice, reply on the thread explaining why rather than silently ignoring it.
 12. Merge after all checks pass and reviews are addressed
 
 **Test location:** `src/Zipper.Tests/`.

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--attachment-rate <number>`: When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0
 - `--target-zip-size <size>`: Specifies a target size for the final Archive (e.g., 500MB, 10GB). This feature works by padding each of the `--count` Native Files with uncompressible data to meet the target size. This significantly reduces the overall Compression Ratio and is intended for specific network or storage performance testing scenarios. Requires `--count`
 - `--include-load-file`: Includes the generated Load File in the root of the output Archive instead of as a separate file
-- `--load-file-format <dat|opt|csv|edrm-xml>`: The format of the Load File. Defaults to `dat`. Also accepts `xml` (alias for `edrm-xml`) and `concordance` (alias for `dat`). Available formats:
+- `--load-file-format <dat|opt|csv|edrm-xml|concordance>`: The format of the Load File. Defaults to `dat`. Also accepts `xml` (alias for `edrm-xml`). Note: `concordance` is a **distinct** format, NOT an alias of `dat`. Available formats:
   - `dat`: Standard Concordance DAT format with ASCII 20/254/174 delimiters
   - `opt`: Opticon format - comma-separated, page-level image references (automatically generated alongside DAT for `tiff` and `jpg` types unless explicitly requested otherwise)
   - `csv`: Comma-separated values format with RFC 4180 escaping
   - `edrm-xml`: EDRM XML format - Electronic Discovery Reference Model schema v1.2
+  - `concordance`: Concordance database-import format - every field quote-wrapped (ASCII 254), ASCII 20-delimited, with leading `BEGATTY`/`ENDDATTY`/`CONTROLNUMBER`/`PATH` columns. Distinct from `dat`
 - `--load-file-formats <format1,format2,...>`: Generate multiple Load File formats simultaneously (e.g., `dat,opt,csv`)
 - `--dat-delimiters <standard|csv>`: DAT delimiter style. `standard` uses ASCII 20/254/174, `csv` uses comma/quote. Defaults to `standard`
 - `--bates-prefix <prefix>`: Prefix for Bates numbering (e.g., "CLIENT001")
@@ -84,7 +85,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--date-format <format>`: Override the default date format (e.g., "yyyy-MM-dd", "MM/dd/yyyy")
 - `--empty-percentage <0-100>`: Override the default empty value percentage for optional fields
 - `--custodian-count <1-1000>`: Override the number of custodians in the data pool. Maximum 1000
-- `--with-families`: Generate parent-child document relationships (BEGATTACH, ENDATTACH, PARENTDOCID columns). Only meaningful with `--type eml` and `--attachment-rate` > 0 (emits a soft warning to stderr otherwise)
+- `--with-families`: Generate parent-child document relationships (BEGATTACH, ENDATTACH, PARENTDOCID columns; `dat` format only). Only meaningful with `--type eml` and `--attachment-rate` > 0 (emits a soft warning to stderr otherwise)
 
 **Loadfile-Only Options:**
 - `--loadfile-only`: Generate standalone Load Files directly to disk without creating Archives or Native Files. Produces a companion `_properties.json` audit file. `--type` becomes optional (defaults to `pdf` for schema). Conflicts with `--target-zip-size` and `--include-load-file`
@@ -235,6 +236,7 @@ Compatibility checklist:
 | `--load-file-formats` vs `--load-file-format` | Multi-format list takes precedence over single format |
 | `--include-load-file` + `--load-file-formats` | All specified formats are included in the ZIP |
 | `--delimiter-*` + `--dat-delimiters` | Specific delimiter flags override the preset for that delimiter only |
+| `--load-file-format csv` vs `--dat-delimiters csv` | Distinct: former selects a true `.csv` (RFC 4180) writer; latter only swaps a `.dat` file's delimiters to comma/quote |
 | `--loadfile-only` + `--target-zip-size` | **Conflict**: cannot use both |
 | `--loadfile-only` + `--include-load-file` | **Conflict**: cannot use both |
 | `--col-delim`, `--quote-delim`, etc. | Require `--loadfile-only`; use `ascii:N` or `char:C` prefix |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
   - `opt`: Opticon format - comma-separated, page-level image references (automatically generated alongside DAT for `tiff` and `jpg` types unless explicitly requested otherwise)
   - `csv`: Comma-separated values format with RFC 4180 escaping
   - `edrm-xml`: EDRM XML format - Electronic Discovery Reference Model schema v1.2
-  - `concordance`: Concordance database-import format - every field quote-wrapped (ASCII 254), ASCII 20-delimited, with leading `BEGATTY`/`ENDDATTY`/`CONTROLNUMBER`/`PATH` columns. Distinct from `dat`
+  - `concordance`: Concordance database-import format - every field quote-wrapped (ASCII 254), ASCII 20-delimited, with leading `BEGATTY`/`ENDATTY`/`CONTROLNUMBER`/`PATH` columns. Distinct from `dat`
 - `--load-file-formats <format1,format2,...>`: Generate multiple Load File formats simultaneously (e.g., `dat,opt,csv`)
 - `--dat-delimiters <standard|csv>`: DAT delimiter style. `standard` uses ASCII 20/254/174, `csv` uses comma/quote. Defaults to `standard`
 - `--bates-prefix <prefix>`: Prefix for Bates numbering (e.g., "CLIENT001")

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
   - `exponential`: Exponential decay with most files in first folders
 - `--with-metadata`: Generates a Load File with additional metadata columns (Custodian, Date Sent, Author, File Size). Supported for all file types including `eml`
 - `--with-text`: Generates a corresponding extracted text file for each document and adds the path to the Load File. Supported for all file types including `eml`
-- `--attachment-rate <number>`: When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0
+- `--attachment-rate <number>`: When type is `eml`, specifies the percentage of Emails (0-100) that will receive a placeholder Native File (jpg/tiff/pdf from the internal pool) as a random Attachment. Defaults to 0
 - `--target-zip-size <size>`: Specifies a target size for the final Archive (e.g., 500MB, 10GB). This feature works by padding each of the `--count` Native Files with uncompressible data to meet the target size. This significantly reduces the overall Compression Ratio and is intended for specific network or storage performance testing scenarios. Requires `--count`
 - `--include-load-file`: Includes the generated Load File in the root of the output Archive instead of as a separate file
 - `--load-file-format <dat|opt|csv|edrm-xml|concordance>`: The format of the Load File. Defaults to `dat`. Also accepts `xml` (alias for `edrm-xml`). Note: `concordance` is a **distinct** format, NOT an alias of `dat`. Available formats:

--- a/Requirements.md
+++ b/Requirements.md
@@ -35,7 +35,10 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 ### FR-000: Automatic Metadata Generation
 - **REQ-000**: A new optional command-line argument `--with-metadata` shall be introduced.
 - **REQ-001**: When `--with-metadata` is specified, the output `.dat` file must include the additional columns: `Custodian`, `Date Sent`, `Author`, and `File Size`. Note: For the Email File Type, email-specific metadata columns are always included regardless of this flag, as these are intrinsic to Emails.
-- **REQ-002**: The `Custodian` field shall be linked to the Folder structure. The tool will generate a unique custodian name for each Folder (e.g., "Custodian 1"). All Native Files within a given Folder will be assigned that Folder's custodian. If no Folders are specified, a single default custodian name will be assigned to all Native Files.
+- **REQ-002**: In the default (standard Archive) generation mode, the `Custodian` field shall be linked to the Folder structure. The tool will generate a unique custodian name for each Folder (e.g., "Custodian 1"). All Native Files within a given Folder will be assigned that Folder's custodian. If no Folders are specified, a single default custodian name will be assigned to all Native Files. This applies to both non-Email and Email standard output (via the built-in `LegacyWithMetadata`/`LegacyEml` profiles). The following modes use a **different** custodian model and are NOT folder-linked:
+  - `--production-set`: custodians are drawn randomly from a pool of size `--custodian-count` (default 10, max 1000), independent of Folders.
+  - `--loadfile-only` (DAT): custodians use an index-based assignment (`Custodian {(index % 10) + 1}`).
+  - An explicit `--column-profile`: custodians come from the profile's `custodians` data source and its distribution (see REQ-076; the profile takes precedence over `--with-metadata`).
 - **REQ-003**: The `Author`, `Date Sent`, and `File Size` fields will be auto-generated with plausible random data without requiring user input.
 
 ### FR-001: Integrated Extracted Text

--- a/Requirements.md
+++ b/Requirements.md
@@ -67,7 +67,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - **REQ-022**: The application must exit with a validation error if `--target-zip-size` is specified without the `--count` argument.
 - **REQ-023**: When both `--target-zip-size` and `--count` are used, the tool must calculate the amount of uncompressible padding needed for each Native File to meet the final compressed --target-zip-size.
 - **REQ-024**: The tool must append the calculated amount of random (non-compressible) data to each of the count Native Files' content before they are added to the Archive for compression.
-- **REQ-025**: The final generated Archive size must fall within a +/- 10% tolerance of the --target-zip-size. This is the final success criterion for the operation.
+- **REQ-025**: The final generated Archive size must fall within a +/- 10% tolerance of the --target-zip-size. This is the final success criterion for the operation. After generation, the tool verifies the final archive size against the target: within tolerance it reports success, and outside tolerance it emits a warning to stderr with the actual size and deviation (it does not hard-fail, since compression variance can legitimately exceed the tolerance).
 - **REQ-026**: The application must perform a pre-check to estimate the minimum possible compressed size of the requested files. If this estimated minimum size already exceeds the --target-zip-size, the tool must exit immediately with a clear error message to prevent an impossible task from running.
 
 ### FR-006: Inclusive Load File
@@ -93,7 +93,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - **REQ-043**: A new optional command-line argument `--tiff-pages <min-max>` shall be introduced.
 - **REQ-044**: The argument accepts a range specification (e.g., "1-20") to define the minimum and maximum page count.
 - **REQ-045**: When `--type tiff` is specified with `--tiff-pages`, each TIFF Native File shall have a random page count within the specified range.
-- **REQ-046**: The Load File must include a `Page Count` column indicating the number of pages in each TIFF file.
+- **REQ-046**: When `--tiff-pages` is specified (with `--type tiff`), the Load File must include a `Page Count` column indicating the number of pages in each TIFF file. When `--tiff-pages` is omitted, no `Page Count` column is emitted, preserving backward-compatible output (see REQ-047).
 - **REQ-047**: The default page range shall be "1-1" (single page) for backward compatibility.
 
 ## 3. Technical Requirements

--- a/Requirements.md
+++ b/Requirements.md
@@ -74,7 +74,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 
 ### FR-007: Multiple Load File Formats
 - **REQ-036**: A new optional command-line argument `--load-file-format <format>` shall be introduced.
-- **REQ-037**: The tool shall support multiple Load File formats as specified in Section 8: `dat` (default), `opt`, `csv`, and `edrm-xml`.
+- **REQ-037**: The tool shall support multiple Load File formats as specified in Section 8: `dat` (default), `opt`, `csv`, `edrm-xml`, and `concordance`. Note: `concordance` is a **distinct** format (every field quote-wrapped, ASCII 20-delimited database-import variant with BEGATTY/ENDATTY/CONTROLNUMBER/PATH columns), NOT an alias of `dat`. See Section 8.7.
 - **REQ-038**: Each format shall conform to industry-standard specifications defined in Section 8 (Load File Format Standards).
 
 ### FR-008: Bates Numbering System
@@ -170,6 +170,8 @@ This section documents industry-standard Load File formats used by major e-disco
 | Concordance DAT | `.dat` | Metadata and document data |
 | Opticon | `.opt` | Image cross-references (page-level) |
 | EDRM XML | `.xml` | Vendor-neutral data interchange |
+| Concordance (DB import) | `.dat` | Fully quote-wrapped database-import variant (`--load-file-format concordance`), distinct from `dat`. See Section 8.7. |
+| CSV | `.csv` | RFC 4180 comma-separated values (`--load-file-format csv`). See Section 8.8. |
 
 ### 8.2 Concordance DAT Format Specification
 
@@ -346,7 +348,7 @@ Based on the above research, the following requirements apply to the Zipper Load
 - **REQ-050**: A new argument `--dat-delimiters <standard|csv>` shall allow switching between standard Concordance delimiters and standard CSV format.
 - **REQ-051**: OPT format shall use comma delimiters and ANSI encoding by default.
 - **REQ-052**: EDRM-XML format shall generate well-formed XML conforming to EDRM schema version 1.2.
-- **REQ-101**: `edrm-xml`, `xml`, and `concordance` shall be treated as aliases: `xml` maps to the same EDRM XML v1.2 output as `edrm-xml`, and `concordance` maps to the same output as `dat`.
+- **REQ-101**: `edrm-xml` and `xml` shall be treated as aliases: `xml` maps to the same EDRM XML v1.2 output as `edrm-xml`. `concordance` is NOT an alias of `dat`; it is a distinct format with its own writer producing fully quote-wrapped, ASCII 20-delimited database-import output with a different column set (see Section 8.7).
 
 #### FR-011: Multi-Format Output
 
@@ -355,14 +357,14 @@ Based on the above research, the following requirements apply to the Zipper Load
 
 #### FR-012: OPT File Generation
 
-- **REQ-057**: When `--type tiff` or `--type jpg` is used, an OPT file shall be generated automatically alongside the DAT file. Note: PDF Native Files do NOT trigger automatic OPT generation as they are treated as Native Files, not page-level images.
-- **REQ-058**: The OPT file shall correctly mark document breaks for multi-page documents (when `--tiff-pages` is used). For multi-page TIFFs, page-level Bates numbers shall use suffixes (e.g., `ABC001_00001_001`, `ABC001_00001_002`).
+- **REQ-057**: When `--type tiff` or `--type jpg` is used **and no Load File format is explicitly selected** (neither `--load-file-format` nor `--load-file-formats` is passed), the tool shall automatically generate both a DAT and an OPT file. If an explicit format is selected, only that format is produced and auto-OPT generation is suppressed (e.g. `--type tiff --load-file-format edrm-xml` yields EDRM-XML only). Note: PDF Native Files do NOT trigger automatic OPT generation as they are treated as Native Files, not page-level images.
+- **REQ-058**: The OPT file shall correctly mark document breaks for multi-page documents (when `--tiff-pages` is used). For multi-page TIFFs, page-level Bates numbers shall use suffixes (e.g., `ABC001_00001_001`, `ABC001_00001_002`). Note: in `--loadfile-only` OPT mode there are no real Native Files, so page counts are synthetic — when `--tiff-pages` is supplied the page count is drawn from that range, otherwise it defaults to a synthetic multi-page distribution (random 1–10 pages per document), independent of the REQ-047 `1-1` Native-File default.
 - **REQ-059**: OPT files shall use ANSI encoding for maximum platform compatibility.
 
 #### FR-013: Family Relationship Support
 
 - **REQ-060**: A new argument `--with-families` shall generate parent-child document relationships.
-- **REQ-061**: When `--with-families` is specified, the Load File shall include `BEGATTACH`, `ENDATTACH`, and `PARENT_DOCID` columns.
+- **REQ-061**: When `--with-families` is specified, the **DAT** Load File shall include `BEGATTACH`, `ENDATTACH`, and `PARENTDOCID` columns. Note: the industry-reference table in Section 8.2 spells this `PARENT_DOCID`, but Zipper emits `PARENTDOCID` (no underscore) to match its built-in column profiles. Family columns are currently supported only for the `dat` format (and OPT document-break semantics); the `csv`, `concordance`, and `edrm-xml` writers do not emit family columns.
 - **REQ-062**: Email Attachments (when using `--attachment-rate`) shall be properly linked as children of their parent Email documents.
 - **REQ-122**: When `--with-families` is specified without `--type eml` or with `--attachment-rate 0`, a soft warning shall be emitted to stderr, but the execution shall not be rejected.
 
@@ -468,6 +470,68 @@ Based on the above research, the following requirements apply to the Zipper Load
   - Quote delimiter: ASCII 254 (Concordance standard)
   - Newline delimiter: ASCII 174 (Concordance standard)
 - **REQ-086**: The application shall replace any newline characters (`\n`, `\r`, `\r\n`) within field values with the configured newline delimiter character to prevent Load File corruption.
+
+### 8.7 Concordance (Database Import) Format Specification
+
+The `concordance` format (`--load-file-format concordance`) is a **distinct** database-import variant, NOT an alias of `dat` (see REQ-101). It targets legacy Concordance database loaders that expect every field quote-wrapped and a fixed leading attachment-range column pair.
+
+#### Structure
+- **Extension**: `.dat`
+- **Encoding**: Same as `--encoding` (UTF-8 default)
+- **Field Delimiter**: Configured column delimiter, default ASCII 20 (DC4)
+- **Quote/Text Qualifier**: ASCII 254 (þ), applied to **every** field (unlike `dat`, which qualifies selectively)
+- **Header Row**: Present; field names UPPERCASE, no spaces, each quote-wrapped
+- **In-field quote escaping**: Embedded quote characters are doubled (DAT-style escaping)
+
+#### Column Order
+Leading columns (always present):
+
+| Column | Notes |
+|--------|-------|
+| `BEGATTY` | Beginning attachment Bates. Emitted empty (generator does not track attachment ranges). |
+| `ENDATTY` | Ending attachment Bates. Emitted empty. |
+| `CONTROLNUMBER` | Unique document identifier. |
+| `PATH` | Relative Native File path within the Archive. |
+
+Conditional columns append in this order when their feature is active: metadata (`CUSTODIAN`, `DATESENT`, `AUTHOR`, `FILESIZE`), email (`TO`, `FROM`, `SUBJECT`, `SENTDATE`, `ATTACHMENT`), `BATES`, `PAGECOUNT`, `TEXT_PATH`.
+
+> [!NOTE]
+> `BEGATTY`/`ENDATTY` are structurally required by the format but are intentionally emitted empty because the generator does not compute attachment parent/child Bates ranges. This is a known limitation, not corruption.
+
+### 8.8 CSV Format Specification
+
+The `csv` format (`--load-file-format csv`) produces a standard RFC 4180 comma-separated values file with a `.csv` extension. It is intended for spreadsheet tools and generic importers, NOT for Concordance-style e-discovery loaders (use `dat` or `concordance` for those).
+
+#### Structure
+- **Extension**: `.csv`
+- **Encoding**: Same as `--encoding` (UTF-8 default)
+- **Field Delimiter**: Comma (`,`)
+- **Text Qualifier**: Double quote (`"`)
+- **Header Row**: Present, comma-joined. Headers default to **UPPERCASE** (e.g. `CONTROL NUMBER`, `FILE PATH`) for e-discovery platform compatibility (Section 8.2). A `--column-profile` with an explicit `fieldNamingConvention` overrides this default.
+- **Line Terminator**: Platform newline
+
+#### RFC 4180 Escaping
+- A field is quoted **only** if it contains a comma, a double quote, CR, or LF.
+- Embedded double quotes are escaped by doubling (`"` → `""`).
+- Empty values are emitted as an empty field (no quotes).
+
+#### Columns
+Same conditional column set and order as the DAT writer: base (`Control Number`, `File Path`), then metadata (`Custodian`, `Date Sent`, `Author`, `File Size`), email (`To`, `From`, `Subject`, `Sent Date`, `Attachment`), `Bates Number`, `Page Count`, `Extracted Text` — each gated by the corresponding feature flag.
+
+#### `--load-file-format csv` vs `--dat-delimiters csv`
+
+These are **distinct** and must not be confused (REQ-050 / REQ-037):
+
+| | `--load-file-format csv` | `--dat-delimiters csv` |
+|---|---|---|
+| Writer | `CsvWriter` (RFC 4180) | DAT writer with CSV-style delimiters |
+| Extension | `.csv` | `.dat` |
+| Column delimiter | `,` | `,` |
+| Quote | `"` (selective, RFC 4180) | `"` |
+| In-field newline | preserved inside quotes | replaced with space |
+| Header names | UPPERCASE by default | DAT header convention |
+
+In short: `--load-file-format csv` selects a true CSV file; `--dat-delimiters csv` only swaps the delimiter preset of a `.dat` file and has no effect unless `--load-file-format dat` (REQ-083).
 
 ---
 

--- a/Requirements.md
+++ b/Requirements.md
@@ -51,7 +51,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - **REQ-008**: The `--type` argument shall be expanded to accept `eml` as a valid file type.
 - **REQ-009**: When `--type eml` is specified, the tool will generate Email Native Files with basic, valid headers (To, From, Subject, Sent-Date) and a simple, repetitive text body.
 - **REQ-010**: The associated `.dat` Load File will contain columns corresponding to the email headers, populated with auto-generated data. For Emails, metadata columns (To, From, Subject, Sent Date, Attachment) are always included regardless of the `--with-metadata` flag, as these are intrinsic to Emails.
-- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated Emails have one of the Native Files included as a random Attachment. Defaults to 0.
+- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated Emails have a placeholder Native File (one of `jpg`, `tiff`, or `pdf` drawn from the internal attachment pool) included as a random Attachment. The Attachment uses internal placeholder content (consistent with REQ-012) rather than a reference to one of the `--count` generated Native Files, to preserve the streaming, no-intermediate-storage generation design. Defaults to 0.
 
 ### FR_E-005: File Distribution Patterns
 - **REQ_E-022**: A new optional command-line argument `--distribution` shall be introduced.
@@ -362,7 +362,7 @@ Based on the above research, the following requirements apply to the Zipper Load
 
 - **REQ-057**: When `--type tiff` or `--type jpg` is used **and no Load File format is explicitly selected** (neither `--load-file-format` nor `--load-file-formats` is passed), the tool shall automatically generate both a DAT and an OPT file. If an explicit format is selected, only that format is produced and auto-OPT generation is suppressed (e.g. `--type tiff --load-file-format edrm-xml` yields EDRM-XML only). Note: PDF Native Files do NOT trigger automatic OPT generation as they are treated as Native Files, not page-level images.
 - **REQ-058**: The OPT file shall correctly mark document breaks for multi-page documents (when `--tiff-pages` is used). For multi-page TIFFs, page-level Bates numbers shall use suffixes (e.g., `ABC001_00001_001`, `ABC001_00001_002`). Note: in `--loadfile-only` OPT mode there are no real Native Files, so page counts are synthetic — when `--tiff-pages` is supplied the page count is drawn from that range, otherwise it defaults to a synthetic multi-page distribution (random 1–10 pages per document), independent of the REQ-047 `1-1` Native-File default.
-- **REQ-059**: OPT files shall use ANSI encoding for maximum platform compatibility.
+- **REQ-059**: OPT files shall default to ANSI (Windows-1252) encoding for maximum platform compatibility. An explicit `--encoding` argument overrides this default (e.g. to UTF-8 or UTF-16), consistent with REQ-051's "by default" wording; note that UTF-8/UTF-16 OPT has limited platform support (Section 8.5).
 
 #### FR-013: Family Relationship Support
 

--- a/Requirements.md
+++ b/Requirements.md
@@ -83,8 +83,8 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 ### FR-008: Bates Numbering System
 - **REQ-039**: New optional command-line arguments for Bates numbering shall be introduced:
   - `--bates-prefix <prefix>`: Prefix for Bates numbering (e.g., "CLIENT001")
-  - `--bates-start <number>`: Starting number for Bates numbering. Defaults to 1
-  - `--bates-digits <number>`: Number of digits for Bates numbering. Defaults to 8
+  - `--bates-start <number>`: Starting number for Bates numbering. Must be non-negative (>= 0). Defaults to 1
+  - `--bates-digits <number>`: Number of digits for Bates numbering. Must be between 1 and 20. Defaults to 8
 - **REQ-040**: When Bates numbering is enabled, the Load File must include a `Bates Number` column.
 - **REQ-041**: Bates numbers shall be formatted as `{PREFIX}{PADDED_NUMBER}` where the number is zero-padded to the specified digit count.
 - **REQ-042**: Bates numbers must increment sequentially for each Native File generated.

--- a/Requirements.md
+++ b/Requirements.md
@@ -28,7 +28,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - **REQ_E-016**: The application must generate a single `.dat` Load File corresponding to the Archive.
 - **REQ_E-017**: The Load File must use ASCII character 20 as the column delimiter.
 - **REQ_E-018**: The Load File must use ASCII character 254 as the quote/text qualifier.
-- **REQ_E-019**: The Load File must be saved with a user-specifiable encoding (`UTF-8`, `UTF-16`, `ANSI`), defaulting to `UTF-8`.
+- **REQ_E-019**: The Load File must be saved with a user-specifiable encoding (`UTF-8`, `UTF-16`, `ANSI`), defaulting to `UTF-8`. Note: `UTF-8` output includes a byte-order mark (BOM); some e-discovery loaders expect UTF-8 without a BOM (see Section 8.2) and may require the BOM to be stripped on import.
 - **REQ_E-020**: The Load File must contain a unique `Control Number` column for each Native File.
 - **REQ_E-021**: The Load File must contain a `File Path` column pointing to the Native File's relative location within the Archive.
 
@@ -181,7 +181,7 @@ This section documents industry-standard Load File formats used by major e-disco
 The Concordance DAT format is the most widely used Load File format in e-discovery. It is a delimited text file containing metadata and document information.
 
 #### Structure
-- **Encoding**: UTF-8 (preferred), UTF-8 without BOM, ASCII (Windows-1252), or UTF-16
+- **Encoding**: UTF-8 (preferred), UTF-8 without BOM, ASCII (Windows-1252), or UTF-16. Note: Zipper's `UTF-8` output emits a BOM; loaders requiring "UTF-8 without BOM" must strip it on import (see REQ_E-019).
 - **Header Row**: First line contains field names (strongly recommended)
 - **Records**: Each subsequent line represents a single document
 - **Text Qualifier**: Used to enclose field values containing delimiters

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -160,7 +160,7 @@ public static class CliValidator
         {
             if (RequestBuilder.GetLoadFileFormat(parsed.LoadFileFormat) == null)
             {
-                Console.Error.WriteLine("Error: Invalid load file format. Supported values are dat, opt, csv, xml, concordance.");
+                Console.Error.WriteLine("Error: Invalid load file format. Supported values are dat, opt, csv, edrm-xml, xml, concordance.");
                 return false;
             }
         }
@@ -191,7 +191,7 @@ public static class CliValidator
             {
                 if (RequestBuilder.GetLoadFileFormat(fmt.Trim()) == null)
                 {
-                    Console.Error.WriteLine($"Error: Invalid load file format '{fmt}'. Supported: dat, opt, csv, edrm-xml.");
+                    Console.Error.WriteLine($"Error: Invalid load file format '{fmt}'. Supported: dat, opt, csv, edrm-xml, xml, concordance.");
                     return false;
                 }
             }

--- a/src/Cli/HelpTextGenerator.cs
+++ b/src/Cli/HelpTextGenerator.cs
@@ -26,7 +26,7 @@ internal static class HelpTextGenerator
         Console.Error.WriteLine("  --include-load-file      Include load file in ZIP archive");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Load File Options:");
-        Console.Error.WriteLine("  --load-file-format <fmt> Load file format: dat, opt, csv, edrm-xml (default: dat)");
+        Console.Error.WriteLine("  --load-file-format <fmt> Load file format: dat, opt, csv, edrm-xml, xml, concordance (default: dat)");
         Console.Error.WriteLine("  --load-file-formats <f>  Multiple formats comma-separated (e.g., dat,opt,csv)");
         Console.Error.WriteLine("  --dat-delimiters <type>  DAT delimiter style: standard, csv (default: standard)");
         Console.Error.WriteLine("  --delimiter-column <c>   Custom column delimiter (char or ASCII code)");

--- a/src/LoadFiles/ConcordanceWriter.cs
+++ b/src/LoadFiles/ConcordanceWriter.cs
@@ -43,7 +43,7 @@ internal class ConcordanceWriter : LoadFileWriterBase
 
         // Concordance format headers are wrapped in quote delimiter, comma-delimited
         header.Append($"{quoteDelim}BEGATTY{quoteDelim}{fieldDelim}");
-        header.Append($"{quoteDelim}ENDDATTY{quoteDelim}{fieldDelim}");
+        header.Append($"{quoteDelim}ENDATTY{quoteDelim}{fieldDelim}");
         header.Append($"{quoteDelim}CONTROLNUMBER{quoteDelim}{fieldDelim}");
         header.Append($"{quoteDelim}PATH{quoteDelim}{fieldDelim}");
 
@@ -99,11 +99,11 @@ internal class ConcordanceWriter : LoadFileWriterBase
             var workItem = fileData.WorkItem;
             var line = new StringBuilder();
 
-            // Note: BEGATTY and ENDDATTY (beginning/ending attachment Bates numbers)
+            // Note: BEGATTY and ENDATTY (beginning/ending attachment Bates numbers)
             // are intentionally left empty. The format requires these fields,
             // but this generator does not track attachment parent/child ranges.
             line.Append($"{quoteDelim}{quoteDelim}{fieldDelim}");  // BEGATTY field (empty)
-            line.Append($"{quoteDelim}{quoteDelim}{fieldDelim}");  // ENDDATTY field (empty)
+            line.Append($"{quoteDelim}{quoteDelim}{fieldDelim}");  // ENDATTY field (empty)
             line.Append($"{quoteDelim}{EscapeDatField(GenerateDocumentId(workItem), quoteDelim)}{quoteDelim}{fieldDelim}");
             line.Append($"{quoteDelim}{EscapeDatField(workItem.FilePathInZip, quoteDelim)}{quoteDelim}{fieldDelim}");
 

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -36,7 +36,9 @@ internal class CsvWriter : LoadFileWriterBase
 
     private static Task WriteHeaderAsync(StreamWriter writer, FileGenerationRequest request)
     {
-        var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
+        // CSV headers default to UPPERCASE for e-discovery platform compatibility (Section 8.2);
+        // an explicit profile fieldNamingConvention still overrides this default.
+        var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention ?? "UPPERCASE";
         var headers = new System.Collections.Generic.List<string>
         {
             NamingConventionHelper.ApplyConvention("Control Number", namingConvention),

--- a/src/LoadFiles/CsvWriter.cs
+++ b/src/LoadFiles/CsvWriter.cs
@@ -36,8 +36,8 @@ internal class CsvWriter : LoadFileWriterBase
 
     private static Task WriteHeaderAsync(StreamWriter writer, FileGenerationRequest request)
     {
-        // CSV headers default to UPPERCASE for e-discovery platform compatibility (Section 8.2);
-        // an explicit profile fieldNamingConvention still overrides this default.
+        // CSV headers default to upper case for e-discovery platform compatibility (Section 8.2).
+        // When a column profile specifies a naming convention, that convention wins instead.
         var namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention ?? "UPPERCASE";
         var headers = new System.Collections.Generic.List<string>
         {

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -162,9 +162,18 @@ internal class OptWriter : LoadFileWriterBase
             // Honor an explicit --tiff-pages range when provided; otherwise keep the
             // synthetic multi-page default (random 1-10) for loadfile-only OPT generation,
             // where no real Native Files exist to derive a page count from.
-            int pageCount = request.Tiff.PageRange.HasValue
-                ? random.Next(request.Tiff.PageRange.Value.Min, request.Tiff.PageRange.Value.Max + 1)
-                : random.Next(1, 11);
+            int pageCount;
+            if (request.Tiff.PageRange.HasValue)
+            {
+                var (min, max) = request.Tiff.PageRange.Value;
+                // Guard against overflow when Max is int.MaxValue (Max + 1 would wrap to int.MinValue).
+                int upperExclusive = max == int.MaxValue ? max : max + 1;
+                pageCount = random.Next(min, upperExclusive);
+            }
+            else
+            {
+                pageCount = random.Next(1, 11);
+            }
 
             foreach (var entry in GeneratePageEntries(batesId, imagePath, pageCount))
             {

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -159,44 +159,59 @@ internal class OptWriter : LoadFileWriterBase
             string volume = "VOL001";
             string imagePath = $"IMAGES\\{batesId}.tif";
 
-            // Honor an explicit --tiff-pages range when provided; otherwise keep the
-            // synthetic multi-page default (random 1-10) for loadfile-only OPT generation,
-            // where no real Native Files exist to derive a page count from.
-            int pageCount;
-            if (request.Tiff.PageRange.HasValue)
-            {
-                var (min, max) = request.Tiff.PageRange.Value;
-                // Guard against overflow when Max is int.MaxValue (Max + 1 would wrap to int.MinValue).
-                int upperExclusive = max == int.MaxValue ? max : max + 1;
-                pageCount = random.Next(min, upperExclusive);
-            }
-            else
-            {
-                pageCount = random.Next(1, 11);
-            }
+            // Honor an explicit --tiff-pages range when provided, reusing the shared
+            // TiffMultiPageGenerator helper (clamps Min/Max, overflow-safe, deterministic)
+            // so this path cannot drift from the real TIFF page-count logic. Without a
+            // range, keep the synthetic multi-page default (random 1-10) for loadfile-only
+            // OPT generation, where no real Native Files exist to derive a page count from.
+            int pageCount = request.Tiff.PageRange.HasValue
+                ? TiffMultiPageGenerator.GetPageCount(request.Tiff.PageRange, request.Metadata.Seed, i)
+                : random.Next(1, 11);
 
-            foreach (var entry in GeneratePageEntries(batesId, imagePath, pageCount))
-            {
-                string line = $"{entry.Bates},{volume},{entry.ImagePath},{entry.DocBreak},,,{entry.PageCountStr}";
-
-                string interceptedLine = ApplyChaosInterception(chaosEngine, currentLineNumber, line, entry.Bates);
-                await writer.WriteAsync(interceptedLine + eolString);
-
-                if (chaosEngine != null)
-                {
-                    var anomaly = chaosEngine.GetEncodingAnomaly(currentLineNumber, currentLineNumber + 1, encoding);
-                    if (anomaly != null)
-                    {
-                        await writer.FlushAsync();
-                        await stream.WriteAsync(anomaly);
-                    }
-                }
-
-                currentLineNumber++;
-            }
+            currentLineNumber = await WriteLoadfileOnlyPagesAsync(
+                writer, stream, encoding, eolString, chaosEngine, batesId, volume, imagePath, pageCount, currentLineNumber);
         }
 
         await writer.FlushAsync();
+    }
+
+    /// <summary>
+    /// Writes the per-page OPT rows for a single document in loadfile-only mode,
+    /// applying chaos interception when enabled. Returns the advanced line number.
+    /// </summary>
+    private static async Task<long> WriteLoadfileOnlyPagesAsync(
+        StreamWriter writer,
+        Stream stream,
+        Encoding encoding,
+        string eolString,
+        ChaosEngine? chaosEngine,
+        string batesId,
+        string volume,
+        string imagePath,
+        int pageCount,
+        long currentLineNumber)
+    {
+        foreach (var entry in GeneratePageEntries(batesId, imagePath, pageCount))
+        {
+            string line = $"{entry.Bates},{volume},{entry.ImagePath},{entry.DocBreak},,,{entry.PageCountStr}";
+
+            string interceptedLine = ApplyChaosInterception(chaosEngine, currentLineNumber, line, entry.Bates);
+            await writer.WriteAsync(interceptedLine + eolString);
+
+            if (chaosEngine != null)
+            {
+                var anomaly = chaosEngine.GetEncodingAnomaly(currentLineNumber, currentLineNumber + 1, encoding);
+                if (anomaly != null)
+                {
+                    await writer.FlushAsync();
+                    await stream.WriteAsync(anomaly);
+                }
+            }
+
+            currentLineNumber++;
+        }
+
+        return currentLineNumber;
     }
 
     /// <summary>

--- a/src/LoadFiles/OptWriter.cs
+++ b/src/LoadFiles/OptWriter.cs
@@ -158,7 +158,13 @@ internal class OptWriter : LoadFileWriterBase
                 : $"IMG{i:D8}";
             string volume = "VOL001";
             string imagePath = $"IMAGES\\{batesId}.tif";
-            int pageCount = random.Next(1, 11);
+
+            // Honor an explicit --tiff-pages range when provided; otherwise keep the
+            // synthetic multi-page default (random 1-10) for loadfile-only OPT generation,
+            // where no real Native Files exist to derive a page count from.
+            int pageCount = request.Tiff.PageRange.HasValue
+                ? random.Next(request.Tiff.PageRange.Value.Min, request.Tiff.PageRange.Value.Max + 1)
+                : random.Next(1, 11);
 
             foreach (var entry in GeneratePageEntries(batesId, imagePath, pageCount))
             {

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -42,6 +42,30 @@ namespace Zipper
             Console.WriteLine(string.Format("\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format("  Archive created: {0}", result.ZipFilePath));
             Console.WriteLine(string.Format("  Performance: {0:F1} files/second", result.FilesPerSecond));
+
+            // REQ-025: the final archive must fall within +/- 10% of --target-zip-size.
+            // This is the success criterion for the operation; verify and report it.
+            // Outside tolerance is warned (not a hard failure) because compression
+            // variance can legitimately push the result beyond +/- 10%.
+            if (request.Output.TargetZipSize.HasValue && File.Exists(result.ZipFilePath))
+            {
+                long target = request.Output.TargetZipSize.Value;
+                long actual = new FileInfo(result.ZipFilePath).Length;
+                double deviation = target > 0 ? Math.Abs(actual - target) / (double)target : 0;
+                if (deviation > 0.10)
+                {
+                    Console.Error.WriteLine(string.Format(
+                        "  Warning: archive size {0:N0} bytes is outside the +/-10% target tolerance ({1:N0} bytes, deviation {2:P1}).",
+                        actual, target, deviation));
+                }
+                else
+                {
+                    Console.WriteLine(string.Format(
+                        "  Target ZIP size met: {0:N0} bytes (within +/-10% of {1:N0} bytes, deviation {2:P1}).",
+                        actual, target, deviation));
+                }
+            }
+
             if (!request.Output.IncludeLoadFile)
             {
                 Console.WriteLine(string.Format("  Load file created: {0}", result.LoadFilePath));

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -54,13 +54,13 @@ namespace Zipper
                 double deviation = target > 0 ? Math.Abs(actual - target) / (double)target : 0;
                 if (deviation > 0.10)
                 {
-                    Console.Error.WriteLine(string.Format(
+                    await Console.Error.WriteLineAsync(string.Format(
                         "  Warning: archive size {0:N0} bytes is outside the +/-10% target tolerance ({1:N0} bytes, deviation {2:P1}).",
                         actual, target, deviation));
                 }
                 else
                 {
-                    Console.WriteLine(string.Format(
+                    await Console.Out.WriteLineAsync(string.Format(
                         "  Target ZIP size met: {0:N0} bytes (within +/-10% of {1:N0} bytes, deviation {2:P1}).",
                         actual, target, deviation));
                 }

--- a/src/Zipper.Tests/CsvLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/CsvLoadFileWriterTests.cs
@@ -32,7 +32,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(4, lines.Length);
-        Assert.Contains("Control Number", lines[0]);
+        Assert.Contains("CONTROL NUMBER", lines[0]);
         Assert.Contains("DOC00000001", lines[1]);
     }
 
@@ -94,16 +94,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         request.Metadata = request.Metadata with { WithMetadata = true };
         var files = this.CreateTestFileData(1);
         var contentWith = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("Custodian", contentWith);
+        Assert.Contains("CUSTODIAN", contentWith);
 
         request.Metadata = request.Metadata with { WithMetadata = false };
         var contentWithout = await this.CaptureCsvOutput(request, files);
-        Assert.DoesNotContain("Custodian", contentWithout);
+        Assert.DoesNotContain("CUSTODIAN", contentWithout);
 
         var emlRequest = this.CreateTestRequest("eml");
         emlRequest.Metadata = emlRequest.Metadata with { WithMetadata = false };
         var emlContent = await this.CaptureCsvOutput(emlRequest, files);
-        Assert.Contains("Custodian", emlContent);
+        Assert.Contains("CUSTODIAN", emlContent);
     }
 
     [Fact]
@@ -112,12 +112,17 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var files = this.CreateTestFileData(1);
         var emlRequest = this.CreateTestRequest("eml");
         var emlContent = await this.CaptureCsvOutput(emlRequest, files);
-        Assert.Contains("To", emlContent);
-        Assert.Contains("From", emlContent);
+
+        // Assert against exact header tokens, not substrings: "TO" is a substring
+        // of "CUSTODIAN", so a substring check would give a false positive/negative.
+        var emlHeader = emlContent.Split('\n')[0].Trim('\r', '\n', ' ').Split(',');
+        Assert.Contains("TO", emlHeader);
+        Assert.Contains("FROM", emlHeader);
 
         var pdfRequest = this.CreateTestRequest("pdf");
         var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
-        Assert.DoesNotContain("To", pdfContent);
+        var pdfHeader = pdfContent.Split('\n')[0].Trim('\r', '\n', ' ').Split(',');
+        Assert.DoesNotContain("TO", pdfHeader);
     }
 
     [Fact]
@@ -128,16 +133,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var files = this.CreateTestFileData(1);
         files[0] = files[0] with { PageCount = 5 };
         var contentWith = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("Page Count", contentWith);
+        Assert.Contains("PAGE COUNT", contentWith);
 
         request.Tiff = request.Tiff with { PageRange = null };
         var contentWithout = await this.CaptureCsvOutput(request, files);
-        Assert.DoesNotContain("Page Count", contentWithout);
+        Assert.DoesNotContain("PAGE COUNT", contentWithout);
 
         var pdfRequest = this.CreateTestRequest("pdf");
         pdfRequest.Tiff = pdfRequest.Tiff with { PageRange = (1, 10) };
         var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
-        Assert.DoesNotContain("Page Count", pdfContent);
+        Assert.DoesNotContain("PAGE COUNT", pdfContent);
     }
 
     [Fact]
@@ -191,7 +196,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         Assert.Equal(0xFE, bytes[1]);
 
         var content = await File.ReadAllTextAsync(outputPath, System.Text.Encoding.Unicode);
-        Assert.Contains("Control Number", content);
+        Assert.Contains("CONTROL NUMBER", content);
     }
 
     [Fact]
@@ -215,6 +220,6 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
 
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
         var content = System.Text.Encoding.GetEncoding(1252).GetString(bytes);
-        Assert.Contains("Control Number", content);
+        Assert.Contains("CONTROL NUMBER", content);
     }
 }

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -72,13 +72,14 @@ namespace Zipper
                 Assert.Equal(10, result.FilesGenerated);
                 Assert.True(File.Exists(result.ZipFilePath));
 
-                // Verify the ZIP file is approximately the target size (within 20% tolerance)
-                // Due to compression variance, exact size isn't possible but files should be padded
+                // REQ-025: the final archive must fall within +/-10% of the target.
+                // Padding is random/incompressible, so the compressed result tracks
+                // the target closely; assert both-sided tolerance, not just a floor.
                 var actualSize = new FileInfo(result.ZipFilePath).Length;
-                var minimumExpected = targetSize * 0.5; // At least 50% of target
+                var deviation = Math.Abs(actualSize - targetSize) / (double)targetSize;
                 Assert.True(
-                    actualSize >= minimumExpected,
-                    $"ZIP size {actualSize} bytes is below minimum expected {minimumExpected} bytes for target {targetSize} bytes");
+                    deviation <= 0.10,
+                    $"ZIP size {actualSize} bytes deviates {deviation:P1} from target {targetSize} bytes (REQ-025 allows +/-10%)");
 
                 // Verify files were created (padding increases file sizes)
                 using var archive = System.IO.Compression.ZipFile.OpenRead(result.ZipFilePath);

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -510,11 +510,23 @@ public class ProductionSetTests : IDisposable
             Assert.NotNull(productionDir);
             Assert.NotNull(firstPdfFile);
 
-            // Cause a mid-generation I/O failure by deleting the NATIVES directory
+            // Cause a mid-generation I/O failure by deleting the NATIVES directory.
+            // The generator is still writing into NATIVES/VOL001 concurrently, so on
+            // Linux/macOS a recursive delete can throw "Directory not empty" when a new
+            // file appears between enumeration and removal. Retry until the delete sticks
+            // (the generator stops writing once it hits the induced failure).
             var nativesDir = Path.Combine(productionDir, "NATIVES");
-            if (Directory.Exists(nativesDir))
+            var deleteSw = System.Diagnostics.Stopwatch.StartNew();
+            while (Directory.Exists(nativesDir))
             {
-                Directory.Delete(nativesDir, true);
+                try
+                {
+                    Directory.Delete(nativesDir, true);
+                }
+                catch (IOException) when (deleteSw.ElapsedMilliseconds < 5000)
+                {
+                    // Concurrent writer recreated a file mid-delete; retry.
+                }
             }
 
             // The generation task should now fail mid-write

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -353,7 +353,7 @@ if not defined csv_zip (
 if not defined csv_file (
     call :print_error "Test 18: No .csv file found"
 )
-powershell -Command "(Get-Content -Path '%csv_file%' -TotalCount 1)" | findstr /c:"Control Number" >nul
+powershell -Command "(Get-Content -Path '%csv_file%' -TotalCount 1)" | findstr /i /c:"Control Number" >nul
 if errorlevel 1 (
     call :print_error "Test 18: 'Control Number' column not found in .csv header"
 )

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -424,7 +424,7 @@ fi
 if [[ -z "$csv_file" ]]; then
   print_error "Test 18: No .csv file found"
 fi
-if ! head -n 1 "$csv_file" | grep -q "Control Number"; then
+if ! head -n 1 "$csv_file" | grep -qi "Control Number"; then
   print_error "Test 18: 'Control Number' column not found in .csv header"
 fi
 print_success "Test Case 18 passed."

--- a/tests/test-load-file-formats.bat
+++ b/tests/test-load-file-formats.bat
@@ -66,7 +66,7 @@ if errorlevel 1 (
 :: Verify header contains expected columns
 for %%f in ("%TEST_OUTPUT_DIR%\test2\*.csv") do set CSV_FILE=%%f
 set /p FIRST_LINE=<"!CSV_FILE!"
-echo !FIRST_LINE! | findstr /C:"Control Number" >nul
+echo !FIRST_LINE! | findstr /I /C:"Control Number" >nul
 if errorlevel 1 (
   echo [ ERROR ] Test 2: 'Control Number' column not found in .csv header
   exit /b 1

--- a/tests/test-load-file-formats.sh
+++ b/tests/test-load-file-formats.sh
@@ -105,7 +105,7 @@ fi
 
 # Verify header contains expected columns
 first_line=$(head -n 1 "$csv_file")
-if ! echo "$first_line" | grep -q "Control Number"; then
+if ! echo "$first_line" | grep -qi "Control Number"; then
   print_error "Test 2: 'Control Number' column not found in .csv header"
 fi
 


### PR DESCRIPTION
## Summary

Spec↔code concordance pass driven by a grill-me review of `Requirements.md`. Surfaced 16 spec/code divergences (3 of them genuine output bugs) and one missing runtime guarantee; resolved each by either fixing the code or correcting the spec, choosing per-finding based on test coverage, industry convention, and disruption.

**1013/1013 tests pass; build clean (Debug + Release); E2E smoke 5/5.**

## Code fixes
- **`ENDDATTY` → `ENDATTY`** — typo in ConcordanceWriter header/fields (no test pinned it; broke `BEGATTY`/`ENDATTY` symmetry).
- **Format-list drift** — 3 CLI messages (`CliValidator` ×2, `HelpTextGenerator`) listed different/incomplete format sets; normalized to canonical `dat, opt, csv, edrm-xml, xml, concordance`.
- **Loadfile-only OPT page count** — `WriteLoadfileOnlyAsync` ignored `--tiff-pages`; now honors the range when supplied, keeps the synthetic 1–10 default otherwise (preserves seeded tests).
- **CSV headers default UPPERCASE** — for e-discovery platform compatibility (§8.2); explicit profile `fieldNamingConvention` still overrides. Fixed a `"TO"`⊂`"CUSTODIAN"` substring-collision by switching the affected test to exact-token assertions.
- **Target-zip-size ±10% verification (REQ-025)** — the "final success criterion" was unverified by code *and* tests. Added a post-generation check that reports success within tolerance and warns (no hard-fail) outside it; tightened the generator test from a one-sided ≥50% floor to both-sided ±10% (verified non-flaky).

## Spec / doc reconciliations
- **REQ-101 / §8.7** — `concordance` is a **distinct** format (quote-wrapped, ASCII-20, `BEGATTY/ENDATTY/CONTROLNUMBER/PATH`), not a `dat` alias. Added a Section 8.7 spec.
- **§8.8** — added the missing CSV (RFC 4180) spec + clarified `--load-file-format csv` vs `--dat-delimiters csv`.
- **REQ-057** — OPT auto-gen for tiff/jpg only when no explicit format is selected.
- **REQ-061** — family columns scoped to DAT; header documented as `PARENTDOCID` (matches code + built-in profiles; industry has no canonical spelling).
- **REQ-002** — custodian model made mode-aware (standard = folder-linked; production-set = random pool; loadfile-only = index%10; profile = data-source).
- **REQ-046** — Page Count column emitted only with `--tiff-pages` (backward-compat per REQ-047).
- **REQ-011** — attachments are placeholder Native Files from the internal pool, not the generated set (matches REQ-012 + streaming design).
- **REQ-059** — OPT defaults to ANSI but honors an explicit `--encoding`.
- **REQ-039** — documented enforced ranges: `--bates-start ≥ 0`, `--bates-digits 1–20`.
- **REQ_E-019 / §8.2** — documented that UTF-8 output emits a BOM (kept as-is by decision).
- README kept in sync (format list, csv interaction row, attachment wording).

## Verified correct (no change needed)
REQ-070 seed reproducibility (pooled + non-pooled tested), REQ-118 manifest fields, EDRM-XML §8.4 element conformance, REQ-034 version-on-startup, REQ-094/REQ-122 chaos & families validation, README default-value table, attachment ID uniqueness (`_A001` suffix).

## Notes
Immutable REQ numbers preserved (no renumbering). No behavior change in the doc-only commits; the 5 code commits are covered by existing or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `xml` aliasing and distinct `concordance` load-file format; ZIP size check with tolerance reporting; OPT multi-page behavior and automatic DAT+OPT generation; OPT respects explicit page ranges.

* **Bug Fixes**
  * Fixed Concordance header field naming.

* **Documentation**
  * Clarified CLI docs: attachment-rate now uses placeholder attachments for EMLs; `--with-families` applies only with EML+attachments and emits a soft warning otherwise; distinguished CSV vs DAT delimiter behaviors; CSV headers default to UPPERCASE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->