### PR TITLE
Harden --output-path: absolute/symlink/Windows-drive paths bypass traversal confinement

### DIFF
--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -52,7 +52,7 @@ public static class CliParser
                 case "--output-path":
                     if (TryGetValue(args, i, out var pathArg))
                     {
-                        var dir = PathValidator.ValidateAndCreateDirectory(pathArg, Path.IsPathRooted(pathArg) ? null : Directory.GetCurrentDirectory());
+                        var dir = PathValidator.ValidateAndCreateDirectory(pathArg, Directory.GetCurrentDirectory());
                         if (dir == null)
                         {
                             return null;

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Zipper
 {
     /// <summary>
@@ -22,19 +24,23 @@ namespace Zipper
             try
             {
                 // Let the OS resolve the full canonical path, resolving any ".." or "." components
-                string fullPath = Path.GetFullPath(path);
+                string fullPath = GetRealPath(path);
 
                 if (baseDirectory != null)
                 {
                     // Determine the base directory to restrict access to
-                    string restrictToBase = Path.GetFullPath(baseDirectory);
+                    string restrictToBase = GetRealPath(baseDirectory);
 
                     // Ensure the resolved canonical path starts with the allowed base directory
                     // We add a trailing separator to ensure /var/www doesn't allow /var/www-backup
                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
-                    if (!fullPathWithTrailing.StartsWith(baseDirWithTrailing, StringComparison.OrdinalIgnoreCase))
+                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        ? StringComparison.OrdinalIgnoreCase
+                        : StringComparison.Ordinal;
+
+                    if (!fullPathWithTrailing.StartsWith(baseDirWithTrailing, comparison))
                     {
                         Console.Error.WriteLine($"Error: Path traversal detected. Destination '{fullPath}' is outside the allowed base directory.");
                         return null;
@@ -82,15 +88,19 @@ namespace Zipper
 
             try
             {
-                string fullPath = Path.GetFullPath(path);
+                string fullPath = GetRealPath(path);
 
                 if (baseDirectory != null)
                 {
-                    string restrictToBase = Path.GetFullPath(baseDirectory);
+                    string restrictToBase = GetRealPath(baseDirectory);
                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
-                    return fullPathWithTrailing.StartsWith(baseDirWithTrailing, StringComparison.OrdinalIgnoreCase);
+                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        ? StringComparison.OrdinalIgnoreCase
+                        : StringComparison.Ordinal;
+
+                    return fullPathWithTrailing.StartsWith(baseDirWithTrailing, comparison);
                 }
 
                 return true;
@@ -99,6 +109,38 @@ namespace Zipper
             {
                 return false;
             }
+        }
+
+        private static string GetRealPath(string path)
+        {
+            string fullPath = Path.GetFullPath(path);
+            DirectoryInfo? current = new DirectoryInfo(fullPath);
+            var parts = new System.Collections.Generic.List<string>();
+
+            while (current != null)
+            {
+                if (current.Exists && current.LinkTarget != null)
+                {
+                    var resolved = current.ResolveLinkTarget(true);
+                    if (resolved != null)
+                    {
+                        string resolvedPath = resolved.FullName;
+                        parts.Reverse();
+                        foreach (var p in parts)
+                        {
+                            if (!string.IsNullOrEmpty(p))
+                            {
+                                resolvedPath = Path.Combine(resolvedPath, p);
+                            }
+                        }
+                        return GetRealPath(resolvedPath);
+                    }
+                }
+                parts.Add(current.Name);
+                current = current.Parent;
+            }
+
+            return fullPath;
         }
     }
 }

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -114,6 +114,19 @@ namespace Zipper
         private static string GetRealPath(string path)
         {
             string fullPath = Path.GetFullPath(path);
+            var linkResult = ResolveLinkTargetWithSuffix(fullPath);
+
+            if (linkResult.HasValue)
+            {
+                string rebuilt = RebuildPathFromParts(linkResult.Value.resolvedRootPath, linkResult.Value.suffixParts);
+                return GetRealPath(rebuilt);
+            }
+
+            return fullPath;
+        }
+
+        private static (string resolvedRootPath, System.Collections.Generic.IEnumerable<string> suffixParts)? ResolveLinkTargetWithSuffix(string fullPath)
+        {
             DirectoryInfo? current = new DirectoryInfo(fullPath);
             var parts = new System.Collections.Generic.List<string>();
 
@@ -124,23 +137,28 @@ namespace Zipper
                     var resolved = current.ResolveLinkTarget(true);
                     if (resolved != null)
                     {
-                        string resolvedPath = resolved.FullName;
                         parts.Reverse();
-                        foreach (var p in parts)
-                        {
-                            if (!string.IsNullOrEmpty(p))
-                            {
-                                resolvedPath = Path.Combine(resolvedPath, p);
-                            }
-                        }
-                        return GetRealPath(resolvedPath);
+                        return (resolved.FullName, parts);
                     }
                 }
                 parts.Add(current.Name);
                 current = current.Parent;
             }
 
-            return fullPath;
+            return null;
+        }
+
+        private static string RebuildPathFromParts(string basePath, System.Collections.Generic.IEnumerable<string> suffixParts)
+        {
+            string resolvedPath = basePath;
+            foreach (var p in suffixParts)
+            {
+                if (!string.IsNullOrEmpty(p))
+                {
+                    resolvedPath = Path.Combine(resolvedPath, p);
+                }
+            }
+            return resolvedPath;
         }
     }
 }

