### PR TITLE
Fix: reject non-DAT/OPT formats in --loadfile-only

### DIFF
--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -498,6 +498,10 @@ namespace Zipper.Tests
             }
         }
 
+        /// <summary>
+        /// Validates that using a CSV format with the --loadfile-only flag returns false,
+        /// satisfying the requirement to reject non-DAT/OPT formats (Covers issue #343).
+        /// </summary>
         [Fact]
         public void Validate_LoadfileOnly_WithCsvFormat_ReturnsFalse()
         {


### PR DESCRIPTION
## Description

This PR documents the test coverage for issue #343. The validation changes inside `CliValidator.cs` to reject non-DAT/OPT formats in `--loadfile-only` mode (REQ-088) were already implemented and merged previously in PR #394 (commit 9dfc4d4). This PR simply closes the issue #343 and adds a docstring to the existing test case to permanently link it to the issue and satisfy CodeRabbit's checks.

Closes #343

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Test coverage
- [x] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Affected Requirements

- REQ-088
