### PR TITLE
chore: escalate AnalysisMode + enable single-file analyzer (#422)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>latest-Recommended</AnalysisMode>
+    <!-- Single-file analysis only supported for net8.0+; netstandard2.0 (Zipper.Analyzers) is excluded by this condition -->
+    <EnableSingleFileAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</EnableSingleFileAnalyzer>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>

--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -14,6 +14,11 @@ public class BuildPropsTests
 
     private static readonly string RepoRoot = FindRepoRoot(AppContext.BaseDirectory);
 
+    /// <summary>
+    /// Walks up the directory tree to locate the root directory containing the build properties file.
+    /// </summary>
+    /// <param name="startDir">The directory to start the search from.</param>
+    /// <returns>The path to the repository root directory.</returns>
     private static string FindRepoRoot(string startDir)
     {
         var dir = new DirectoryInfo(startDir);
@@ -31,6 +36,10 @@ public class BuildPropsTests
             $"Could not find repo root ({BuildPropsFileName}) walking up from: {startDir}");
     }
 
+    /// <summary>
+    /// Loads the root <c>Directory.Build.props</c> file as an XML document.
+    /// </summary>
+    /// <returns>An <see cref="XDocument"/> representing the build properties file.</returns>
     private XDocument LoadBuildProps()
     {
         var path = Path.Combine(RepoRoot, BuildPropsFileName);
@@ -38,12 +47,27 @@ public class BuildPropsTests
         return XDocument.Load(path);
     }
 
+    /// <summary>
+    /// Gets the first XML element with the specified local name.
+    /// </summary>
+    /// <param name="doc">The XML document to search.</param>
+    /// <param name="propertyName">The local name of the property element to find.</param>
+    /// <returns>The <see cref="XElement"/> if found; otherwise, <c>null</c>.</returns>
     private static XElement? GetPropertyElement(XDocument doc, string propertyName)
         => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == propertyName);
 
+    /// <summary>
+    /// Gets the string value of the specified property element.
+    /// </summary>
+    /// <param name="doc">The XML document to search.</param>
+    /// <param name="propertyName">The local name of the property element to find.</param>
+    /// <returns>The trimmed value of the property if found; otherwise, <c>null</c>.</returns>
     private static string? GetPropertyValue(XDocument doc, string propertyName)
         => GetPropertyElement(doc, propertyName)?.Value.Trim();
 
+    /// <summary>
+    /// Verifies that the <c>AnalysisMode</c> property is set to <c>latest-Recommended</c>.
+    /// </summary>
     [Fact]
     public void DirectoryBuildProps_ShouldHave_AnalysisMode_Set()
     {
@@ -54,6 +78,9 @@ public class BuildPropsTests
         Assert.Equal("latest-Recommended", value);
     }
 