--- a/src/Zipper.Tests/ChaosScenarioTests.cs
+++ b/src/Zipper.Tests/ChaosScenarioTests.cs
@@ -146,7 +146,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_WithoutChaosMode_ReturnsError()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, stderr) = await RunWithCapture(new[]
@@ -169,7 +169,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_WithChaosTypes_ReturnsConflictError()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, stderr) = await RunWithCapture(new[]
@@ -193,7 +193,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_InvalidName_ReturnsError()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, stderr) = await RunWithCapture(new[]
@@ -216,7 +216,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_FormatMismatch_ReturnsError()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, stderr) = await RunWithCapture(new[]
@@ -240,7 +240,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_ValidRun_GeneratesLoadFileWithAnomalies()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, stdout, _) = await RunWithCapture(new[]
@@ -290,7 +290,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_AmountOverride_UsesCustomAmount()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, _) = await RunWithCapture(new[]
@@ -324,7 +324,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_FullChaos_EnablesAllTypes()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, _, _) = await RunWithCapture(new[]
@@ -356,7 +356,7 @@ public class ChaosScenarioTests
     [Fact]
     public async Task ChaosScenario_BrokenBoundaries_WorksWithOpt()
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         try
         {
             var (exitCode, stdout, _) = await RunWithCapture(new[]

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -9,7 +9,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_RequiredArgs_ParsesCorrectly()
         {
-            var args = new[] { "--type", "pdf", "--count", "100", "--output-path", "/tmp/test" };
+            var args = new[] { "--type", "pdf", "--count", "100", "--output-path", Path.Combine(Directory.GetCurrentDirectory(), "test") };
             var result = CliParser.Parse(args);
             Assert.NotNull(result);
             Assert.Equal("pdf", result!.FileType);
@@ -26,14 +26,14 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_UnknownFlag_OutputsWarningButContinues()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--unknown-flag" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--unknown-flag" });
             Assert.NotNull(result);
         }
 
         [Fact]
         public void Parse_AllBooleanFlags_SetCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "5", "--output-path", "/tmp", "--with-metadata", "--with-text", "--include-load-file", "--with-families", "--loadfile-only", "--chaos-mode", "--production-set", "--production-zip" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "5", "--output-path", Directory.GetCurrentDirectory(), "--with-metadata", "--with-text", "--include-load-file", "--with-families", "--loadfile-only", "--chaos-mode", "--production-set", "--production-zip" });
             Assert.NotNull(result);
             Assert.True(result!.WithMetadata);
             Assert.True(result.WithText);
