### PR TITLE
fix: Emit EDRM XML 1.2 compliant <Tags> instead of <Fields>

### DIFF
--- a/Requirements.md
+++ b/Requirements.md
@@ -315,11 +315,11 @@ The EDRM (Electronic Discovery Reference Model) XML format is a vendor-neutral s
           <ExternalFile FilePath="TEXT\DOC001.txt"/>
         </File>
       </Files>
-      <Fields>
-        <Field Name="Custodian">John Smith</Field>
-        <Field Name="Author">Jane Doe</Field>
-        <Field Name="DateCreated">2024-01-15T10:30:00Z</Field>
-      </Fields>
+      <Tags>
+        <Tag TagName="Custodian" TagValue="John Smith"/>
+        <Tag TagName="Author" TagValue="Jane Doe"/>
+        <Tag TagName="DateCreated" TagValue="2024-01-15T10:30:00Z"/>
+      </Tags>
     </Document>
   </Batch>
 </Root>

--- a/Requirements.md
+++ b/Requirements.md
@@ -298,7 +298,7 @@ The EDRM (Electronic Discovery Reference Model) XML format is a vendor-neutral s
 | `File` | File reference with type (Native, Image, Text, Redacted) |
 | `ExternalFile` | Reference to external file with path, size, hash |
 | `InlineContent` | Embedded content within XML |
-| `Fields` | Metadata fields container |
+| `Tags` | Metadata tags container |
 | `Tag` | Tagging/coding information |
 
 #### Example EDRM XML
@@ -318,7 +318,7 @@ The EDRM (Electronic Discovery Reference Model) XML format is a vendor-neutral s
       <Tags>
         <Tag TagName="Custodian" TagValue="John Smith"/>
         <Tag TagName="Author" TagValue="Jane Doe"/>
-        <Tag TagName="DateCreated" TagValue="2024-01-15T10:30:00Z"/>
+        <Tag TagName="DateSent" TagValue="2024-01-15T10:30:00Z"/>
       </Tags>
     </Document>
   </Batch>

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -10,7 +10,7 @@ namespace Zipper.LoadFiles;
 /// </summary>
 internal class XmlLoadFileWriter : LoadFileWriterBase
 {
-    private const string FieldElement = "Field";
+    private const string TagElement = "Tag";
 
     public override string FormatName => "XML";
 
@@ -74,6 +74,13 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
         }
     }
 
+    private static void AddTag(XElement parent, string name, object? value, string? namingConvention)
+    {
+        parent.Add(new XElement(TagElement,
+            new XAttribute("TagName", NamingConventionHelper.ApplyConvention(name, namingConvention)),
+            new XAttribute("TagValue", value ?? string.Empty)));
+    }
+
     private static XElement CreateDocumentElement(
         FileWorkItem workItem,
         FileData fileData,
@@ -125,47 +132,47 @@ internal class XmlLoadFileWriter : LoadFileWriterBase
 
         docElement.Add(filesElement);
 
-        var fieldsElement = new XElement("Fields");
+        var tagsElement = new XElement("Tags");
 
         if (request.Metadata.ShouldIncludeMetadataColumns(request.Output))
         {
             var metadata = GenerateMetadataValues(workItem, fileData, random, now, request);
 
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("Custodian", namingConvention)), metadata.Custodian));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("DateSent", namingConvention)), metadata.DateSent));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("Author", namingConvention)), metadata.Author));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("FileSize", namingConvention)), metadata.FileSize));
+            AddTag(tagsElement, "Custodian", metadata.Custodian, namingConvention);
+            AddTag(tagsElement, "DateSent", metadata.DateSent, namingConvention);
+            AddTag(tagsElement, "Author", metadata.Author, namingConvention);
+            AddTag(tagsElement, "FileSize", metadata.FileSize, namingConvention);
         }
 
         if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
         {
             var eml = GenerateEmlValues(workItem, fileData, random, now, request);
 
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("To", namingConvention)), eml.To));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("From", namingConvention)), eml.From));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("Subject", namingConvention)), eml.Subject));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("SentDate", namingConvention)), eml.SentDate));
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("Attachment", namingConvention)), eml.Attachment));
+            AddTag(tagsElement, "To", eml.To, namingConvention);
+            AddTag(tagsElement, "From", eml.From, namingConvention);
+            AddTag(tagsElement, "Subject", eml.Subject, namingConvention);
+            AddTag(tagsElement, "SentDate", eml.SentDate, namingConvention);
+            AddTag(tagsElement, "Attachment", eml.Attachment, namingConvention);
         }
 
         if (request.Bates != null)
         {
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("BatesNumber", namingConvention)), GenerateBatesNumber(request, workItem)));
+            AddTag(tagsElement, "BatesNumber", GenerateBatesNumber(request, workItem), namingConvention);
         }
 
         if (request.Tiff.ShouldIncludePageCount(request.Output))
         {
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("PageCount", namingConvention)), fileData.PageCount));
+            AddTag(tagsElement, "PageCount", fileData.PageCount, namingConvention);
         }
 
         if (request.Output.WithText)
         {
-            fieldsElement.Add(new XElement(FieldElement, new XAttribute("Name", NamingConventionHelper.ApplyConvention("ExtractedTextPath", namingConvention)), GenerateTextPath(request, workItem)));
+            AddTag(tagsElement, "ExtractedTextPath", GenerateTextPath(request, workItem), namingConvention);
         }
 
