### PR TITLE
fix: Add error messages for missing values

### DIFF
--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -80,6 +80,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --folders requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--encoding":
@@ -89,6 +94,11 @@ public static class CliParser
                         parsed.IsEncodingExplicit = true;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --encoding requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--distribution":
@@ -96,6 +106,11 @@ public static class CliParser
                     {
                         parsed.Distribution = dist;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --distribution requires a value.");
+                        return null;
                     }
 
                     break;
@@ -120,6 +135,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --attachment-rate requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--target-zip-size":
@@ -127,6 +147,11 @@ public static class CliParser
                     {
                         parsed.TargetZipSize = zipSize;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --target-zip-size requires a value.");
+                        return null;
                     }
 
                     break;
@@ -140,6 +165,11 @@ public static class CliParser
                         parsed.IsLoadFileFormatExplicit = true;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --load-file-format requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--bates-prefix":
@@ -147,6 +177,11 @@ public static class CliParser
                     {
                         parsed.BatesPrefix = batesPfx;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --bates-prefix requires a value.");
+                        return null;
                     }
 
                     break;
@@ -165,6 +200,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --bates-start requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--bates-digits":
@@ -182,6 +222,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --bates-digits requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--tiff-pages":
@@ -190,6 +235,11 @@ public static class CliParser
                         parsed.TiffPagesRange = tiffPages;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --tiff-pages requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--column-profile":
@@ -197,6 +247,11 @@ public static class CliParser
                     {
                         parsed.ColumnProfile = colProf;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --column-profile requires a value.");
+                        return null;
                     }
 
                     break;
@@ -215,6 +270,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --seed requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--date-format":
@@ -222,6 +282,11 @@ public static class CliParser
                     {
                         parsed.DateFormat = dateFmt;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --date-format requires a value.");
+                        return null;
                     }
 
                     break;
@@ -240,6 +305,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --empty-percentage requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--custodian-count":
@@ -257,6 +327,11 @@ public static class CliParser
 
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --custodian-count requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--with-families":
@@ -269,6 +344,11 @@ public static class CliParser
                         parsed.IsLoadFileFormatExplicit = true;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --load-file-formats requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--dat-delimiters":
@@ -276,6 +356,11 @@ public static class CliParser
                     {
                         parsed.DatDelimiters = datDelims;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --dat-delimiters requires a value.");
+                        return null;
                     }
 
                     break;
@@ -328,6 +413,11 @@ public static class CliParser
                         parsed.IsLoadFileFormatExplicit = true;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --loadfile-format requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--eol":
@@ -335,6 +425,11 @@ public static class CliParser
                     {
                         parsed.Eol = eolVal;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --eol requires a value.");
+                        return null;
                     }
 
                     break;
@@ -344,6 +439,11 @@ public static class CliParser
                         parsed.ColDelim = colDelimVal;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --col-delim requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--quote-delim":
@@ -351,6 +451,11 @@ public static class CliParser
                     {
                         parsed.QuoteDelim = quoteDelimVal;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --quote-delim requires a value.");
+                        return null;
                     }
 
                     break;
@@ -360,6 +465,11 @@ public static class CliParser
                         parsed.NewlineDelim = newlineDelimVal;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --newline-delim requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--multi-delim":
@@ -368,6 +478,11 @@ public static class CliParser
                         parsed.MultiDelim = multiDelimVal;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --multi-delim requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--nested-delim":
@@ -375,6 +490,11 @@ public static class CliParser
                     {
                         parsed.NestedDelim = nestedDelimVal;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --nested-delim requires a value.");
+                        return null;
                     }
 
                     break;
@@ -387,6 +507,11 @@ public static class CliParser
                         parsed.ChaosAmount = chaosAmtVal;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --chaos-amount requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--chaos-types":
@@ -395,6 +520,11 @@ public static class CliParser
                         parsed.ChaosTypes = chaosTypesVal;
                         i++;
                     }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --chaos-types requires a value.");
+                        return null;
+                    }
 
                     break;
                 case "--chaos-scenario":
@@ -402,6 +532,11 @@ public static class CliParser
                     {
                         parsed.ChaosScenario = chaosScenarioVal;
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --chaos-scenario requires a value.");
+                        return null;
                     }
 
                     break;
@@ -428,6 +563,11 @@ public static class CliParser
                         }
 
                         i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --volume-size requires a value.");
+                        return null;
                     }
 
                     break;

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -28,6 +28,7 @@ namespace Zipper.Tests
         {
             var flags = new[]
             {
+                "--type", "--count", "--output-path", "--delimiter-column", "--delimiter-quote", "--delimiter-newline",
                 "--folders", "--encoding", "--distribution", "--attachment-rate", "--target-zip-size",
                 "--load-file-format", "--bates-prefix", "--bates-start", "--bates-digits", "--tiff-pages",
                 "--column-profile", "--seed", "--date-format", "--empty-percentage", "--custodian-count",

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -24,6 +24,26 @@ namespace Zipper.Tests
         }
 
         [Fact]
+        public void Parse_MissingValueForValueTakingFlags_ReturnsNull()
+        {
+            var flags = new[]
+            {
+                "--folders", "--encoding", "--distribution", "--attachment-rate", "--target-zip-size",
+                "--load-file-format", "--bates-prefix", "--bates-start", "--bates-digits", "--tiff-pages",
+                "--column-profile", "--seed", "--date-format", "--empty-percentage", "--custodian-count",
+                "--load-file-formats", "--dat-delimiters", "--loadfile-format", "--eol", "--col-delim",
+                "--quote-delim", "--newline-delim", "--multi-delim", "--nested-delim", "--chaos-amount",
+                "--chaos-types", "--chaos-scenario", "--volume-size"
+            };
+
+            foreach (var flag in flags)
+            {
+                var result = CliParser.Parse(new[] { flag });
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
         public void Parse_UnknownFlag_OutputsWarningButContinues()
         {
             var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--unknown-flag" });


### PR DESCRIPTION
Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command-line parser now consistently validates that flags requiring values are properly provided with those values. When a required value is missing, the parser returns an error with a flag-specific message to help users understand what went wrong.

* **Tests**
  * Added test coverage for command-line flag validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->