### PR TITLE
fix: ensure chaos encoding anomaly on last data line in DAT loadfile-only

### DIFF
--- a/src/LoadFiles/ProfileDrivenDatWriter.cs
+++ b/src/LoadFiles/ProfileDrivenDatWriter.cs
@@ -138,7 +138,7 @@ internal sealed class ProfileDrivenDatWriter : LoadFileWriterBase
             string interceptedLine = ApplyChaosInterception(chaosEngine, lineNumber, line, recordId);
             await writer.WriteAsync(interceptedLine + context.EolString);
 
-            if (chaosEngine != null && i < context.Request.Output.FileCount)
+            if (chaosEngine != null)
             {
                 var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, context.Encoding);
                 if (anomaly != null)

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -714,6 +714,10 @@ namespace Zipper
             Assert.Equal(Encoding.UTF8.GetString(stream1.ToArray()), Encoding.UTF8.GetString(stream2.ToArray()));
         }
 
+        /// <summary>
+        /// Tests that a chaos encoding anomaly successfully injects invalid bytes on both the header boundary
+        /// and the final data record boundary in loadfile-only mode.
+        /// </summary>
         [Fact]
         public async Task WriteAsync_LoadfileOnlyMode_WithChaosEncoding_TargetsHeaderAndLastLine_InjectsInvalidBytesAndCreatesAudit()
         {

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -713,5 +713,42 @@ namespace Zipper
 
             Assert.Equal(Encoding.UTF8.GetString(stream1.ToArray()), Encoding.UTF8.GetString(stream2.ToArray()));
         }
+
+        [Fact]
+        public async Task WriteAsync_LoadfileOnlyMode_WithChaosEncoding_TargetsHeaderAndLastLine_InjectsInvalidBytesAndCreatesAudit()
+        {
+            var request = DefaultRequest();
+            request.Metadata = request.Metadata with { Seed = 42 };
+            request.Output = request.Output with { FileCount = 3 }; // 1 header + 3 data lines = 4 lines
+
+            // Generate baseline
+            using var baseStream = new MemoryStream();
+            await new DatWriter(LoadFiles.WriterMode.LoadfileOnly).WriteAsync(baseStream, request, []);
+            var baseBytes = baseStream.ToArray();
+
+            // Total lines = FileCount + 1 (header + 3 data = 4 lines)
+            var chaosEngine = new ChaosEngine(
+                totalLines: 4,
+                chaosAmount: "100%", // target all lines, so header (line 1) and last line (line 4) are targeted
+                chaosTypes: "encoding",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            using var chaosStream = new MemoryStream();
+            await new DatWriter(LoadFiles.WriterMode.LoadfileOnly).WriteAsync(chaosStream, request, [], chaosEngine);
+            var chaosBytes = chaosStream.ToArray();
+
+            // The output should have anomalies injected for line 1 and line 4 (among others).
+            // This means there should be anomalies in the Audit log specifically for Boundary 1-2 and Boundary 4-5.
+            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
+            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
+
+            Assert.NotNull(headerAnomaly);
+            Assert.NotNull(lastLineAnomaly);
+            Assert.True(chaosBytes.Length > baseBytes.Length, "Encoding chaos should inject extra bytes");
+        }
     }
 }

--- a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+++ b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
@@ -142,5 +142,38 @@ namespace Zipper
                 Assert.Matches(@"^Custodian_[12]$", v);
             }
         }
+
+        [Fact]
+        public async Task WriteAsync_WithChaosEncoding_TargetsHeaderAndLastLine_InjectsInvalidBytesAndCreatesAudit()
+        {
+            var profile = MakeMinimalProfile();
+            var request = MakeRequest(profile);
+            request.Output = request.Output with { FileCount = 3 };
+
+            using var baseStream = new MemoryStream();
+            await new ProfileDrivenDatWriter().WriteAsync(baseStream, request, []);
+            var baseBytes = baseStream.ToArray();
+
+            var chaosEngine = new ChaosEngine(
+                totalLines: 4,
+                chaosAmount: "100%",
+                chaosTypes: "encoding",
+                format: LoadFileFormat.Dat,
+                columnDelimiter: "\u0014",
+                quoteDelimiter: "\u00fe",
+                eol: "\r\n",
+                seed: 42);
+
+            using var chaosStream = new MemoryStream();
+            await new ProfileDrivenDatWriter().WriteAsync(chaosStream, request, [], chaosEngine);
+            var chaosBytes = chaosStream.ToArray();
+
+            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
+            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
+
+            Assert.NotNull(headerAnomaly);
+            Assert.NotNull(lastLineAnomaly);
+            Assert.True(chaosBytes.Length > baseBytes.Length, "Encoding chaos should inject extra bytes");
+        }
     }
 }

--- a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+++ b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
@@ -143,6 +143,10 @@ namespace Zipper
             }
         }
 
+        /// <summary>
+        /// Tests that a chaos encoding anomaly successfully injects invalid bytes on both the header boundary
+        /// and the final data record boundary.
+        /// </summary>
         [Fact]
         public async Task WriteAsync_WithChaosEncoding_TargetsHeaderAndLastLine_InjectsInvalidBytesAndCreatesAudit()
         {


### PR DESCRIPTION
## Description
Closes #345

This PR fixes an issue where chaos encoding anomalies were not being injected for the final data line when generating loadfiles in DAT loadfile-only mode.

## Changes Made
- Removed the `i < context.Request.Output.FileCount` loop guard in `ProfileDrivenDatWriter.WriteWithChaosAsync` that prevented the anomaly injection condition from passing on the final data boundary.
- Added comprehensive unit tests in `ProfileDrivenDatWriterTests.cs` and `DatWriterTests.cs` to verify that when a chaos encoding anomaly targets the header boundary (`Boundary 1-2`) and the final record boundary (`Boundary 4-5`), invalid bytes are correctly injected and audit log entries are generated.
- Added XML docstrings to the new test methods to satisfy docstring coverage checks.

## Testing
- **Unit Testing**: Confirmed the new tests fail against the `main` branch implementation and pass against this branch.
- **Pre-commit Checks**: Confirmed that `dotnet test` and formatting checks pass locally.
- **Coverage**: Verified that docstrings have been added to the new test methods.