-        if (fieldsElement.HasElements)
+        if (tagsElement.HasElements)
         {
-            docElement.Add(fieldsElement);
+            docElement.Add(tagsElement);
         }
 
         return docElement;

--- a/src/Zipper.Tests/AllWritersTests.cs
+++ b/src/Zipper.Tests/AllWritersTests.cs
@@ -97,14 +97,14 @@ public class AllWritersTests : TempDirectoryTestBase
                 var doc2Content = content.Substring(doc2Index, doc3Index - doc2Index);
                 var doc3Content = content.Substring(doc3Index);
 
-                Assert.Contains("Name=\"PageCount\"", doc1Content);
-                Assert.Contains(">5<", doc1Content);
+                Assert.Contains("TagName=\"PageCount\"", doc1Content);
+                Assert.Contains("TagValue=\"5\"", doc1Content);
 
-                Assert.Contains("Name=\"PageCount\"", doc2Content);
-                Assert.Contains(">7<", doc2Content);
+                Assert.Contains("TagName=\"PageCount\"", doc2Content);
+                Assert.Contains("TagValue=\"7\"", doc2Content);
 
-                Assert.Contains("Name=\"PageCount\"", doc3Content);
-                Assert.Contains(">3<", doc3Content);
+                Assert.Contains("TagName=\"PageCount\"", doc3Content);
+                Assert.Contains("TagValue=\"3\"", doc3Content);
             }
             else if (format == LoadFileFormat.Opt)
             {

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -85,6 +85,8 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
         Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content);
         Assert.Contains("<Tags>", content);
         Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content);
+        Assert.DoesNotContain("<Fields>", content);
+        Assert.DoesNotContain("<Field ", content);
         Assert.Contains("</Document>", content);
         Assert.Contains("</Batch>", content);
         Assert.Contains("</Root>", content);

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -83,8 +83,8 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
         Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.pdf\" FileName=\"file_00000001.pdf\" FileSize=\"14\" Hash=\"", content);
         Assert.Contains("<File FileType=\"Text\">", content);
         Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content);
-        Assert.Contains("<Fields>", content);
-        Assert.Contains("<Field Name=\"Custodian\">Custodian 1</Field>", content);
+        Assert.Contains("<Tags>", content);
+        Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content);
         Assert.Contains("</Document>", content);
         Assert.Contains("</Batch>", content);
         Assert.Contains("</Root>", content);

--- a/tests/test-argument-interactions.bat
+++ b/tests/test-argument-interactions.bat
@@ -9,30 +9,30 @@ set FAILED=0
 
 echo [ INFO ] === CLI Argument Interaction Tests ===
 