@@ -48,7 +48,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_LoadfileOnlyArgs_ParsesCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--loadfile-only", "--count", "10", "--output-path", "/tmp", "--eol", "LF", "--col-delim", "ascii:20", "--quote-delim", "none", "--multi-delim", "char:;", "--nested-delim", "char:\\", "--loadfile-format", "opt" });
+            var result = CliParser.Parse(new[] { "--loadfile-only", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--eol", "LF", "--col-delim", "ascii:20", "--quote-delim", "none", "--multi-delim", "char:;", "--nested-delim", "char:\\", "--loadfile-format", "opt" });
             Assert.NotNull(result);
             Assert.True(result!.LoadfileOnly);
             Assert.Equal("LF", result.Eol);
@@ -62,7 +62,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_ChaosArgs_ParsesCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--loadfile-only", "--count", "50", "--output-path", "/tmp", "--chaos-mode", "--chaos-amount", "5%", "--chaos-types", "quotes,columns", "--chaos-scenario", "test" });
+            var result = CliParser.Parse(new[] { "--loadfile-only", "--count", "50", "--output-path", Directory.GetCurrentDirectory(), "--chaos-mode", "--chaos-amount", "5%", "--chaos-types", "quotes,columns", "--chaos-scenario", "test" });
             Assert.NotNull(result);
             Assert.True(result!.ChaosMode);
             Assert.Equal("5%", result.ChaosAmount);
@@ -73,7 +73,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_ProductionSetArgs_ParsesCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--bates-start", "100", "--bates-digits", "6", "--volume-size", "1000", "--count", "20", "--output-path", "/tmp" });
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--bates-start", "100", "--bates-digits", "6", "--volume-size", "1000", "--count", "20", "--output-path", Directory.GetCurrentDirectory() });
             Assert.NotNull(result);
             Assert.True(result!.ProductionSet);
             Assert.Equal("CL001", result.BatesPrefix);
@@ -85,7 +85,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_DelimiterArgs_ParsesCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--dat-delimiters", "csv", "--delimiter-column", "|", "--delimiter-quote", "~", "--delimiter-newline", " " });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--dat-delimiters", "csv", "--delimiter-column", "|", "--delimiter-quote", "~", "--delimiter-newline", " " });
             Assert.NotNull(result);
             Assert.Equal("csv", result!.DatDelimiters);
             Assert.Equal("|", result.DelimiterColumn);
@@ -96,7 +96,7 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_ColumnProfileArgs_ParsesCorrectly()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--column-profile", "standard", "--seed", "42", "--date-format", "yyyy-MM-dd", "--empty-percentage", "15", "--custodian-count", "50" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--column-profile", "standard", "--seed", "42", "--date-format", "yyyy-MM-dd", "--empty-percentage", "15", "--custodian-count", "50" });
             Assert.NotNull(result);
             Assert.Equal("standard", result!.ColumnProfile);
             Assert.Equal(42, result.Seed);
@@ -114,63 +114,63 @@ namespace Zipper.Tests
         [Fact]
         public void Parse_InvalidCount_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "not-a-number", "--output-path", "/tmp" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "not-a-number", "--output-path", Directory.GetCurrentDirectory() });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidFolders_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--folders", "notanumber" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--folders", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidAttachmentRate_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--attachment-rate", "notanumber" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--attachment-rate", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidBatesStart_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--bates-start", "notanumber" });
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", Directory.GetCurrentDirectory(), "--bates-start", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidBatesDigits_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--bates-digits", "notanumber" });
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", Directory.GetCurrentDirectory(), "--bates-digits", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidSeed_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--seed", "notanumber" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--seed", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidEmptyPercentage_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--empty-percentage", "notanumber" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--empty-percentage", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidCustodianCount_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "/tmp", "--custodian-count", "notanumber" });
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--custodian-count", "notanumber" });
             Assert.Null(result);
         }
 
         [Fact]
         public void Parse_InvalidVolumeSize_ReturnsNull()
         {
-            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", "/tmp", "--volume-size", "notanumber" });
+            var result = CliParser.Parse(new[] { "--production-set", "--bates-prefix", "CL001", "--count", "5", "--output-path", Directory.GetCurrentDirectory(), "--volume-size", "notanumber" });
             Assert.Null(result);
         }
 

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -9,7 +9,7 @@ namespace Zipper
 
         public CliPipelineTests()
         {
-            this.tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(this.tempDir);
         }
 

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -12,7 +12,7 @@ namespace Zipper.Tests
             {
                 FileType = "pdf",
                 Count = 10,
-                OutputDirectory = new DirectoryInfo(Path.GetTempPath()),
+                OutputDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()),
             };
         }
 

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -10,7 +10,7 @@ namespace Zipper
 
         public ColumnProfileLoaderTests()
         {
-            this.tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(this.tempDir);
         }
 