+    /// <summary>
+    /// Verifies that the <c>EnableSingleFileAnalyzer</c> property is enabled with the correct TargetFramework condition.
+    /// </summary>
     [Fact]
     public void DirectoryBuildProps_ShouldHave_EnableSingleFileAnalyzer_True()
     {

--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -1,0 +1,77 @@
+using System.Xml.Linq;
+using Xunit;
+
+namespace Zipper;
+
+/// <summary>
+/// Tests that verify Directory.Build.props contains the required build property settings.
+/// These tests enforce the build configuration contract so that settings cannot be
+/// accidentally removed without a failing test.
+/// </summary>
+public class BuildPropsTests
+{
+    private const string BuildPropsFileName = "Directory.Build.props";
+
+    private static readonly string RepoRoot = FindRepoRoot(AppContext.BaseDirectory);
+
+    private static string FindRepoRoot(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, BuildPropsFileName)))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find repo root ({BuildPropsFileName}) walking up from: {startDir}");
+    }
+
+    private XDocument LoadBuildProps()
+    {
+        var path = Path.Combine(RepoRoot, BuildPropsFileName);
+        Assert.True(File.Exists(path), $"{BuildPropsFileName} not found at: {path}");
+        return XDocument.Load(path);
+    }
+
+    private static XElement? GetPropertyElement(XDocument doc, string propertyName)
+        => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == propertyName);
+
+    private static string? GetPropertyValue(XDocument doc, string propertyName)
+        => GetPropertyElement(doc, propertyName)?.Value.Trim();
+
+    [Fact]
+    public void DirectoryBuildProps_ShouldHave_AnalysisMode_Set()
+    {
+        var doc = LoadBuildProps();
+        var value = GetPropertyValue(doc, "AnalysisMode");
+        Assert.NotNull(value);
+        Assert.NotEmpty(value);
+        Assert.Equal("latest-Recommended", value);
+    }
+
+    [Fact]
+    public void DirectoryBuildProps_ShouldHave_EnableSingleFileAnalyzer_True()
+    {
+        var doc = LoadBuildProps();
+
+        // Exactly one element: no accidental unconditional duplicate that would cause NETSDK1211
+        var elements = doc.Descendants()
+            .Where(e => e.Name.LocalName == "EnableSingleFileAnalyzer")
+            .ToList();
+        var element = Assert.Single(elements);
+        Assert.Equal("true", element.Value.Trim(), ignoreCase: true);
+
+        // The Condition must use IsTargetFrameworkCompatible (not a simple equality check like
+        // '$(TargetFramework)' == 'net8.0') so that net9.0+ also receives the analyzer.
+        // netstandard2.0 (Zipper.Analyzers) evaluates to false and is correctly excluded.
+        var condition = element.Attribute("Condition")?.Value;
+        Assert.NotNull(condition);
+        Assert.Contains("IsTargetFrameworkCompatible", condition, StringComparison.Ordinal);
+        Assert.Contains("net8.0", condition, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

Activates the full .NET recommended analyzer ruleset and enables the single-file publish analyzer. Part of #421. Depends on #420 (already merged).

## Changes

### `Directory.Build.props`
- **`<AnalysisMode>latest-Recommended</AnalysisMode>`** — Previously `AnalysisLevel=latest` was set but `AnalysisMode` was unset, leaving only the default CA subset active. This activates the full recommended ruleset.
- **`<EnableSingleFileAnalyzer Condition="...">true</EnableSingleFileAnalyzer>`** — The project already sets `PublishSingleFile=true` but had no analyzer guarding single-file-unsafe APIs (e.g. `Assembly.Location`). The condition `$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))` correctly excludes `Zipper.Analyzers` (targets `netstandard2.0`), which does not support single-file analysis and would otherwise emit NETSDK1211 warnings.

### `src/Zipper.Tests/BuildPropsTests.cs` (new)
- TDD: tests were written first (failing red), then the props were added (green).
- `DirectoryBuildProps_ShouldHave_AnalysisMode_Set` — enforces `AnalysisMode=latest-Recommended` as a build-configuration contract.
- `DirectoryBuildProps_ShouldHave_EnableSingleFileAnalyzer_True` — enforces the `EnableSingleFileAnalyzer` element exists with value `true`, uses `Assert.Single` to guard against accidental duplicate elements, and verifies the `Condition` uses `IsTargetFrameworkCompatible` (not a simple equality check that would silently exclude net9.0+).

## Acceptance checklist

- [x] `AnalysisMode` set in `Directory.Build.props`
- [x] `EnableSingleFileAnalyzer=true` (conditional on net8.0+ via `IsTargetFrameworkCompatible`)
- [x] Warning backlog triaged — build is already clean (0 warnings with `TreatWarningsAsErrors=true`); no new warnings introduced by the escalated ruleset
- [x] Build clean (0 warnings, `TreatWarningsAsErrors` on); all 1045 tests pass
- [x] `dotnet format --verify-no-changes` clean

## Review notes

Autoreview ran (4 specialists in parallel: correctness, adversarial, testing, maintainability). All findings were INFO; none were ACTION. All AUTO-FIX items applied before this PR was opened:
- Extracted `BuildPropsFileName` constant (eliminates 4× repeated literal)
- Added `GetPropertyElement` helper used by both tests (removes open-coded duplicate query)
- Used `Assert.Single` instead of `FirstOrDefault` for the `EnableSingleFileAnalyzer` check
- Tightened `Condition` assertion to also verify `IsTargetFrameworkCompatible` is present (multi-source confirmed across 3 specialists)

One finding intentionally rejected: Correctness specialist (conf 7) suggested collapsing `AnalysisLevel=latest` + `AnalysisMode=latest-Recommended` into a single `AnalysisLevel=latest-Recommended`. Rejected because the issue body explicitly prescribes `<AnalysisMode>latest-Recommended</AnalysisMode>` as the property to add, and the build is clean today. Can be consolidated in a follow-up if desired.

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to improve static code analysis on .NET 8.0+
* **Tests**
  * Added validation tests for build configuration properties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->