-call :assert_rejected "--loadfile-only + --include-load-file" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --include-load-file
-call :assert_rejected "--loadfile-only + --target-zip-size" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --target-zip-size 10MB
-call :assert_rejected "--production-set + --loadfile-only" --production-set --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --bates-prefix TEST
-call :assert_rejected "--chaos-scenario + --chaos-types" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --chaos-mode --chaos-scenario full-chaos --chaos-types quotes
-call :assert_rejected "--chaos-mode without --loadfile-only" --type pdf --count 5 --output-path "%TEMP%\zi_test" --chaos-mode
-call :assert_rejected "--chaos-amount without --chaos-mode" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --chaos-amount "5%%"
-call :assert_rejected "--chaos-types without --chaos-mode" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --chaos-types quotes
-call :assert_rejected "--chaos-scenario without --chaos-mode" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --chaos-scenario full-chaos
-call :assert_rejected "--col-delim without --loadfile-only" --type pdf --count 5 --output-path "%TEMP%\zi_test" --col-delim "char:|"
-call :assert_rejected "--production-set without --bates-prefix" --production-set --count 5 --output-path "%TEMP%\zi_test"
-call :assert_rejected "--production-zip without --production-set" --type pdf --count 5 --output-path "%TEMP%\zi_test" --production-zip
-call :assert_rejected "--volume-size without --production-set" --type pdf --count 5 --output-path "%TEMP%\zi_test" --volume-size 100
-call :assert_rejected "--target-zip-size without --count" --type pdf --output-path "%TEMP%\zi_test" --target-zip-size 10MB
+call :assert_rejected "--loadfile-only + --include-load-file" --loadfile-only --count 5 --output-path ".\results\zi_test" --include-load-file
+call :assert_rejected "--loadfile-only + --target-zip-size" --loadfile-only --count 5 --output-path ".\results\zi_test" --target-zip-size 10MB
+call :assert_rejected "--production-set + --loadfile-only" --production-set --loadfile-only --count 5 --output-path ".\results\zi_test" --bates-prefix TEST
+call :assert_rejected "--chaos-scenario + --chaos-types" --loadfile-only --count 5 --output-path ".\results\zi_test" --chaos-mode --chaos-scenario full-chaos --chaos-types quotes
+call :assert_rejected "--chaos-mode without --loadfile-only" --type pdf --count 5 --output-path ".\results\zi_test" --chaos-mode
+call :assert_rejected "--chaos-amount without --chaos-mode" --loadfile-only --count 5 --output-path ".\results\zi_test" --chaos-amount "5%%"
+call :assert_rejected "--chaos-types without --chaos-mode" --loadfile-only --count 5 --output-path ".\results\zi_test" --chaos-types quotes
+call :assert_rejected "--chaos-scenario without --chaos-mode" --loadfile-only --count 5 --output-path ".\results\zi_test" --chaos-scenario full-chaos
+call :assert_rejected "--col-delim without --loadfile-only" --type pdf --count 5 --output-path ".\results\zi_test" --col-delim "char:|"
+call :assert_rejected "--production-set without --bates-prefix" --production-set --count 5 --output-path ".\results\zi_test"
+call :assert_rejected "--production-zip without --production-set" --type pdf --count 5 --output-path ".\results\zi_test" --production-zip
+call :assert_rejected "--volume-size without --production-set" --type pdf --count 5 --output-path ".\results\zi_test" --volume-size 100
+call :assert_rejected "--target-zip-size without --count" --type pdf --output-path ".\results\zi_test" --target-zip-size 10MB
 
-call :assert_accepted "valid standard --loadfile-only" --loadfile-only --count 5 --output-path "%TEMP%\zi_test"
-call :assert_accepted "valid standard --loadfile-only with --col-delim" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --col-delim "char:|"
-call :assert_accepted "valid standard --production-set" --production-set --count 5 --bates-prefix TEST --type pdf --output-path "%TEMP%\zi_test"
-call :assert_accepted "--loadfile-only + --chaos-mode + --chaos-amount" --loadfile-only --count 5 --chaos-mode --chaos-amount "5%%" --output-path "%TEMP%\zi_test"
-call :assert_accepted "--production-set + --bates-prefix + --volume-size" --production-set --count 5 --bates-prefix TEST --volume-size 100 --output-path "%TEMP%\zi_test"
-call :assert_accepted "--loadfile-only + --col-delim + --quote-delim" --loadfile-only --count 5 --col-delim "char:|" --quote-delim "char:\"" --output-path "%TEMP%\zi_test"
+call :assert_accepted "valid standard --loadfile-only" --loadfile-only --count 5 --output-path ".\results\zi_test"
+call :assert_accepted "valid standard --loadfile-only with --col-delim" --loadfile-only --count 5 --output-path ".\results\zi_test" --col-delim "char:|"
+call :assert_accepted "valid standard --production-set" --production-set --count 5 --bates-prefix TEST --type pdf --output-path ".\results\zi_test"
+call :assert_accepted "--loadfile-only + --chaos-mode + --chaos-amount" --loadfile-only --count 5 --chaos-mode --chaos-amount "5%%" --output-path ".\results\zi_test"
+call :assert_accepted "--production-set + --bates-prefix + --volume-size" --production-set --count 5 --bates-prefix TEST --volume-size 100 --output-path ".\results\zi_test"
+call :assert_accepted "--loadfile-only + --col-delim + --quote-delim" --loadfile-only --count 5 --col-delim "char:|" --quote-delim "char:\"" --output-path ".\results\zi_test"
 