--- a/src/Zipper.Tests/FieldNamingTests.cs
+++ b/src/Zipper.Tests/FieldNamingTests.cs
@@ -14,7 +14,7 @@ public class FieldNamingTests : IDisposable
 
     public FieldNamingTests()
     {
-        this.tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        this.tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(this.tempDir);
     }
 

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -16,7 +16,7 @@ namespace Zipper
 
         public LoadfileOnlyGeneratorTests()
         {
-            this.tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            this.tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(this.tempDir);
         }
 
@@ -196,7 +196,7 @@ namespace Zipper
             var content1 = await File.ReadAllTextAsync(result1.LoadFilePath);
 
             // Reset temp dir
-            var tempDir2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempDir2 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir2);
             try
             {

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_ShouldCreateCorrectCount()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -47,7 +47,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_WithTargetZipSize_PadsFilesToReachTargetSize()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -106,7 +106,7 @@ namespace Zipper
         public async Task GenerateFilesAsync_WithImpossibleTargetSize_ThrowsInvalidOperationException()
         {
             // REQ-026: When estimated minimum compressed size already exceeds target, abort immediately.
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -145,7 +145,7 @@ namespace Zipper
         {
             // C1 regression: unbounded work channel materialized ALL work items upfront,
             // causing OOM. Bounded channel with backpressure must still complete.
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -185,7 +185,7 @@ namespace Zipper
         {
             // B3 regression: padding per file must apply independently.
             // Previous code mutated shared paddingPerFile var on cap.
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -226,7 +226,7 @@ namespace Zipper
         {
             // B1 regression: fire-and-forget Task.Run in CreateWorkChannel could deadlock
             // if an exception prevented writer.Complete(). Verify pipeline always completes.
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -266,7 +266,7 @@ namespace Zipper
             // B1 regression: exception inside CreateWorkChannel's Task.Run must propagate
             // via writer.Complete(ex), not hang the pipeline. Folders=0 triggers
             // ArgumentOutOfRangeException in FileDistributionHelper.GetFolderNumber.
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -305,7 +305,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_FileCountZero_ThrowsArgumentException()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -338,7 +338,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_FileCountOne_GeneratesSingleFile()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -373,7 +373,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_UnknownFileType_ThrowsInvalidOperationException()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -406,7 +406,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_ConcurrencyZero_UsesDefaultConcurrency()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -439,7 +439,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_ConcurrencyExceedsFileCount_WorksCorrectly()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
@@ -504,7 +504,7 @@ namespace Zipper
         [WindowsUnsupportedFact(Timeout = 10000)]
         public async Task GenerateFilesAsync_ConsumerFaults_PipelineTerminatesWithException()
         {
-            var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var outputPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 
             try
@@ -652,7 +652,7 @@ namespace Zipper
         [Fact]
         public async Task GenerateFilesAsync_WithChaosModeAndNoLoadfileOnly_ThrowsInvalidOperationException()
         {
-            var tempDir = Path.GetTempPath();
+            var tempDir = Directory.GetCurrentDirectory();
             var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
             Directory.CreateDirectory(outputPath);
 

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -53,21 +53,28 @@ namespace Zipper
         public void ValidateAndCreateDirectory_RelativePathWithTraversal_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
-            Directory.CreateDirectory(baseDir);
-
-            string[] relativePaths =
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
+            try
             {
-                "../../../etc",
-                "test/../../../etc/passwd",
-                "folder/subfolder/../../../sensitive",
-            };
+                Directory.CreateDirectory(baseDir);
 
-            // Act & Assert
-            foreach (string path in relativePaths)
+                string[] relativePaths =
+                {
+                    "../../../etc",
+                    "test/../../../etc/passwd",
+                    "folder/subfolder/../../../sensitive",
+                };
+
+                // Act & Assert
+                foreach (string path in relativePaths)
+                {
+                    var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                    Assert.Null(result);
+                }
+            }
+            finally
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
-                Assert.Null(result);
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
             }
         }
 
@@ -75,21 +82,28 @@ namespace Zipper
         public void ValidateAndCreateDirectory_MixedSlashesWithTraversal_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
-            Directory.CreateDirectory(baseDir);
-
-            string[] mixedPaths =
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
+            try
             {
-                $"folder{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}etc",
-                $"folder/../..{Path.DirectorySeparatorChar}etc",
-                $"folder{Path.DirectorySeparatorChar}../etc/passwd",
-            };
+                Directory.CreateDirectory(baseDir);
 
-            // Act & Assert
-            foreach (string path in mixedPaths)
+                string[] mixedPaths =
+                {
+                    $"folder{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}etc",
+                    $"folder/../..{Path.DirectorySeparatorChar}etc",
+                    $"folder{Path.DirectorySeparatorChar}../etc/passwd",
+                };
+
+                // Act & Assert
+                foreach (string path in mixedPaths)
+                {
+                    var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                    Assert.Null(result);
+                }
+            }
+            finally
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
-                Assert.Null(result);
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
             }
         }
 
@@ -243,17 +257,24 @@ namespace Zipper
         public void ValidateAndCreateDirectory_CanonicalTraversalAttempt_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
-            Directory.CreateDirectory(baseDir);
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(baseDir);
 
-            // A path that technically starts with the base dir name but canonically resolves outside it
-            string escapePath = Path.Combine(baseDir, "..", "..", "etc", "passwd");
+                // A path that technically starts with the base dir name but canonically resolves outside it
+                string escapePath = Path.Combine(baseDir, "..", "..", "etc", "passwd");
 
-            // Act
-            var result = PathValidator.ValidateAndCreateDirectory(escapePath, baseDir);
+                // Act
+                var result = PathValidator.ValidateAndCreateDirectory(escapePath, baseDir);
 
-            // Assert
-            Assert.Null(result); // Canonical path escapes baseDir, should be rejected
+                // Assert
+                Assert.Null(result); // Canonical path escapes baseDir, should be rejected
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
+            }
         }
 
         [Fact]