-call :assert_rejected "--loadfile-only + --load-file-format csv" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --load-file-format csv
-call :assert_rejected "--loadfile-only + --load-file-format xml" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --load-file-format xml
-call :assert_rejected "--loadfile-only + --load-file-format concordance" --loadfile-only --count 5 --output-path "%TEMP%\zi_test" --load-file-format concordance
+call :assert_rejected "--loadfile-only + --load-file-format csv" --loadfile-only --count 5 --output-path ".\results\zi_test" --load-file-format csv
+call :assert_rejected "--loadfile-only + --load-file-format xml" --loadfile-only --count 5 --output-path ".\results\zi_test" --load-file-format xml
+call :assert_rejected "--loadfile-only + --load-file-format concordance" --loadfile-only --count 5 --output-path ".\results\zi_test" --load-file-format concordance
 
 echo.
 set /a TOTAL=!PASSED!+!FAILED!
@@ -48,7 +48,9 @@ exit /b 0
 set "DESC=%~1"
 set "ARGS=%*"
 set "ARGS=!ARGS:%1 =!"
-set "STDERR_FILE=%TEMP%\stderr_!PASSED!_!FAILED!.txt"
+set "TEMP_DIR=.\results\test-interactions-%RANDOM%"
+mkdir "%TEMP_DIR%" 2>nul
+set "STDERR_FILE=%TEMP_DIR%\stderr.txt"
 %ZIPPER_CMD% !ARGS! >nul 2>"!STDERR_FILE!"
 if errorlevel 1 (
     findstr /i /c:"Unhandled exception" /c:"NullReferenceException" /c:"Exception:" "!STDERR_FILE!" >nul

--- a/tests/test-argument-interactions.sh
+++ b/tests/test-argument-interactions.sh
@@ -9,7 +9,8 @@ source "$(dirname "$0")/_zipper-cli.sh"
 
 PASSED=0
 FAILED=0
-TEMP_DIR=$(mktemp -d)
+TEMP_DIR="./results/test-interactions-$$"
+mkdir -p "$TEMP_DIR"
 
 function print_info() { local msg="$1"; echo -e "\033[44m[ INFO ]\033[0m $msg"; }
 function print_success() { local msg="$1"; echo -e "\033[42m[ SUCCESS ]\033[0m $msg"; }

--- a/tests/test-eml-comprehensive.bat
+++ b/tests/test-eml-comprehensive.bat
@@ -10,7 +10,7 @@ echo ========================================
 echo.
 
 REM Set test environment
-set "TEST_DIR=%TEMP%\zipper-eml-test-%RANDOM%"
+set "TEST_DIR=.\results\zipper-eml-test-%RANDOM%"
 set "REPO_ROOT=%~dp0.."
 set "FILE_COUNT=20"
 

--- a/tests/test-eml-comprehensive.sh
+++ b/tests/test-eml-comprehensive.sh
@@ -11,7 +11,7 @@ echo "========================================"
 echo
 
 # Set test environment
-TEST_DIR="/tmp/zipper-eml-test-$$"
+TEST_DIR="./results/zipper-eml-test-$$"
 REPO_ROOT="$(pwd)"
 FILE_COUNT=20 # Use a consistent number of files for most tests
 

--- a/tests/test-path-traversal-security.sh
+++ b/tests/test-path-traversal-security.sh
@@ -11,7 +11,8 @@ echo "🔒 Path Traversal Security Test"
 echo "================================="
 
 # Create test directory
-TEST_DIR="$(mktemp -d)"
+TEST_DIR="./results/security_test"
+mkdir -p "$TEST_DIR"
 echo "Created test directory: $TEST_DIR"
 
 # Test 1: Normal path should work


### PR DESCRIPTION
Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated XML metadata representation to use Tags structure instead of Fields for document metadata, including custodian, author, date created, and page count.

* **Documentation**
  * Updated documentation examples to reflect the new XML format.

* **Tests**
  * Updated test assertions to validate the new Tags-based XML structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->