@@ -327,9 +348,21 @@ namespace Zipper
                 {
                     Directory.CreateSymbolicLink(linkPath, targetDir);
                 }
-                catch (Exception)
+                catch (UnauthorizedAccessException)
                 {
                     // Ignore if symlink creation is not permitted (e.g. Windows non-admin)
+                    return;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    return;
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    return;
+                }
+                catch (System.IO.IOException ex) when (ex.Message.Contains("privilege") || ex.HResult == -2147024564)
+                {
                     return;
                 }
 

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Zipper
@@ -8,7 +9,7 @@ namespace Zipper
         public void ValidateAndCreateDirectory_ValidPath_ReturnsDirectoryInfo()
         {
             // Arrange
-            string validPath = Path.GetTempPath();
+            string validPath = Directory.GetCurrentDirectory();
 
             // Act
             var result = PathValidator.ValidateAndCreateDirectory(validPath);
@@ -31,13 +32,13 @@ namespace Zipper
         public void ValidateAndCreateDirectory_PathWithTraversal_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.GetTempPath();
+            string baseDir = Directory.GetCurrentDirectory();
             string[] traversalPaths =
             {
                 "../",
                 "folder/../../folder",
-                "..\\",
-                "folder\\..\\..\\folder",
+                "..".PadRight(3, Path.DirectorySeparatorChar),
+                $"folder{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}folder",
             };
 
             // Act & Assert
@@ -52,7 +53,7 @@ namespace Zipper
         public void ValidateAndCreateDirectory_RelativePathWithTraversal_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Path.GetTempPath(), "ZipperBase");
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
             Directory.CreateDirectory(baseDir);
 
             string[] relativePaths =
@@ -74,14 +75,14 @@ namespace Zipper
         public void ValidateAndCreateDirectory_MixedSlashesWithTraversal_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Path.GetTempPath(), "ZipperBase");
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
             Directory.CreateDirectory(baseDir);
 
             string[] mixedPaths =
             {
-                "folder\\..\\..\\etc",
-                "folder/../..\\etc",
-                "folder\\../etc/passwd",
+                $"folder{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}etc",
+                $"folder/../..{Path.DirectorySeparatorChar}etc",
+                $"folder{Path.DirectorySeparatorChar}../etc/passwd",
             };
 
             // Act & Assert
@@ -121,7 +122,7 @@ namespace Zipper
         public void IsPathSafe_InvalidPaths_ReturnsFalse(string path)
         {
             // Arrange
-            string baseDir = Path.GetTempPath();
+            string baseDir = Directory.GetCurrentDirectory();
 
             // Act
             bool result = PathValidator.IsPathSafe(path, baseDir);
@@ -170,7 +171,7 @@ namespace Zipper
         public void ValidateAndCreateDirectory_WithPathTooLong_DoesNotThrow()
         {
             // Arrange - Create a path longer than max path length
-            string longPath = Path.Combine(Path.GetTempPath(), new string('a', 300));
+            string longPath = Path.Combine(Directory.GetCurrentDirectory(), new string('a', 300));
 
             // Act
             var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(longPath));
@@ -183,14 +184,14 @@ namespace Zipper
         public void ValidateAndCreateDirectory_WithComplexTraversalAttempts_ReturnsNull()
         {
             // Arrange - Complex traversal attack patterns
-            string baseDir = Path.GetTempPath();
+            string baseDir = Directory.GetCurrentDirectory();
             string[] complexTraversals =
             {
                 "../../../../../../../etc/passwd",
-                "..\\..\\..\\..\\..\\..\\..\\windows\\system32",
+                $"..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}windows{Path.DirectorySeparatorChar}system32",
                 "test/../../sensitive/../../../data",
                 "/folder/../../etc/shadow",
-                "C:\\folder\\..\\..\\sensitive",
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:\\folder\\..\\..\\sensitive" : "/folder/../../sensitive",
             };
 
             // Act & Assert
@@ -242,7 +243,7 @@ namespace Zipper
         public void ValidateAndCreateDirectory_CanonicalTraversalAttempt_ReturnsNull()
         {
             // Arrange
-            string baseDir = Path.Combine(Path.GetTempPath(), "ZipperBase");
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase");
             Directory.CreateDirectory(baseDir);
 
             // A path that technically starts with the base dir name but canonically resolves outside it
@@ -258,7 +259,7 @@ namespace Zipper
         [Fact]
         public void ValidateAndCreateDirectory_WithUncPath_DoesNotThrow()
         {
-            var baseDir = Path.GetTempPath();
+            var baseDir = Directory.GetCurrentDirectory();
             var uncPath = @"\\server\share\folder";
             var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(uncPath, baseDir));
             Assert.Null(exception);
@@ -267,7 +268,7 @@ namespace Zipper
         [Fact]
         public void ValidateAndCreateDirectory_WithUnicodeCharacters_ReturnsDirectoryInfo()
         {
-            var tempPath = Path.GetTempPath();
+            var tempPath = Directory.GetCurrentDirectory();
             var unicodePath = Path.Combine(tempPath, "über-cool_文件_パス");
             var result = PathValidator.ValidateAndCreateDirectory(unicodePath);
             Assert.NotNull(result);
@@ -276,7 +277,7 @@ namespace Zipper
         [Fact]
         public void ValidateAndCreateDirectory_WithTrailingSeparator_NormalizesPath()
         {
-            var tempPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            var tempPath = Directory.GetCurrentDirectory().TrimEnd(Path.DirectorySeparatorChar);
             var pathWithTrailing = tempPath + Path.DirectorySeparatorChar;
             var result = PathValidator.ValidateAndCreateDirectory(pathWithTrailing);
             Assert.NotNull(result);
@@ -287,7 +288,7 @@ namespace Zipper
         public void IsPathSafe_UncPath_DoesNotThrow()
         {
             var uncPath = @"\\server\share\folder";
-            var baseDir = Path.GetTempPath();
+            var baseDir = Directory.GetCurrentDirectory();
             var exception = Record.Exception(() => PathValidator.IsPathSafe(uncPath, baseDir));
             Assert.Null(exception);
         }
@@ -308,6 +309,38 @@ namespace Zipper
             var safePath = Path.Combine(Environment.CurrentDirectory, "folder") + Path.DirectorySeparatorChar;
             var result = PathValidator.IsPathSafe(safePath);
             Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_SymlinkEscapingBase_ReturnsNull()
+        {
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseSymlinkTest_" + Guid.NewGuid().ToString());
+            string targetDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperTargetSymlinkTest_" + Guid.NewGuid().ToString());
+
+            try
+            {
+                Directory.CreateDirectory(baseDir);
+                Directory.CreateDirectory(targetDir);
+
+                string linkPath = Path.Combine(baseDir, "symlink");
+                try
+                {
+                    Directory.CreateSymbolicLink(linkPath, targetDir);
+                }
+                catch (Exception)
+                {
+                    // Ignore if symlink creation is not permitted (e.g. Windows non-admin)
+                    return;
+                }
+
+                var result = PathValidator.ValidateAndCreateDirectory(linkPath, baseDir);
+                Assert.Null(result);
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
+                if (Directory.Exists(targetDir)) Directory.Delete(targetDir, true);
+            }
         }
     }
 }

--- a/src/Zipper.Tests/ProductionManifestWriterTests.cs
+++ b/src/Zipper.Tests/ProductionManifestWriterTests.cs
@@ -10,7 +10,7 @@ public class ProductionManifestWriterTests
     public async Task WriteAsync_GeneratesManifestWithExpectedStructure()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
 
         var request = new FileGenerationRequest();
@@ -115,7 +115,7 @@ public class ProductionManifestWriterTests
     public async Task WriteAsync_WithEmptyDelimiters_FormatsCorrectly()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
 
         var request = new FileGenerationRequest();
@@ -158,7 +158,7 @@ public class ProductionManifestWriterTests
     public async Task WriteAsync_WithNonPrintableDelimiters_FormatsCorrectly()
     {
         // Arrange
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDir);
 
         var request = new FileGenerationRequest();

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -12,7 +12,7 @@ public class ProductionSetTests : IDisposable
 
     public ProductionSetTests()
     {
-        this.testOutputPath = Path.Combine(Path.GetTempPath(), $"zipper_prod_test_{Guid.NewGuid():N}");
+        this.testOutputPath = Path.Combine(Directory.GetCurrentDirectory(), $"zipper_prod_test_{Guid.NewGuid():N}");
         Directory.CreateDirectory(this.testOutputPath);
     }
 
@@ -465,7 +465,7 @@ public class ProductionSetTests : IDisposable
     [Fact]
     public async Task ProductionSet_OnFailure_CleansUpPartialOutput()
     {
-        var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var outputPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(outputPath);
 
         try
@@ -561,7 +561,7 @@ public class ProductionSetTests : IDisposable
     public async Task GenerateAsync_WithMultiPageTiff_ShouldWritePageLevelImageFilesToDisk()
     {
         // Arrange
-        var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var outputPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(outputPath);
 
         try
@@ -610,7 +610,7 @@ public class ProductionSetTests : IDisposable
     [Fact]
     public async Task GenerateAsync_WithChaosModeAndNoLoadfileOnly_ThrowsInvalidOperationException()
     {
-        var tempDir = Path.GetTempPath();
+        var tempDir = Directory.GetCurrentDirectory();
         var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
         Directory.CreateDirectory(outputPath);
 

--- a/src/Zipper.Tests/ProgramTests.cs
+++ b/src/Zipper.Tests/ProgramTests.cs
@@ -67,7 +67,7 @@ namespace Zipper
         public async Task Main_WithInvalidFileType_ReturnsErrorCode()
         {
             // Arrange
-            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             string[] args =
             {
                 "--output", tempPath,
@@ -92,7 +92,7 @@ namespace Zipper
         public async Task Main_WithInvalidCount_ReturnsErrorCode()
         {
             // Arrange
-            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             string[] args =
             {
                 "--output", tempPath,
@@ -117,7 +117,7 @@ namespace Zipper
         public async Task Main_WithInvalidNumericArgument_ReturnsErrorCode()
         {
             // Arrange
-            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             string[] args =
             {
                 "--output", tempPath,
@@ -159,8 +159,8 @@ namespace Zipper
         public async Task Main_WithSameSeed_ProducesIdenticalOutputSizes()
         {
             // Arrange
-            string tempPath1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            string tempPath2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath1 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+            string tempPath2 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
 
             try
             {
@@ -258,8 +258,8 @@ namespace Zipper
         public async Task Main_WithSeedAndTargetZipSize_ProducesIdenticalOutputAndHashes()
         {
             // Arrange
-            string tempPath1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            string tempPath2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string tempPath1 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+            string tempPath2 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
 
             try
             {

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -12,7 +12,7 @@ namespace Zipper.Tests
             {
                 FileType = "pdf",
                 Count = 100,
-                OutputDirectory = new DirectoryInfo(Path.GetTempPath()),
+                OutputDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()),
             };
         }
 
@@ -23,7 +23,7 @@ namespace Zipper.Tests
             var result = RequestBuilder.Build(parsed);
 
             Assert.NotNull(result);
-            Assert.Equal(Path.GetTempPath(), result.Output.OutputPath);
+            Assert.Equal(Directory.GetCurrentDirectory(), result.Output.OutputPath);
             Assert.Equal(100, result.Output.FileCount);
             Assert.Equal("pdf", result.Output.FileType);
             Assert.Equal(1, result.Output.Folders);

--- a/src/Zipper.Tests/SmokeTests.cs
+++ b/src/Zipper.Tests/SmokeTests.cs
@@ -7,7 +7,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithParallelGeneration_ShouldCreateValidArchive()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -42,7 +42,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithEmlAndAttachments_ShouldCreateArchive()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -76,7 +76,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithTiffPageRange_ShouldCreateArchive()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -109,7 +109,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithLoadfileOnly_ShouldCreateLoadFileOnly()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -145,7 +145,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithChaosMode_ShouldCreateLoadFile()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -174,7 +174,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithTargetZipSize_ShouldCreateArchiveNearTarget()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -202,8 +202,8 @@ public class SmokeTests
     [Fact]
     public async Task Main_ConcurrentGeneration_ShouldHandleParallelRuns()
     {
-        var tempDir1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        var tempDir2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir1 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        var tempDir2 = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir1);
         Directory.CreateDirectory(tempDir2);
 
@@ -247,7 +247,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithAutoOptGeneration_ForTiffAndJpg_CreatesBothDatAndOpt()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try
@@ -300,7 +300,7 @@ public class SmokeTests
     [Fact]
     public async Task Main_WithEmlFamiliesAndAttachments_ShouldCreateFamilyColumnsAndRows()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
 
         try

--- a/src/Zipper.Tests/TempDirectoryTestBase.cs
+++ b/src/Zipper.Tests/TempDirectoryTestBase.cs
@@ -9,7 +9,7 @@ public abstract class TempDirectoryTestBase : IDisposable
 
     protected TempDirectoryTestBase()
     {
-        this.TempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        this.TempDir = Path.Combine(Directory.GetCurrentDirectory(), "TestOutput_" + Guid.NewGuid().ToString());
         Directory.CreateDirectory(this.TempDir);
     }
 

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -391,7 +391,7 @@ namespace Zipper.Tests
         public async Task CreateArchiveAsync_AuditFile_TotalRecordsEqualsFileCount()
         {
             // Arrange
-            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
             var zipPath = Path.Combine(tempDir, "test.zip");
             var loadPath = Path.Combine(tempDir, "load.dat");


### PR DESCRIPTION
Closes #412

This PR addresses the directory traversal containment bypasses reported in issue #412. It ensures that:
1. Confinement checks are properly applied to absolute paths.
2. Symbolic links and junctions are correctly resolved using `ResolveLinkTarget(true)` before the prefix validation is evaluated.
3. Drive-relative paths (e.g., `C:foo`) are correctly bounded.
4. The OS-specific file system case sensitivity is correctly utilized.

All paths are now fully validated against the current working directory, preventing arbitrary writes outside of the current directory tree. Tests have been fully updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added symbolic link security validation to prevent path traversal attacks through symlink targets.

* **Bug Fixes**
  * Enhanced path validation to properly resolve symbolic links and real paths before security checks.
  * Improved output directory creation with more robust fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->