### PR TITLE
feat: add Meziantou.Analyzer + BannedApiAnalyzers — culture/locale guardrails

### DIFF
--- a/.agents/skills/autoreview/OPERATIONS.local.md
+++ b/.agents/skills/autoreview/OPERATIONS.local.md
@@ -1,0 +1,8 @@
+
+### 2026-06-09 claude-code:branch:feat/ISSUE-422-chore-escalate-analysismode-enable-singl
+
+- **findings**: 0 ACTION, 12 INFO (across 4 specialists). Key: multi-source confirmed (testing+adversarial+correctness) — Condition assertion too loose (needed IsTargetFrameworkCompatible check). Others: filename literal constant (maintainability), GetPropertyElement helper refactor (maintainability), Assert.Single instead of FirstOrDefault (testing), AnalysisLevel+AnalysisMode redundancy (correctness, rejected per issue spec).
+- **outcome**: all AUTO-FIX items applied (4 fixes); 1 INFO finding rejected (AnalysisLevel+AnalysisMode collapse — not prescribed by issue). PR created: #477.
+- **telemetry**: host=claude-code mode=branch specialists=4 bundle=~2500c
+- **lessons**: For build-config-only diffs, all specialists return INFO at most. The Condition-assertion-too-loose finding was the only multi-source finding and most valuable — caught by testing (conf 8), adversarial (conf 8), and correctness (conf 8).
+- **suppressions**: none

--- a/.editorconfig
+++ b/.editorconfig
@@ -131,6 +131,24 @@ dotnet_diagnostic.CA1311.severity = warning   # specify culture / use invariant 
 # CA1308 intentionally NOT enabled: hash hex is emitted lowercase (ToLowerInvariant) per
 # EDRM document-hash convention; forcing ToUpperInvariant would break byte-identity/goldens.
 
+# --- Meziantou.Analyzer & Banned APIs ---
+dotnet_diagnostic.MA0011.severity = error     # IFormatProvider is missing
+dotnet_diagnostic.RS0030.severity = error     # Do not use banned APIs
+dotnet_diagnostic.MA0048.severity = none      # File name must match type name
+dotnet_diagnostic.MA0051.severity = none      # Method is too long
+dotnet_diagnostic.MA0016.severity = none      # Prefer collection abstraction
+dotnet_diagnostic.MA0015.severity = none      # ArgumentException parameter name
+dotnet_diagnostic.MA0023.severity = none      # RegexOptions
+dotnet_diagnostic.MA0025.severity = none      # NotImplementedException
+dotnet_diagnostic.MA0144.severity = none
+dotnet_diagnostic.MA0158.severity = none      # Lock
+dotnet_diagnostic.MA0169.severity = none
+dotnet_diagnostic.MA0004.severity = none
+dotnet_diagnostic.MA0002.severity = none
+dotnet_diagnostic.MA0006.severity = none
+dotnet_diagnostic.MA0072.severity = none
+
+
 # --- Performance quick wins ---
 dotnet_diagnostic.CA1510.severity = warning   # use ArgumentNullException.ThrowIfNull
 dotnet_diagnostic.CA1513.severity = warning   # use ObjectDisposedException.ThrowIf

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,0 +1,6 @@
+P:System.DateTime.Now;Use DateTime.UtcNow instead
+P:System.Globalization.CultureInfo.CurrentCulture;Use CultureInfo.InvariantCulture instead
+M:System.String.Format(System.String,System.Object);Use an overload that takes an IFormatProvider instead
+M:System.String.Format(System.String,System.Object[]);Use an overload that takes an IFormatProvider instead
+M:System.String.Format(System.String,System.Object,System.Object);Use an overload that takes an IFormatProvider instead
+M:System.String.Format(System.String,System.Object,System.Object,System.Object);Use an overload that takes an IFormatProvider instead

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.102">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
   </ItemGroup>
 
 </Project>

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,4633 @@
+diff --git a/.agents/skills/autoreview/OPERATIONS.local.md b/.agents/skills/autoreview/OPERATIONS.local.md
+new file mode 100644
+index 0000000..a4cb0cd
+--- /dev/null
++++ b/.agents/skills/autoreview/OPERATIONS.local.md
+@@ -0,0 +1,8 @@
++
++### 2026-06-09 claude-code:branch:feat/ISSUE-422-chore-escalate-analysismode-enable-singl
++
++- **findings**: 0 ACTION, 12 INFO (across 4 specialists). Key: multi-source confirmed (testing+adversarial+correctness) — Condition assertion too loose (needed IsTargetFrameworkCompatible check). Others: filename literal constant (maintainability), GetPropertyElement helper refactor (maintainability), Assert.Single instead of FirstOrDefault (testing), AnalysisLevel+AnalysisMode redundancy (correctness, rejected per issue spec).
++- **outcome**: all AUTO-FIX items applied (4 fixes); 1 INFO finding rejected (AnalysisLevel+AnalysisMode collapse — not prescribed by issue). PR created: #477.
++- **telemetry**: host=claude-code mode=branch specialists=4 bundle=~2500c
++- **lessons**: For build-config-only diffs, all specialists return INFO at most. The Condition-assertion-too-loose finding was the only multi-source finding and most valuable — caught by testing (conf 8), adversarial (conf 8), and correctness (conf 8).
++- **suppressions**: none
+diff --git a/.editorconfig b/.editorconfig
+index e8539d0..d7a067e 100644
+--- a/.editorconfig
++++ b/.editorconfig
+@@ -131,6 +131,24 @@ dotnet_diagnostic.CA1311.severity = warning   # specify culture / use invariant
+ # CA1308 intentionally NOT enabled: hash hex is emitted lowercase (ToLowerInvariant) per
+ # EDRM document-hash convention; forcing ToUpperInvariant would break byte-identity/goldens.
+ 
++# --- Meziantou.Analyzer & Banned APIs ---
++dotnet_diagnostic.MA0011.severity = error     # IFormatProvider is missing
++dotnet_diagnostic.RS0030.severity = error     # Do not use banned APIs
++dotnet_diagnostic.MA0048.severity = none      # File name must match type name
++dotnet_diagnostic.MA0051.severity = none      # Method is too long
++dotnet_diagnostic.MA0016.severity = none      # Prefer collection abstraction
++dotnet_diagnostic.MA0015.severity = none      # ArgumentException parameter name
++dotnet_diagnostic.MA0023.severity = none      # RegexOptions
++dotnet_diagnostic.MA0025.severity = none      # NotImplementedException
++dotnet_diagnostic.MA0144.severity = none
++dotnet_diagnostic.MA0158.severity = none      # Lock
++dotnet_diagnostic.MA0169.severity = none
++dotnet_diagnostic.MA0004.severity = none
++dotnet_diagnostic.MA0002.severity = none
++dotnet_diagnostic.MA0006.severity = none
++dotnet_diagnostic.MA0072.severity = none
++
++
+ # --- Performance quick wins ---
+ dotnet_diagnostic.CA1510.severity = warning   # use ArgumentNullException.ThrowIfNull
+ dotnet_diagnostic.CA1513.severity = warning   # use ObjectDisposedException.ThrowIf
+diff --git a/BannedSymbols.txt b/BannedSymbols.txt
+new file mode 100644
+index 0000000..ec53d8b
+--- /dev/null
++++ b/BannedSymbols.txt
+@@ -0,0 +1,6 @@
++P:System.DateTime.Now;Use DateTime.UtcNow instead
++P:System.Globalization.CultureInfo.CurrentCulture;Use CultureInfo.InvariantCulture instead
++M:System.String.Format(System.String,System.Object);Use an overload that takes an IFormatProvider instead
++M:System.String.Format(System.String,System.Object[]);Use an overload that takes an IFormatProvider instead
++M:System.String.Format(System.String,System.Object,System.Object);Use an overload that takes an IFormatProvider instead
++M:System.String.Format(System.String,System.Object,System.Object,System.Object);Use an overload that takes an IFormatProvider instead
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 6d68b38..822cfbb 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -18,6 +18,18 @@
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+     </PackageReference>
++    <PackageReference Include="Meziantou.Analyzer" Version="3.0.102">
++      <PrivateAssets>all</PrivateAssets>
++      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
++    </PackageReference>
++    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
++      <PrivateAssets>all</PrivateAssets>
++      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
++    </PackageReference>
++  </ItemGroup>
++
++  <ItemGroup>
++    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+   </ItemGroup>
+ 
+ </Project>
+diff --git a/src/ChaosEngine.cs b/src/ChaosEngine.cs
+index 3aeca9d..cef3ae3 100644
+--- a/src/ChaosEngine.cs
++++ b/src/ChaosEngine.cs
+@@ -150,7 +150,7 @@ internal class ChaosEngine
+             // Unpaired high surrogate in little-endian: 0x00D8 as LE bytes
+             invalidBytes = new byte[] { 0x00, 0xD8 };
+         }
+-        else if (encodingName.Contains("UTF-8", StringComparison.Ordinal) || encodingName == "UTF-8")
++        else if (encodingName.Contains("UTF-8", StringComparison.Ordinal) || string.Equals(encodingName, "UTF-8", StringComparison.Ordinal))
+         {
+             // Invalid UTF-8 continuation byte without start byte
+             invalidBytes = new byte[] { 0xFE, 0xFF };
+@@ -183,13 +183,13 @@ internal class ChaosEngine
+ 
+         if (chaosAmount.EndsWith('%'))
+         {
+-            if (double.TryParse(chaosAmount.TrimEnd('%'), out var pct))
++            if (double.TryParse(chaosAmount.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture, out var pct))
+             {
+                 return Math.Max(1, (int)(totalLines * pct / 100.0));
+             }
+         }
+ 
+-        if (int.TryParse(chaosAmount, out var exact))
++        if (int.TryParse(chaosAmount, System.Globalization.CultureInfo.InvariantCulture, out var exact))
+         {
+             return Math.Min(exact, totalLines);
+         }
+@@ -347,7 +347,7 @@ internal class ChaosEngine
+         delimiterIndex = this.random.Next(positions.Count) + 1;
+         int targetPos = positions[delimiterIndex - 1];
+ 
+-        var alternatives = AlternativeDelimiters.Where(c => c.ToString() != this.columnDelimiter).ToArray();
++        var alternatives = AlternativeDelimiters.Where(c => !string.Equals(c.ToString(), this.columnDelimiter, StringComparison.Ordinal)).ToArray();
+         if (alternatives.Length == 0)
+         {
+             return line;
+@@ -444,7 +444,7 @@ internal class ChaosEngine
+         var parts = line.Split(',');
+         if (parts.Length >= 4)
+         {
+-            parts[3] = parts[3].Trim() == "Y" ? string.Empty : "Y";
++            parts[3] = string.Equals(parts[3].Trim(), "Y", StringComparison.Ordinal) ? string.Empty : "Y";
+             return string.Join(",", parts);
+         }
+ 
+diff --git a/src/Cli/CliParser.cs b/src/Cli/CliParser.cs
+index c7167b1..1a7970f 100644
+--- a/src/Cli/CliParser.cs
++++ b/src/Cli/CliParser.cs
+@@ -28,7 +28,7 @@ public static class CliParser
+                 case "--count":
+                     if (TryGetValue(args, i, out var countStr))
+                     {
+-                        if (long.TryParse(countStr, out var count))
++                        if (long.TryParse(countStr, System.Globalization.CultureInfo.InvariantCulture, out var count))
+                         {
+                             parsed.Count = count;
+                             i++;
+@@ -68,7 +68,7 @@ public static class CliParser
+                 case "--folders":
+                     if (TryGetValue(args, i, out var foldersStr))
+                     {
+-                        if (int.TryParse(foldersStr, out var folders))
++                        if (int.TryParse(foldersStr, System.Globalization.CultureInfo.InvariantCulture, out var folders))
+                         {
+                             parsed.Folders = folders;
+                         }
+@@ -123,7 +123,7 @@ public static class CliParser
+                 case "--attachment-rate":
+                     if (TryGetValue(args, i, out var attRateStr))
+                     {
+-                        if (int.TryParse(attRateStr, out var attachmentRate))
++                        if (int.TryParse(attRateStr, System.Globalization.CultureInfo.InvariantCulture, out var attachmentRate))
+                         {
+                             parsed.AttachmentRate = attachmentRate;
+                         }
+@@ -188,7 +188,7 @@ public static class CliParser
+                 case "--bates-start":
+                     if (TryGetValue(args, i, out var batesStartStr))
+                     {
+-                        if (long.TryParse(batesStartStr, out var batesStart))
++                        if (long.TryParse(batesStartStr, System.Globalization.CultureInfo.InvariantCulture, out var batesStart))
+                         {
+                             parsed.BatesStart = batesStart;
+                         }
+@@ -210,7 +210,7 @@ public static class CliParser
+                 case "--bates-digits":
+                     if (TryGetValue(args, i, out var batesDigitsStr))
+                     {
+-                        if (int.TryParse(batesDigitsStr, out var batesDigits))
++                        if (int.TryParse(batesDigitsStr, System.Globalization.CultureInfo.InvariantCulture, out var batesDigits))
+                         {
+                             parsed.BatesDigits = batesDigits;
+                         }
+@@ -258,7 +258,7 @@ public static class CliParser
+                 case "--seed":
+                     if (TryGetValue(args, i, out var seedStr))
+                     {
+-                        if (int.TryParse(seedStr, out var seed))
++                        if (int.TryParse(seedStr, System.Globalization.CultureInfo.InvariantCulture, out var seed))
+                         {
+                             parsed.Seed = seed;
+                         }
+@@ -293,7 +293,7 @@ public static class CliParser
+                 case "--empty-percentage":
+                     if (TryGetValue(args, i, out var emptyPctStr))
+                     {
+-                        if (int.TryParse(emptyPctStr, out var emptyPct))
++                        if (int.TryParse(emptyPctStr, System.Globalization.CultureInfo.InvariantCulture, out var emptyPct))
+                         {
+                             parsed.EmptyPercentage = emptyPct;
+                         }
+@@ -315,7 +315,7 @@ public static class CliParser
+                 case "--custodian-count":
+                     if (TryGetValue(args, i, out var custCountStr))
+                     {
+-                        if (int.TryParse(custCountStr, out var custCount))
++                        if (int.TryParse(custCountStr, System.Globalization.CultureInfo.InvariantCulture, out var custCount))
+                         {
+                             parsed.CustodianCount = custCount;
+                         }
+@@ -549,7 +549,7 @@ public static class CliParser
+                 case "--volume-size":
+                     if (TryGetValue(args, i, out var volumeSizeVal))
+                     {
+-                        if (int.TryParse(volumeSizeVal, out var volumeSize))
++                        if (int.TryParse(volumeSizeVal, System.Globalization.CultureInfo.InvariantCulture, out var volumeSize))
+                         {
+                             parsed.VolumeSize = volumeSize;
+                         }
+diff --git a/src/Cli/CliValidator.cs b/src/Cli/CliValidator.cs
+index 7f86e2f..1b09859 100644
+--- a/src/Cli/CliValidator.cs
++++ b/src/Cli/CliValidator.cs
+@@ -197,7 +197,7 @@ public static class CliValidator
+         if (!string.IsNullOrEmpty(parsed.DatDelimiters))
+         {
+             var delim = parsed.DatDelimiters.ToLowerInvariant();
+-            if (delim != "standard" && delim != "csv")
++            if (!string.Equals(delim, "standard", StringComparison.Ordinal) && !string.Equals(delim, "csv", StringComparison.Ordinal))
+             {
+                 Console.Error.WriteLine("Error: DAT delimiters must be 'standard' or 'csv'.");
+                 return false;
+@@ -235,7 +235,7 @@ public static class CliValidator
+                 return false;
+             }
+ 
+-            if (parsed.BatesPrefix == ".." || parsed.BatesPrefix.Contains("../", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("..\\", StringComparison.Ordinal))
++            if (string.Equals(parsed.BatesPrefix, "..", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("../", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("..\\", StringComparison.Ordinal))
+             {
+                 Console.Error.WriteLine("Error: --bates-prefix must not contain directory traversal sequences.");
+                 return false;
+@@ -456,7 +456,7 @@ public static class CliValidator
+         if (!string.IsNullOrEmpty(parsed.Eol))
+         {
+             var eolUpper = parsed.Eol.ToUpperInvariant();
+-            if (eolUpper != "CRLF" && eolUpper != "LF" && eolUpper != "CR")
++            if (!string.Equals(eolUpper, "CRLF", StringComparison.Ordinal) && !string.Equals(eolUpper, "LF", StringComparison.Ordinal) && !string.Equals(eolUpper, "CR", StringComparison.Ordinal))
+             {
+                 Console.Error.WriteLine("Error: --eol must be CRLF, LF, or CR.");
+                 return false;
+@@ -490,7 +490,7 @@ public static class CliValidator
+         if (value.StartsWith("ascii:", StringComparison.OrdinalIgnoreCase))
+         {
+             var numPart = value.Substring(6);
+-            return int.TryParse(numPart, out var code) && code >= 0 && code <= 255;
++            return int.TryParse(numPart, System.Globalization.CultureInfo.InvariantCulture, out var code) && code >= 0 && code <= 255;
+         }
+ 
+         if (value.StartsWith("char:", StringComparison.OrdinalIgnoreCase))
+@@ -505,9 +505,9 @@ public static class CliValidator
+     {
+         if (value.EndsWith('%'))
+         {
+-            return double.TryParse(value.TrimEnd('%'), out var pct) && pct > 0;
++            return double.TryParse(value.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture, out var pct) && pct > 0;
+         }
+ 
+-        return int.TryParse(value, out var count) && count > 0;
++        return int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var count) && count > 0;
+     }
+ }
+diff --git a/src/Cli/RequestBuilder.cs b/src/Cli/RequestBuilder.cs
+index 03f91f1..d4c3ff2 100644
+--- a/src/Cli/RequestBuilder.cs
++++ b/src/Cli/RequestBuilder.cs
+@@ -42,7 +42,7 @@ public static class RequestBuilder
+         else if (!parsed.IsLoadFileFormatExplicit)
+         {
+             var fileType = (parsed.FileType ?? "pdf").ToLowerInvariant();
+-            if (fileType == "tiff" || fileType == "jpg")
++            if (string.Equals(fileType, "tiff", StringComparison.Ordinal) || string.Equals(fileType, "jpg", StringComparison.Ordinal))
+             {
+                 multiFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt };
+             }
+@@ -188,7 +188,7 @@ public static class RequestBuilder
+             if (size.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+             {
+                 var numberPart = size.Substring(0, size.Length - suffix.Length);
+-                return long.TryParse(numberPart, out var value) ? value * multiplier : null;
++                return long.TryParse(numberPart, System.Globalization.CultureInfo.InvariantCulture, out var value) ? value * multiplier : null;
+             }
+         }
+ 
+@@ -229,27 +229,27 @@ public static class RequestBuilder
+             throw new ArgumentException("Delimiter argument cannot be empty.");
+         }
+ 
+-        if (arg == "\\t")
++        if (string.Equals(arg, "\\t", StringComparison.Ordinal))
+         {
+             return "\t";
+         }
+ 
+-        if (arg == "\\n")
++        if (string.Equals(arg, "\\n", StringComparison.Ordinal))
+         {
+             return "\n";
+         }
+ 
+-        if (arg == "\\r")
++        if (string.Equals(arg, "\\r", StringComparison.Ordinal))
+         {
+             return "\r";
+         }
+ 
+-        if (arg == "\\r\\n")
++        if (string.Equals(arg, "\\r\\n", StringComparison.Ordinal))
+         {
+             return "\r\n";
+         }
+ 
+-        if (int.TryParse(arg, out var asciiCode) && asciiCode >= 0 && asciiCode <= 255)
++        if (int.TryParse(arg, System.Globalization.CultureInfo.InvariantCulture, out var asciiCode) && asciiCode >= 0 && asciiCode <= 255)
+         {
+             return ((char)asciiCode).ToString();
+         }
+@@ -267,7 +267,7 @@ public static class RequestBuilder
+         if (arg.StartsWith("ascii:", StringComparison.OrdinalIgnoreCase))
+         {
+             var numPart = arg.Substring(6);
+-            if (int.TryParse(numPart, out var code) && code >= 0 && code <= 255)
++            if (int.TryParse(numPart, System.Globalization.CultureInfo.InvariantCulture, out var code) && code >= 0 && code <= 255)
+             {
+                 return ((char)code).ToString();
+             }
+diff --git a/src/Config/OutputConfig.cs b/src/Config/OutputConfig.cs
+index 3b97f63..800914d 100644
+--- a/src/Config/OutputConfig.cs
++++ b/src/Config/OutputConfig.cs
+@@ -20,7 +20,7 @@ public record OutputConfig
+ 
+     public string FileTypeLower => this.FileType.ToLowerInvariant();
+ 
+-    public bool IsEml => this.FileTypeLower == "eml";
++    public bool IsEml => string.Equals(this.FileTypeLower, "eml", StringComparison.Ordinal);
+ 
+-    public bool IsTiff => this.FileTypeLower == "tiff";
++    public bool IsTiff => string.Equals(this.FileTypeLower, "tiff", StringComparison.Ordinal);
+ }
+diff --git a/src/DiskBackedFileDataList.cs b/src/DiskBackedFileDataList.cs
+index b544d10..60f6574 100644
+--- a/src/DiskBackedFileDataList.cs
++++ b/src/DiskBackedFileDataList.cs
+@@ -10,7 +10,7 @@ namespace Zipper
+         private FileStream? writeStream;
+         private BinaryWriter? writer;
+         private int count;
+-        private readonly object syncRoot = new object();
++        private readonly Lock syncRoot = new();
+ 
+         public DiskBackedFileDataList()
+         {
+diff --git a/src/Emails/Email.cs b/src/Emails/Email.cs
+index 6517915..fbfcf85 100644
+--- a/src/Emails/Email.cs
++++ b/src/Emails/Email.cs
+@@ -11,7 +11,7 @@ public record Email
+ 
+     public string Subject { get; init; } = string.Empty;
+ 
+-    public DateTime SentDate { get; init; } = DateTime.Now;
++    public DateTime SentDate { get; init; } = DateTime.UtcNow;
+ 
+     public string Body { get; init; } = string.Empty;
+ 
+diff --git a/src/Emails/EmailFactory.cs b/src/Emails/EmailFactory.cs
+index d32d2ad..8d03ebd 100644
+--- a/src/Emails/EmailFactory.cs
++++ b/src/Emails/EmailFactory.cs
+@@ -146,13 +146,13 @@ internal static class EmailFactory
+         ArgumentNullException.ThrowIfNull(seeded);
+         var referenceDate = request.Metadata.Seed.HasValue
+             ? new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local)
+-            : DateTime.Now;
++            : DateTime.UtcNow;
+         return Create((int)item.Index, (int)item.Index, category: null, seeded, referenceDate);
+     }
+ 
+     internal static Email Create(int recipientIndex, int senderIndex, EmailCategory? category, Random random)
+     {
+-        return Create(recipientIndex, senderIndex, category, random, DateTime.Now);
++        return Create(recipientIndex, senderIndex, category, random, DateTime.UtcNow);
+     }
+ 
+     internal static Email Create(int recipientIndex, int senderIndex, EmailCategory? category, Random random, DateTime referenceDate)
+@@ -179,7 +179,7 @@ internal static class EmailFactory
+     {
+         ArgumentNullException.ThrowIfNull(context);
+         ArgumentNullException.ThrowIfNull(random);
+-        var referenceDate = DateTime.Now;
++        var referenceDate = DateTime.UtcNow;
+         var baseTemplate = GetContextualBaseTemplate(context);
+         return new Email
+         {
+@@ -237,6 +237,7 @@ internal static class EmailFactory
+     private static Dictionary<string, string> BuildReplacements(int recipientIndex, int senderIndex, Random random, DateTime referenceDate)
+     {
+         return new Dictionary<string, string>
++(StringComparer.Ordinal)
+         {
+             ["{recipient}"] = $"Recipient {recipientIndex:D3}",
+             ["{sender}"] = $"Sender {senderIndex:D3}",
+diff --git a/src/GenerationRunner.cs b/src/GenerationRunner.cs
+index a4ad92c..b55c40d 100644
+--- a/src/GenerationRunner.cs
++++ b/src/GenerationRunner.cs
+@@ -15,7 +15,7 @@ namespace Zipper
+         {
+             try
+             {
+-                await mode.RunAsync(request);
++                await mode.RunAsync(request).ConfigureAwait(false);
+                 return 0;
+             }
+             catch (Exception ex)
+diff --git a/src/LoadFiles/ConcordanceComposingWriter.cs b/src/LoadFiles/ConcordanceComposingWriter.cs
+index a56ba6c..0790be0 100644
+--- a/src/LoadFiles/ConcordanceComposingWriter.cs
++++ b/src/LoadFiles/ConcordanceComposingWriter.cs
+@@ -23,6 +23,6 @@ internal sealed class ConcordanceComposingWriter : ILoadFileWriter
+         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+ 
+         await LoadFileEmitter.EmitAsync(
+-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null);
++            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
+     }
+ }
+diff --git a/src/LoadFiles/CsvComposingWriter.cs b/src/LoadFiles/CsvComposingWriter.cs
+index fd56012..78db728 100644
+--- a/src/LoadFiles/CsvComposingWriter.cs
++++ b/src/LoadFiles/CsvComposingWriter.cs
+@@ -22,6 +22,6 @@ internal sealed class CsvComposingWriter : ILoadFileWriter
+         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+ 
+         await LoadFileEmitter.EmitAsync(
+-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null);
++            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
+     }
+ }
+diff --git a/src/LoadFiles/DatComposingWriter.cs b/src/LoadFiles/DatComposingWriter.cs
+index 64c3974..7d1cf12 100644
+--- a/src/LoadFiles/DatComposingWriter.cs
++++ b/src/LoadFiles/DatComposingWriter.cs
+@@ -41,6 +41,6 @@ internal sealed class DatComposingWriter : ILoadFileWriter
+             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
+ 
+         var records = composer.Compose(processedFiles);
+-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine);
++        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
+     }
+ }
+diff --git a/src/LoadFiles/LoadFileEmitter.cs b/src/LoadFiles/LoadFileEmitter.cs
+index 8940428..dc4661a 100644
+--- a/src/LoadFiles/LoadFileEmitter.cs
++++ b/src/LoadFiles/LoadFileEmitter.cs
+@@ -46,11 +46,11 @@ internal static class LoadFileEmitter
+ 
+         if (chaosEngine == null)
+         {
+-            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol);
++            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol).ConfigureAwait(false);
+         }
+         else
+         {
+-            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine);
++            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
+         }
+     }
+ 
+@@ -66,21 +66,26 @@ internal static class LoadFileEmitter
+         // A StreamWriter owns the encoding preamble (written once) and chunks output to the
+         // underlying stream by its internal buffer, so records stream out without the whole
+         // file ever being materialized in memory.
+-        await using var writer = new StreamWriter(stream, encoding, leaveOpen: true);
+-
+-        if (hasHeader)
++        var writer = new StreamWriter(stream, encoding, leaveOpen: true);
++        // A StreamWriter owns the encoding preamble (written once) and chunks output to the
++        // underlying stream by its internal buffer, so records stream out without the whole
++        // file ever being materialized in memory.
++        await using (writer.ConfigureAwait(false))
+         {
+-            await writer.WriteAsync(serializer.RenderHeader(headerColumns));
+-            await writer.WriteAsync(eol);
+-        }
++            if (hasHeader)
++            {
++                await writer.WriteAsync(serializer.RenderHeader(headerColumns)).ConfigureAwait(false);
++                await writer.WriteAsync(eol).ConfigureAwait(false);
++            }
+ 
+-        foreach (var record in records)
+-        {
+-            await writer.WriteAsync(serializer.RenderRecord(record));
+-            await writer.WriteAsync(eol);
+-        }
++            foreach (var record in records)
++            {
++                await writer.WriteAsync(serializer.RenderRecord(record)).ConfigureAwait(false);
++                await writer.WriteAsync(eol).ConfigureAwait(false);
++            }
+ 
+-        await writer.FlushAsync();
++            await writer.FlushAsync().ConfigureAwait(false);
++        }
+     }
+ 
+     private static async Task EmitWithChaosAsync(
+@@ -99,19 +104,19 @@ internal static class LoadFileEmitter
+         var preamble = encoding.GetPreamble();
+         if (preamble.Length > 0)
+         {
+-            await stream.WriteAsync(preamble);
++            await stream.WriteAsync(preamble).ConfigureAwait(false);
+         }
+ 
+         long lineNumber = 1;
+         if (hasHeader)
+         {
+-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol);
++            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol).ConfigureAwait(false);
+             lineNumber++;
+         }
+ 
+         foreach (var record in records)
+         {
+-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol);
++            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol).ConfigureAwait(false);
+             lineNumber++;
+         }
+     }
+@@ -129,12 +134,12 @@ internal static class LoadFileEmitter
+             ? chaosEngine.Intercept(lineNumber, originalLine, recordId)
+             : originalLine;
+ 
+-        await stream.WriteAsync(encoding.GetBytes(text + eol));
++        await stream.WriteAsync(encoding.GetBytes(text + eol)).ConfigureAwait(false);
+ 
+         var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
+         if (anomaly != null)
+         {
+-            await stream.WriteAsync(anomaly);
++            await stream.WriteAsync(anomaly).ConfigureAwait(false);
+         }
+     }
+ }
+diff --git a/src/LoadFiles/LoadFileRecordBuilder.cs b/src/LoadFiles/LoadFileRecordBuilder.cs
+index 19eef5c..5a3e4c2 100644
+--- a/src/LoadFiles/LoadFileRecordBuilder.cs
++++ b/src/LoadFiles/LoadFileRecordBuilder.cs
+@@ -14,7 +14,7 @@ internal static class LoadFileRecordBuilder
+                 $"Load file value count {orderedValues.Count} does not match header column count {headerColumns.Count}.");
+         }
+ 
+-        var values = new Dictionary<string, string>(headerColumns.Count);
++        var values = new Dictionary<string, string>(headerColumns.Count, StringComparer.Ordinal);
+         for (int i = 0; i < headerColumns.Count; i++)
+         {
+             values[headerColumns[i]] = orderedValues[i];
+diff --git a/src/LoadFiles/OptComposingWriter.cs b/src/LoadFiles/OptComposingWriter.cs
+index a119327..61f5c14 100644
+--- a/src/LoadFiles/OptComposingWriter.cs
++++ b/src/LoadFiles/OptComposingWriter.cs
+@@ -49,7 +49,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
+             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
+ 
+         var records = composer.Compose(processedFiles);
+-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos);
++        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos).ConfigureAwait(false);
+     }
+ 
+     /// <summary>
+@@ -58,7 +58,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
+     private static Encoding GetOptEncoding(FileGenerationRequest request)
+     {
+         var resolvedEncoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
+-        return request.LoadFile.IsEncodingExplicit || resolvedEncoding != Encoding.UTF8
++        return request.LoadFile.IsEncodingExplicit || !object.Equals(resolvedEncoding, Encoding.UTF8)
+             ? resolvedEncoding
+             : EncodingHelper.GetEncoding("ANSI") ?? Encoding.UTF8;
+     }
+diff --git a/src/LoadFiles/XmlLoadFileWriter.cs b/src/LoadFiles/XmlLoadFileWriter.cs
+index 4e15c96..8fc9c86 100644
+--- a/src/LoadFiles/XmlLoadFileWriter.cs
++++ b/src/LoadFiles/XmlLoadFileWriter.cs
+@@ -32,45 +32,47 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
+             CloseOutput = false,
+         };
+ 
+-        await using var writer = System.Xml.XmlWriter.Create(stream, settings);
+-
+-        try
++        var writer = System.Xml.XmlWriter.Create(stream, settings);
++        await using (writer.ConfigureAwait(false))
+         {
+-            // Match the original XDeclaration("1.0", "UTF-8", "yes")
+-            await writer.WriteStartDocumentAsync(standalone: true);
+-            await writer.WriteStartElementAsync(null, "Root", null);
+-            await writer.WriteAttributeStringAsync(null, "DataInterchangeType", null, "Export");
+-            await writer.WriteAttributeStringAsync(null, "MajorVersion", null, "1");
+-            await writer.WriteAttributeStringAsync(null, "MinorVersion", null, "2");
++            try
++            {
++                // Match the original XDeclaration("1.0", "UTF-8", "yes")
++                await writer.WriteStartDocumentAsync(standalone: true);
++                await writer.WriteStartElementAsync(null, "Root", null);
++                await writer.WriteAttributeStringAsync(null, "DataInterchangeType", null, "Export");
++                await writer.WriteAttributeStringAsync(null, "MajorVersion", null, "1");
++                await writer.WriteAttributeStringAsync(null, "MinorVersion", null, "2");
+ 
+-            await writer.WriteStartElementAsync(null, "Batch", null);
++                await writer.WriteStartElementAsync(null, "Batch", null);
+ 
+ #pragma warning disable S2245
+-            var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
++                var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
+ #pragma warning restore S2245
+-            var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
++                var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+ 
+-            foreach (var fileData in processedFiles)
+-            {
+-                var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
+-                await element.WriteToAsync(writer, CancellationToken.None);
+-            }
++                foreach (var fileData in processedFiles)
++                {
++                    var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
++                    await element.WriteToAsync(writer, CancellationToken.None);
++                }
+ 
+-            await writer.WriteEndElementAsync(); // </Batch>
+-            await writer.WriteEndElementAsync(); // </Root>
+-            await writer.WriteEndDocumentAsync();
++                await writer.WriteEndElementAsync(); // </Batch>
++                await writer.WriteEndElementAsync(); // </Root>
++                await writer.WriteEndDocumentAsync();
+ 
+-            await writer.FlushAsync();
+-        }
+-        catch (Exception ex)
+-        {
+-            if (ex is OperationCanceledException)
+-            {
+-                throw;
++                await writer.FlushAsync();
+             }
++            catch (Exception ex)
++            {
++                if (ex is OperationCanceledException)
++                {
++                    throw;
++                }
+ 
+-            throw new InvalidOperationException(
+-                $"Failed to write XML load file: {ex.Message}", ex);
++                throw new InvalidOperationException(
++                    $"Failed to write XML load file: {ex.Message}", ex);
++            }
+         }
+     }
+ 
+diff --git a/src/LoadfileAuditWriter.cs b/src/LoadfileAuditWriter.cs
+index 4047b24..8d21e3e 100644
+--- a/src/LoadfileAuditWriter.cs
++++ b/src/LoadfileAuditWriter.cs
+@@ -33,7 +33,7 @@ internal static class LoadfileAuditWriter
+     {
+         var propertiesPath = Path.ChangeExtension(outputPath, null) + "_properties.json";
+         var json = GenerateAuditJson(outputPath, request, totalRecords, anomalies, format);
+-        await File.WriteAllTextAsync(propertiesPath, json);
++        await File.WriteAllTextAsync(propertiesPath, json).ConfigureAwait(false);
+         return propertiesPath;
+     }
+ 
+@@ -85,7 +85,7 @@ internal static class LoadfileAuditWriter
+         var encodingName = request.LoadFile.Encoding;
+         if (activeFormat == LoadFileFormat.Opt)
+         {
+-            if (!request.LoadFile.IsEncodingExplicit && request.LoadFile.Encoding == "UTF-8")
++            if (!request.LoadFile.IsEncodingExplicit && string.Equals(request.LoadFile.Encoding, "UTF-8", StringComparison.Ordinal))
+             {
+                 encodingName = "ANSI";
+             }
+diff --git a/src/LoadfileOnlyGenerator.cs b/src/LoadfileOnlyGenerator.cs
+index 683033f..097a77c 100644
+--- a/src/LoadfileOnlyGenerator.cs
++++ b/src/LoadfileOnlyGenerator.cs
+@@ -22,7 +22,7 @@ internal static class LoadfileOnlyGenerator
+ 
+         Directory.CreateDirectory(request.Output.OutputPath);
+ 
+-        var baseFileName = $"loadfile_{DateTime.Now:yyyyMMdd_HHmmss}";
++        var baseFileName = $"loadfile_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+ 
+         var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
+             ? request.LoadFile.LoadFileFormats
+@@ -71,9 +71,10 @@ internal static class LoadfileOnlyGenerator
+                 format == LoadFileFormat.Opt ? LoadFileFormat.Opt : LoadFileFormat.Dat,
+                 WriterMode.LoadfileOnly);
+ 
+-            await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
++            var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
++            await using (fileStream.ConfigureAwait(false))
+             {
+-                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine);
++                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine).ConfigureAwait(false);
+             }
+ 
+             string propertiesPath;
+@@ -84,7 +85,7 @@ internal static class LoadfileOnlyGenerator
+                     request,
+                     request.Output.FileCount,
+                     chaosEngine?.Anomalies,
+-                    format);
++                    format).ConfigureAwait(false);
+             }
+             catch
+             {
+diff --git a/src/LoadfileOnlyMode.cs b/src/LoadfileOnlyMode.cs
+index e7010d2..e656ebf 100644
+--- a/src/LoadfileOnlyMode.cs
++++ b/src/LoadfileOnlyMode.cs
+@@ -23,7 +23,7 @@ namespace Zipper
+                 }
+             }
+ 
+-            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
++            var result = await LoadfileOnlyGenerator.GenerateAsync(request).ConfigureAwait(false);
+ 
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Load file: {0}", result.LoadFilePath));
+diff --git a/src/ParallelFileGenerator.cs b/src/ParallelFileGenerator.cs
+index 5f89d7d..de02bf3 100644
+--- a/src/ParallelFileGenerator.cs
++++ b/src/ParallelFileGenerator.cs
+@@ -45,7 +45,7 @@ namespace Zipper
+ 
+                 Directory.CreateDirectory(request.Output.OutputPath);
+ 
+-                var baseFileName = $"archive_{DateTime.Now:yyyyMMdd_HHmmss}";
++                var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+                 var zipFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}.zip");
+                 var loadFileName = $"{baseFileName}.dat";
+                 var loadFilePath = Path.Combine(request.Output.OutputPath, loadFileName);
+@@ -83,14 +83,14 @@ namespace Zipper
+                 Exception? producerException = null;
+                 try
+                 {
+-                    var completed = await Task.WhenAny(allProducersTask, consumerTask);
++                    var completed = await Task.WhenAny(allProducersTask, consumerTask).ConfigureAwait(false);
+                     if (completed == consumerTask && consumerTask.IsFaulted)
+                     {
+                         // Consumer died — complete channel with its exception to unblock producers
+                         resultChannel.Writer.TryComplete(consumerTask.Exception);
+                         try
+                         {
+-                            await allProducersTask;
++                            await allProducersTask.ConfigureAwait(false);
+                         }
+                         catch
+                         {
+@@ -100,7 +100,7 @@ namespace Zipper
+                     else
+                     {
+                         // Producers finished first (normal path)
+-                        await allProducersTask;
++                        await allProducersTask.ConfigureAwait(false);
+                     }
+                 }
+                 catch (Exception ex)
+@@ -114,7 +114,7 @@ namespace Zipper
+                 }
+ 
+                 // Always wait for consumer (releases zip file handles)
+-                var actualLoadFilePath = await consumerTask;
++                var actualLoadFilePath = await consumerTask.ConfigureAwait(false);
+ 
+                 RethrowIfNotNull(producerException);
+ 
+@@ -163,7 +163,7 @@ namespace Zipper
+                             FolderName = folderName,
+                             FileName = fileName,
+                             FilePathInZip = filePathInZip,
+-                        });
++                        }).ConfigureAwait(false);
+                     }
+ 
+                     writer.Complete();
+@@ -181,12 +181,12 @@ namespace Zipper
+         {
+             long filesProcessed = 0;
+ 
+-            await foreach (var workItem in reader.ReadAllAsync())
++            await foreach (var workItem in reader.ReadAllAsync().ConfigureAwait(false))
+             {
+                 var fileData = this.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+                 try
+                 {
+-                    await writer.WriteAsync(fileData);
++                    await writer.WriteAsync(fileData).ConfigureAwait(false);
+                 }
+                 catch
+                 {
+diff --git a/src/PathValidator.cs b/src/PathValidator.cs
+index b3a07f0..6b2761a 100644
+--- a/src/PathValidator.cs
++++ b/src/PathValidator.cs
+@@ -36,7 +36,7 @@ namespace Zipper
+                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+ 
+-                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
++                    StringComparison comparison = OperatingSystem.IsWindows()
+                         ? StringComparison.OrdinalIgnoreCase
+                         : StringComparison.Ordinal;
+ 
+@@ -96,7 +96,7 @@ namespace Zipper
+                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+ 
+-                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
++                    StringComparison comparison = OperatingSystem.IsWindows()
+                         ? StringComparison.OrdinalIgnoreCase
+                         : StringComparison.Ordinal;
+ 
+diff --git a/src/PerformanceBenchmarkRunner.cs b/src/PerformanceBenchmarkRunner.cs
+index 969eab4..d465588 100644
+--- a/src/PerformanceBenchmarkRunner.cs
++++ b/src/PerformanceBenchmarkRunner.cs
+@@ -15,10 +15,10 @@ namespace Zipper
+             Console.WriteLine("=== Performance Benchmark Suite ===");
+             Console.WriteLine();
+ 
+-            await BenchmarkParallelVsSequential();
+-            await BenchmarkMemoryPooling();
+-            await BenchmarkScalability();
+-            await BenchmarkAllocation();
++            await BenchmarkParallelVsSequential().ConfigureAwait(false);
++            await BenchmarkMemoryPooling().ConfigureAwait(false);
++            await BenchmarkScalability().ConfigureAwait(false);
++            await BenchmarkAllocation().ConfigureAwait(false);
+ 
+             Console.WriteLine("=== Benchmark Suite Complete ===");
+         }
+@@ -58,7 +58,7 @@ namespace Zipper
+                     LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
+                 };
+ 
+-                await generator.GenerateFilesAsync(request);
++                await generator.GenerateFilesAsync(request).ConfigureAwait(false);
+ 
+                 var allocatedAfter = GC.GetTotalAllocatedBytes(precise: true);
+                 var totalAllocated = allocatedAfter - allocatedBefore;
+@@ -94,7 +94,7 @@ namespace Zipper
+             {
+                 // Sequential baseline
+                 var sw = Stopwatch.StartNew();
+-                await GenerateSequentialFiles(fileCount, outputPath1);
++                await GenerateSequentialFiles(fileCount, outputPath1).ConfigureAwait(false);
+                 sw.Stop();
+                 var sequentialTime = sw.ElapsedMilliseconds;
+ 
+@@ -113,7 +113,7 @@ namespace Zipper
+                     },
+                     LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
+                 };
+-                await generator.GenerateFilesAsync(request);
++                await generator.GenerateFilesAsync(request).ConfigureAwait(false);
+                 sw.Stop();
+                 var parallelTime = sw.ElapsedMilliseconds;
+ 
+@@ -224,7 +224,7 @@ namespace Zipper
+                         LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
+                     };
+ 
+-                    var result = await generator.GenerateFilesAsync(request);
++                    var result = await generator.GenerateFilesAsync(request).ConfigureAwait(false);
+                     sw.Stop();
+ 
+                     var throughput = result.FilesPerSecond;
+@@ -246,7 +246,7 @@ namespace Zipper
+         {
+             return Task.Run(async () =>
+             {
+-                var baseFileName = $"archive_{DateTime.Now:yyyyMMdd_HHmmss}";
++                var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+                 var zipFilePath = Path.Combine(outputPath, $"{baseFileName}.zip");
+ 
+                 using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
+@@ -259,7 +259,7 @@ namespace Zipper
+                     var fileName = $"{i:D8}.pdf";
+                     var entry = archive.CreateEntry(fileName, CompressionLevel.Optimal);
+                     using var entryStream = entry.Open();
+-                    await entryStream.WriteAsync(placeholderContent);
++                    await entryStream.WriteAsync(placeholderContent).ConfigureAwait(false);
+                 }
+             });
+         }
+diff --git a/src/PerformanceMonitor.cs b/src/PerformanceMonitor.cs
+index 613916b..51862f9 100644
+--- a/src/PerformanceMonitor.cs
++++ b/src/PerformanceMonitor.cs
+@@ -13,7 +13,7 @@ namespace Zipper
+         private long totalFiles;
+         private DateTime lastProgressUpdate = DateTime.UtcNow;
+         private double lastDisplayedPercentage;
+-        private readonly object syncRoot = new object();
++        private readonly Lock syncRoot = new();
+ 
+         /// <summary>
+         /// Starts performance monitoring for a new operation.
+@@ -64,7 +64,7 @@ namespace Zipper
+         public void ReportProgress(long completed, long total)
+         {
+             // Disable progress bar in CI environments to prevent hangs
+-            if (Environment.GetEnvironmentVariable("CI") == "true")
++            if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.Ordinal))
+             {
+                 return;
+             }
+@@ -91,7 +91,7 @@ namespace Zipper
+         public void FinalizeProgress()
+         {
+             // Disable in CI environments
+-            if (Environment.GetEnvironmentVariable("CI") == "true")
++            if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.Ordinal))
+             {
+                 return;
+             }
+diff --git a/src/ProductionManifestWriter.cs b/src/ProductionManifestWriter.cs
+index 80a309d..fcb766d 100644
+--- a/src/ProductionManifestWriter.cs
++++ b/src/ProductionManifestWriter.cs
+@@ -72,7 +72,7 @@ internal static class ProductionManifestWriter
+         };
+ 
+         var json = JsonSerializer.Serialize(manifest, ManifestSerializerOptions);
+-        await File.WriteAllTextAsync(manifestPath, json);
++        await File.WriteAllTextAsync(manifestPath, json).ConfigureAwait(false);
+ 
+         return manifestPath;
+     }
+diff --git a/src/ProductionSetGenerator.cs b/src/ProductionSetGenerator.cs
+index 4a2a84f..ab31660 100644
+--- a/src/ProductionSetGenerator.cs
++++ b/src/ProductionSetGenerator.cs
+@@ -25,12 +25,12 @@ internal static class ProductionSetGenerator
+ 
+         var stopwatch = Stopwatch.StartNew();
+ 
+-        var productionName = $"PRODUCTION_{DateTime.Now:yyyyMMdd_HHmmss}";
++        var productionName = $"PRODUCTION_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+         var productionPath = Path.Combine(request.Output.OutputPath, productionName);
+ 
+         try
+         {
+-            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch);
++            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch).ConfigureAwait(false);
+         }
+         catch
+         {
+@@ -103,11 +103,11 @@ internal static class ProductionSetGenerator
+             var generated = fileGenerator.Generate(workItem, request);
+             var nativeContent = generated.Content;
+ 
+-            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.NativeRelPath), nativeContent);
++            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.NativeRelPath), nativeContent).ConfigureAwait(false);
+ 
+             var textContent = $"Extracted text for document {plan.BatesNumber}. " +
+                               Profiles.LoremIpsum.GetParagraph(random);
+-            await File.WriteAllTextAsync(Path.Combine(productionPath, plan.TextRelPath), textContent, encoding);
++            await File.WriteAllTextAsync(Path.Combine(productionPath, plan.TextRelPath), textContent, encoding).ConfigureAwait(false);
+ 
+             // Write placeholder TIFF image (single-pixel stub)
+             if (generated.PageCount > 1)
+@@ -120,12 +120,12 @@ internal static class ProductionSetGenerator
+                 for (int pageIdx = 1; pageIdx <= generated.PageCount; pageIdx++)
+                 {
+                     var pageImageRelPath = $"{imagePathWithoutExt}_{pageIdx:D3}{imageExt}";
+-                    await File.WriteAllBytesAsync(Path.Combine(productionPath, pageImageRelPath), PlaceholderFiles.GetContent("tiff"));
++                    await File.WriteAllBytesAsync(Path.Combine(productionPath, pageImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+                 }
+             }
+             else
+             {
+-                await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff"));
++                await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+             }
+ 
+             fileDataList.Add(new FileData
+@@ -147,12 +147,12 @@ internal static class ProductionSetGenerator
+                 var childTextRelPath = Path.Combine("TEXT", plan.VolumeName, $"{childBates}.txt");
+                 var childImageRelPath = Path.Combine("IMAGES", plan.VolumeName, $"{childBates}.tif");
+ 
+-                await File.WriteAllBytesAsync(Path.Combine(productionPath, childNativeRelPath), attach.content);
++                await File.WriteAllBytesAsync(Path.Combine(productionPath, childNativeRelPath), attach.content).ConfigureAwait(false);
+ 
+                 var childTextContent = $"Extracted text for attachment {childBates}.";
+-                await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding);
++                await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding).ConfigureAwait(false);
+ 
+-                await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff"));
++                await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+             }
+ 
+             // Progress reporting
+@@ -175,13 +175,14 @@ internal static class ProductionSetGenerator
+         var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
+         long datTotalLines = totalRecords + 1; // header + data rows
+         var datChaosEngine = ChaosEngineBuilder.Build(request, datTotalLines, LoadFileFormat.Dat);
+-        await using (var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
++        var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
++        await using (datStream.ConfigureAwait(false))
+         {
+-            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine);
++            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine).ConfigureAwait(false);
+         }
+ 
+         var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, totalRecords, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
+-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson);
++        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson).ConfigureAwait(false);
+ 
+         // Write OPT load file
+         var optPath = Path.Combine(dataDir, "loadfile.opt");
+@@ -190,21 +191,22 @@ internal static class ProductionSetGenerator
+             (request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
+             + (request.Metadata.WithFamilies && request.Output.IsEml && f.Attachment.HasValue ? 1 : 0));
+         var optChaosEngine = ChaosEngineBuilder.Build(request, optTotalLines, LoadFileFormat.Opt);
+-        await using (var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
++        var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true);
++        await using (optStream.ConfigureAwait(false))
+         {
+-            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine);
++            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine).ConfigureAwait(false);
+         }
+ 
+         var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, optTotalLines, optChaosEngine?.Anomalies, LoadFileFormat.Opt);
+ 
+         // Save OPT properties with a slightly different name to avoid overwriting DAT properties
+-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson);
++        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson).ConfigureAwait(false);
+ 
+         // Write manifest
+         var batesStart = plans[0].BatesNumber;
+         var batesEnd = plans[^1].BatesNumber;
+         var manifestPath = await ProductionManifestWriter.WriteAsync(
+-            productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed);
++            productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed).ConfigureAwait(false);
+ 
+         // Optionally wrap in ZIP
+         string? zipPath = null;
+diff --git a/src/ProductionSetMode.cs b/src/ProductionSetMode.cs
+index f6d4ae8..892b42b 100644
+--- a/src/ProductionSetMode.cs
++++ b/src/ProductionSetMode.cs
+@@ -21,7 +21,7 @@ namespace Zipper
+                 Console.WriteLine("  ZIP Output: Enabled");
+             }
+ 
+-            var result = await ProductionSetGenerator.GenerateAsync(request);
++            var result = await ProductionSetGenerator.GenerateAsync(request).ConfigureAwait(false);
+ 
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Production: {0}", result.ProductionPath));
+diff --git a/src/Profiles/BuiltInProfiles.cs b/src/Profiles/BuiltInProfiles.cs
+index b32a7c3..79ff310 100644
+--- a/src/Profiles/BuiltInProfiles.cs
++++ b/src/Profiles/BuiltInProfiles.cs
+@@ -25,6 +25,7 @@ public static class BuiltInProfiles
+             DateFormat = "yyyy-MM-dd",
+         },
+         DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+         {
+             ["custodians"] = new DataSourceConfig { Count = 10, Distribution = "pareto", Prefix = "Custodian_" },
+         },
+@@ -54,6 +55,7 @@ public static class BuiltInProfiles
+             DateFormat = "yyyy-MM-dd",
+         },
+         DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+         {
+             ["custodians"] = new DataSourceConfig { Count = 25, Distribution = "pareto", Prefix = "Custodian_" },
+             ["authors"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Author_" },
+@@ -114,6 +116,7 @@ public static class BuiltInProfiles
+             DateFormat = "yyyy-MM-dd",
+         },
+         DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+         {
+             ["custodians"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Custodian_" },
+             ["authors"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Author_" },
+@@ -143,6 +146,7 @@ public static class BuiltInProfiles
+             DateFormat = "yyyy-MM-dd",
+         },
+         DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+         {
+             ["custodians"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Custodian_" },
+             ["authors"] = new DataSourceConfig { Count = 200, Distribution = "pareto", Prefix = "Author_" },
+@@ -188,7 +192,7 @@ public static class BuiltInProfiles
+         Version = "1.0",
+         FieldNamingConvention = null,
+         Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+-        DataSources = new Dictionary<string, DataSourceConfig>(),
++        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+         Columns = new List<ColumnDefinition>
+         {
+             new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
+@@ -209,7 +213,7 @@ public static class BuiltInProfiles
+         Version = "1.0",
+         FieldNamingConvention = null,
+         Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+-        DataSources = new Dictionary<string, DataSourceConfig>(),
++        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+         Columns = new List<ColumnDefinition>
+         {
+             new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
+@@ -370,7 +374,7 @@ public static class BuiltInProfiles
+                 Name = $"NOTES{i:D2}",
+                 Type = "longtext",
+                 Generator = "loremParagraphs",
+-                GeneratorParams = new Dictionary<string, object> { ["min"] = 1, ["max"] = 3 },
++                GeneratorParams = new Dictionary<string, object>(StringComparer.Ordinal) { ["min"] = 1, ["max"] = 3 },
+                 EmptyPercentage = 70 + (i * 2),
+             });
+         }
+diff --git a/src/Profiles/ColumnProfile.cs b/src/Profiles/ColumnProfile.cs
+index 7f590cb..ca96ef8 100644
+--- a/src/Profiles/ColumnProfile.cs
++++ b/src/Profiles/ColumnProfile.cs
+@@ -41,7 +41,7 @@ public class ColumnProfile
+     /// Gets or sets the data sources for value generation.
+     /// </summary>
+     [JsonPropertyName("dataSources")]
+-    public Dictionary<string, DataSourceConfig> DataSources { get; set; } = new();
++    public Dictionary<string, DataSourceConfig> DataSources { get; set; } = new(StringComparer.Ordinal);
+ 
+     /// <summary>
+     /// Gets or sets the column definitions.
+@@ -76,7 +76,7 @@ public class ColumnProfile
+                     Prefix = kv.Value.Prefix,
+                     Values = kv.Value.Values != null ? new List<string>(kv.Value.Values) : null,
+                     Weights = kv.Value.Weights != null ? new List<int>(kv.Value.Weights) : null,
+-                }),
++                }, StringComparer.Ordinal),
+             Columns = this.Columns.Select(col => new ColumnDefinition
+             {
+                 Name = col.Name,
+@@ -93,7 +93,7 @@ public class ColumnProfile
+                 TruePercentage = col.TruePercentage,
+                 Weights = col.Weights != null ? new List<int>(col.Weights) : null,
+                 Generator = col.Generator,
+-                GeneratorParams = col.GeneratorParams != null ? new Dictionary<string, object>(col.GeneratorParams) : null,
++                GeneratorParams = col.GeneratorParams != null ? new Dictionary<string, object>(col.GeneratorParams, StringComparer.Ordinal) : null,
+             }).ToList(),
+         };
+         return cloned;
+diff --git a/src/Profiles/DataGenerator.cs b/src/Profiles/DataGenerator.cs
+index 7a14c26..d613f38 100644
+--- a/src/Profiles/DataGenerator.cs
++++ b/src/Profiles/DataGenerator.cs
+@@ -55,9 +55,9 @@ internal class DataGenerator
+ #pragma warning disable S2245
+         this.random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
+ #pragma warning restore S2245
+-        this.dataSources = new Dictionary<string, string[]>();
+-        this.distributionIndices = new Dictionary<string, int[]>();
+-        this.columnGenerators = new Dictionary<string, IColumnValueGenerator>();
++        this.dataSources = new Dictionary<string, string[]>(StringComparer.Ordinal);
++        this.distributionIndices = new Dictionary<string, int[]>(StringComparer.Ordinal);
++        this.columnGenerators = new Dictionary<string, IColumnValueGenerator>(StringComparer.Ordinal);
+         this.now = now ?? DateTime.UtcNow;
+         this.InitializeDataSources();
+         this.InitializeColumnGenerators();
+@@ -122,7 +122,7 @@ internal class DataGenerator
+             Now = this.now,
+             FileData = fileData,
+         };
+-        var row = new Dictionary<string, string>(this.profile.Columns.Count);
++        var row = new Dictionary<string, string>(this.profile.Columns.Count, StringComparer.Ordinal);
+         foreach (var col in this.profile.Columns)
+         {
+             var emptyPct = col.EmptyPercentage ?? this.profile.Settings.EmptyValuePercentage;
+@@ -150,7 +150,7 @@ internal class DataGenerator
+                 ? cfg.Values
+                 : Enumerable.Range(1, cfg.Count).Select(i => $"{cfg.Prefix}{i}")).ToArray();
+             this.dataSources[name] = vals;
+-            if (cfg.Distribution == "pareto" || cfg.Distribution == "weighted")
++            if (string.Equals(cfg.Distribution, "pareto", StringComparison.Ordinal) || string.Equals(cfg.Distribution, "weighted", StringComparison.Ordinal))
+             {
+                 this.distributionIndices[name] = this.PrecomputeIndices(vals.Length, cfg);
+             }
+@@ -203,7 +203,7 @@ internal class DataGenerator
+     private int[] PrecomputeIndices(int count, DataSourceConfig cfg)
+     {
+         var indices = new int[1000];
+-        if (cfg.Distribution == "weighted" && cfg.Weights?.Count > 0)
++        if (string.Equals(cfg.Distribution, "weighted", StringComparison.Ordinal) && cfg.Weights?.Count > 0)
+         {
+             var total = cfg.Weights.Take(count).Sum();
+             if (total <= 0)
+diff --git a/src/Profiles/Generation/CodedGenerator.cs b/src/Profiles/Generation/CodedGenerator.cs
+index d7db73c..a9267df 100644
+--- a/src/Profiles/Generation/CodedGenerator.cs
++++ b/src/Profiles/Generation/CodedGenerator.cs
+@@ -34,7 +34,7 @@ internal sealed class CodedGenerator : IColumnValueGenerator
+                 return string.Empty;
+             }
+ 
+-            var selected = new HashSet<string>();
++            var selected = new HashSet<string>(StringComparer.Ordinal);
+             selected.Add(this.PickValue(context));
+             while (selected.Count < count && selected.Count < this.values.Length)
+             {
+diff --git a/src/Profiles/Generation/LongTextGenerator.cs b/src/Profiles/Generation/LongTextGenerator.cs
+index 052c48d..461a6b6 100644
+--- a/src/Profiles/Generation/LongTextGenerator.cs
++++ b/src/Profiles/Generation/LongTextGenerator.cs
+@@ -27,7 +27,7 @@ internal sealed class LongTextGenerator : IColumnValueGenerator
+ 
+     public string Generate(ColumnGenerationContext context)
+     {
+-        if (this.generatorName == "reviewNote")
++        if (string.Equals(this.generatorName, "reviewNote", StringComparison.Ordinal))
+         {
+             return ReviewNotes.GetRandomNote(context.Seeded);
+         }
+diff --git a/src/Profiles/Generation/NumberGenerator.cs b/src/Profiles/Generation/NumberGenerator.cs
+index e9c74f2..fe0d76c 100644
+--- a/src/Profiles/Generation/NumberGenerator.cs
++++ b/src/Profiles/Generation/NumberGenerator.cs
+@@ -50,14 +50,14 @@ internal sealed class NumberGenerator : IColumnValueGenerator
+             return this.min.ToString(System.Globalization.CultureInfo.InvariantCulture);
+         }
+ 
+-        if (this.distribution == "exponential")
++        if (string.Equals(this.distribution, "exponential", StringComparison.Ordinal))
+         {
+             var lambda = 3.0 / (this.max - this.min);
+             var value = this.min + (int)(-Math.Log(1 - context.Seeded.NextDouble()) / lambda);
+             return Math.Min(value, this.max).ToString(System.Globalization.CultureInfo.InvariantCulture);
+         }
+ 
+-        if (this.distribution == "gaussian" || this.distribution == "normal")
++        if (string.Equals(this.distribution, "gaussian", StringComparison.Ordinal) || string.Equals(this.distribution, "normal", StringComparison.Ordinal))
+         {
+             double u1 = 1.0 - context.Seeded.NextDouble();
+             double u2 = 1.0 - context.Seeded.NextDouble();
+diff --git a/src/Program.cs b/src/Program.cs
+index a5a2c1b..7279038 100644
+--- a/src/Program.cs
++++ b/src/Program.cs
+@@ -16,7 +16,7 @@ namespace Zipper
+             {
+                 try
+                 {
+-                    await PerformanceBenchmarkRunner.RunBenchmarks();
++                    await PerformanceBenchmarkRunner.RunBenchmarks().ConfigureAwait(false);
+                     return 0;
+                 }
+                 catch (Exception ex)
+@@ -39,7 +39,7 @@ namespace Zipper
+             }
+ 
+             IGenerationMode mode = SelectMode(request);
+-            return await GenerationRunner.RunAsync(mode, request);
++            return await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
+         }
+ 
+         /// <summary>
+diff --git a/src/StandardMode.cs b/src/StandardMode.cs
+index 3b566ad..d6da6d8 100644
+--- a/src/StandardMode.cs
++++ b/src/StandardMode.cs
+@@ -42,7 +42,7 @@ namespace Zipper
+             // Use parallel file generator for improved performance
+             var generator = new ParallelFileGenerator();
+ 
+-            var result = await generator.GenerateFilesAsync(request);
++            var result = await generator.GenerateFilesAsync(request).ConfigureAwait(false);
+ 
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
+             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Archive created: {0}", result.ZipFilePath));
+@@ -61,13 +61,13 @@ namespace Zipper
+                 {
+                     await Console.Error.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                         "  Warning: archive size {0:N0} bytes is outside the +/-10% target tolerance ({1:N0} bytes, deviation {2:P1}).",
+-                        actual, target, deviation));
++                        actual, target, deviation)).ConfigureAwait(false);
+                 }
+                 else
+                 {
+                     await Console.Out.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                         "  Target ZIP size met: {0:N0} bytes (within +/-10% of {1:N0} bytes, deviation {2:P1}).",
+-                        actual, target, deviation));
++                        actual, target, deviation)).ConfigureAwait(false);
+                 }
+             }
+ 
+diff --git a/src/TiffMultiPageGenerator.cs b/src/TiffMultiPageGenerator.cs
+index a16a926..251feaa 100644
+--- a/src/TiffMultiPageGenerator.cs
++++ b/src/TiffMultiPageGenerator.cs
+@@ -75,7 +75,7 @@ internal static class TiffMultiPageGenerator
+             return null;
+         }
+ 
+-        if (!int.TryParse(parts[0], out var min) || !int.TryParse(parts[1], out var max))
++        if (!int.TryParse(parts[0], System.Globalization.CultureInfo.InvariantCulture, out var min) || !int.TryParse(parts[1], System.Globalization.CultureInfo.InvariantCulture, out var max))
+         {
+             return null;
+         }
+diff --git a/src/ZipArchiveService.cs b/src/ZipArchiveService.cs
+index 458a734..1fdd4e1 100644
+--- a/src/ZipArchiveService.cs
++++ b/src/ZipArchiveService.cs
+@@ -45,7 +45,7 @@ namespace Zipper
+ 
+             try
+             {
+-                await foreach (var incomingFileData in fileDataReader.ReadAllAsync())
++                await foreach (var incomingFileData in fileDataReader.ReadAllAsync().ConfigureAwait(false))
+                 {
+                     if (incomingFileData.WorkItem.Index == nextExpectedIndex)
+                     {
+@@ -106,7 +106,7 @@ namespace Zipper
+                     var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
+                     using (var loadFileStream = loadFileEntry.Open())
+                     {
+-                        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine);
++                        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+                     }
+ 
+                     // Write audit file to ZIP
+@@ -115,7 +115,7 @@ namespace Zipper
+                     using (var propertiesStream = propertiesEntry.Open())
+                     using (var propertiesWriter = new StreamWriter(propertiesStream))
+                     {
+-                        await propertiesWriter.WriteAsync(auditJson);
++                        await propertiesWriter.WriteAsync(auditJson).ConfigureAwait(false);
+                     }
+ 
+                     // Return path within the ZIP archive when load file is included
+@@ -124,15 +124,18 @@ namespace Zipper
+                 else
+                 {
+                     var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
+-                    await using var fileStream = new FileStream(currentFilePath, FileMode.Create);
+-                    await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine);
+-                    await fileStream.FlushAsync();
++                    var fileStream = new FileStream(currentFilePath, FileMode.Create);
++                    await using (fileStream.ConfigureAwait(false))
++                    {
++                        await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine);
++                        await fileStream.FlushAsync();
+ 
+-                    // Write audit file to disk
+-                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
+-                    await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
++                        // Write audit file to disk
++                        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
++                        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
+ 
+-                    actualLoadFilePath = currentFilePath;
++                        actualLoadFilePath = currentFilePath;
++                    }
+                 }
+             }
+ 
+diff --git a/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs b/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
+index d3bd628..d05acc6 100644
+--- a/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
++++ b/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
+@@ -147,7 +147,7 @@ public sealed class FgrFlatAccessAnalyzer : DiagnosticAnalyzer
+             return;
+         }
+ 
+-        if (symbol.ContainingType?.Name != "FileGenerationRequest")
++        if (!string.Equals(symbol.ContainingType?.Name, "FileGenerationRequest", StringComparison.Ordinal))
+         {
+             return;
+         }
+diff --git a/src/Zipper.Tests/AllWritersTests.cs b/src/Zipper.Tests/AllWritersTests.cs
+index 41a0220..5de3820 100644
+--- a/src/Zipper.Tests/AllWritersTests.cs
++++ b/src/Zipper.Tests/AllWritersTests.cs
+@@ -55,8 +55,8 @@ public class AllWritersTests : TempDirectoryTestBase
+ 
+             var content = await File.ReadAllTextAsync(outputPath);
+ 
+-            Assert.Contains("TEST", content);
+-            Assert.Contains("000001", content);
++            Assert.Contains("TEST", content, StringComparison.Ordinal);
++            Assert.Contains("000001", content, StringComparison.Ordinal);
+         }
+     }
+ 
+@@ -85,9 +85,9 @@ public class AllWritersTests : TempDirectoryTestBase
+ 
+             if (format == LoadFileFormat.EdrmXml)
+             {
+-                var doc1Index = content.IndexOf("DocID=\"DOC00000001\"");
+-                var doc2Index = content.IndexOf("DocID=\"DOC00000002\"");
+-                var doc3Index = content.IndexOf("DocID=\"DOC00000003\"");
++                var doc1Index = content.IndexOf("DocID=\"DOC00000001\"", StringComparison.Ordinal);
++                var doc2Index = content.IndexOf("DocID=\"DOC00000002\"", StringComparison.Ordinal);
++                var doc3Index = content.IndexOf("DocID=\"DOC00000003\"", StringComparison.Ordinal);
+ 
+                 Assert.True(doc1Index != -1);
+                 Assert.True(doc2Index != -1);
+@@ -97,28 +97,28 @@ public class AllWritersTests : TempDirectoryTestBase
+                 var doc2Content = content.Substring(doc2Index, doc3Index - doc2Index);
+                 var doc3Content = content.Substring(doc3Index);
+ 
+-                Assert.Contains("TagName=\"PageCount\"", doc1Content);
+-                Assert.Contains("TagValue=\"5\"", doc1Content);
++                Assert.Contains("TagName=\"PageCount\"", doc1Content, StringComparison.Ordinal);
++                Assert.Contains("TagValue=\"5\"", doc1Content, StringComparison.Ordinal);
+ 
+-                Assert.Contains("TagName=\"PageCount\"", doc2Content);
+-                Assert.Contains("TagValue=\"7\"", doc2Content);
++                Assert.Contains("TagName=\"PageCount\"", doc2Content, StringComparison.Ordinal);
++                Assert.Contains("TagValue=\"7\"", doc2Content, StringComparison.Ordinal);
+ 
+-                Assert.Contains("TagName=\"PageCount\"", doc3Content);
+-                Assert.Contains("TagValue=\"3\"", doc3Content);
++                Assert.Contains("TagName=\"PageCount\"", doc3Content, StringComparison.Ordinal);
++                Assert.Contains("TagValue=\"3\"", doc3Content, StringComparison.Ordinal);
+             }
+             else if (format == LoadFileFormat.Opt)
+             {
+-                var line1 = lines.FirstOrDefault(l => l.StartsWith("DOC00000001_001"));
+-                var line2 = lines.FirstOrDefault(l => l.StartsWith("DOC00000002_001"));
+-                var line3 = lines.FirstOrDefault(l => l.StartsWith("DOC00000003_001"));
++                var line1 = lines.FirstOrDefault(l => l.StartsWith("DOC00000001_001", StringComparison.Ordinal));
++                var line2 = lines.FirstOrDefault(l => l.StartsWith("DOC00000002_001", StringComparison.Ordinal));
++                var line3 = lines.FirstOrDefault(l => l.StartsWith("DOC00000003_001", StringComparison.Ordinal));
+ 
+                 Assert.NotNull(line1);
+                 Assert.NotNull(line2);
+                 Assert.NotNull(line3);
+ 
+-                Assert.EndsWith(",5", line1);
+-                Assert.EndsWith(",7", line2);
+-                Assert.EndsWith(",3", line3);
++                Assert.EndsWith(",5", line1, StringComparison.Ordinal);
++                Assert.EndsWith(",7", line2, StringComparison.Ordinal);
++                Assert.EndsWith(",3", line3, StringComparison.Ordinal);
+             }
+             else
+             {
+diff --git a/src/Zipper.Tests/BuildPropsTests.cs b/src/Zipper.Tests/BuildPropsTests.cs
+index c0b79d9..909f199 100644
+--- a/src/Zipper.Tests/BuildPropsTests.cs
++++ b/src/Zipper.Tests/BuildPropsTests.cs
+@@ -54,7 +54,7 @@ public class BuildPropsTests
+     /// <param name="propertyName">The local name of the property element to find.</param>
+     /// <returns>The <see cref="XElement"/> if found; otherwise, <c>null</c>.</returns>
+     private static XElement? GetPropertyElement(XDocument doc, string propertyName)
+-        => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == propertyName);
++        => doc.Descendants().FirstOrDefault(e => string.Equals(e.Name.LocalName, propertyName, StringComparison.Ordinal));
+ 
+     /// <summary>
+     /// Gets the string value of the specified property element.
+@@ -88,7 +88,7 @@ public class BuildPropsTests
+ 
+         // Exactly one element: no accidental unconditional duplicate that would cause NETSDK1211
+         var elements = doc.Descendants()
+-            .Where(e => e.Name.LocalName == "EnableSingleFileAnalyzer")
++            .Where(e => string.Equals(e.Name.LocalName, "EnableSingleFileAnalyzer", StringComparison.Ordinal))
+             .ToList();
+         var element = Assert.Single(elements);
+         Assert.Equal("true", element.Value.Trim(), ignoreCase: true);
+diff --git a/src/Zipper.Tests/ChaosEngineBuilderTests.cs b/src/Zipper.Tests/ChaosEngineBuilderTests.cs
+index 94a64f8..a9cfbda 100644
+--- a/src/Zipper.Tests/ChaosEngineBuilderTests.cs
++++ b/src/Zipper.Tests/ChaosEngineBuilderTests.cs
+@@ -98,7 +98,7 @@ public class ChaosEngineBuilderTests
+         Assert.NotNull(enabledTypes);
+         Assert.Equal(expectedTypes, enabledTypes);
+ 
+-        var pct = double.Parse(scenario.DefaultAmount.TrimEnd('%'));
++        var pct = double.Parse(scenario.DefaultAmount.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture);
+         var expectedCount = Math.Max(1, (int)(100 * pct / 100.0));
+ 
+         Assert.NotNull(targetLines);
+diff --git a/src/Zipper.Tests/ChaosEngineTests.cs b/src/Zipper.Tests/ChaosEngineTests.cs
+index c9ff7c1..7bcee4f 100644
+--- a/src/Zipper.Tests/ChaosEngineTests.cs
++++ b/src/Zipper.Tests/ChaosEngineTests.cs
+@@ -18,7 +18,7 @@ namespace Zipper
+                 eol: "\r\n",
+                 seed: 42));
+ 
+-            Assert.Contains("Chaos Engine does not support load files larger than Int32.MaxValue lines", ex.Message);
++            Assert.Contains("Chaos Engine does not support load files larger than Int32.MaxValue lines", ex.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -138,8 +138,8 @@ namespace Zipper
+                 if (engine.ShouldIntercept(i))
+                 {
+                     string modified = engine.Intercept(i, line, $"DOC{i:D8}");
+-                    Assert.Contains("\n", modified);
+-                    Assert.DoesNotContain("\r\n", modified);
++                    Assert.Contains("\n", modified, StringComparison.Ordinal);
++                    Assert.DoesNotContain("\r\n", modified, StringComparison.Ordinal);
+                     break;
+                 }
+             }
+@@ -284,7 +284,7 @@ namespace Zipper
+                     string lastField = modified.Split(',').Last();
+ 
+                     // Should be either "ABC" or "-1"
+-                    Assert.True(lastField == "ABC" || lastField == "-1", $"Last field was '{lastField}'");
++                    Assert.True(string.Equals(lastField, "ABC", StringComparison.Ordinal) || string.Equals(lastField, "-1", StringComparison.Ordinal), $"Last field was '{lastField}'");
+                     break;
+                 }
+             }
+@@ -418,7 +418,7 @@ namespace Zipper
+                 {
+                     string modified = engine.Intercept(i, line, "IMG001");
+                     var parts = modified.Split(',');
+-                    Assert.Contains("invalid", parts[2]);
++                    Assert.Contains("invalid", parts[2], StringComparison.Ordinal);
+                     break;
+                 }
+             }
+@@ -444,7 +444,7 @@ namespace Zipper
+                 if (engine.ShouldIntercept(i))
+                 {
+                     string modified = engine.Intercept(i, line, "IMG001");
+-                    Assert.StartsWith(",VOL001", modified);
++                    Assert.StartsWith(",VOL001", modified, StringComparison.Ordinal);
+                     break;
+                 }
+             }
+@@ -516,7 +516,7 @@ namespace Zipper
+                 eol: "\r\n",
+                 seed: 42));
+ 
+-            Assert.Contains("Chaos Engine requires a positive totalLines count", ex.Message);
++            Assert.Contains("Chaos Engine requires a positive totalLines count", ex.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -663,7 +663,7 @@ namespace Zipper
+             Assert.Equal(10, interceptedCount);
+             Assert.True(engine.Anomalies.Count > 0);
+ 
+-            var types = engine.Anomalies.Select(a => a.ErrorType).Distinct().ToList();
++            var types = engine.Anomalies.Select(a => a.ErrorType).Distinct(StringComparer.Ordinal).ToList();
+             Assert.True(
+                 types.Count >= 2,
+                 $"Expected at least 2 distinct anomaly types with all types enabled, got {types.Count}: {string.Join(", ", types)}");
+@@ -700,7 +700,7 @@ namespace Zipper
+             // Every numeric line number in Anomalies must be an intercepted line
+             foreach (var anomaly in engine.Anomalies)
+             {
+-                if (long.TryParse(anomaly.LineNumber, out var lineNum))
++                if (long.TryParse(anomaly.LineNumber, System.Globalization.CultureInfo.InvariantCulture, out var lineNum))
+                 {
+                     Assert.Contains(lineNum, interceptedLines);
+                 }
+@@ -736,7 +736,7 @@ namespace Zipper
+             }
+ 
+             var anomalyLines = engine.Anomalies
+-                .Select(a => long.TryParse(a.LineNumber, out var n) ? (long?)n : null)
++                .Select(a => long.TryParse(a.LineNumber, System.Globalization.CultureInfo.InvariantCulture, out var n) ? (long?)n : null)
+                 .Where(n => n.HasValue)
+                 .Select(n => n!.Value)
+                 .ToHashSet();
+diff --git a/src/Zipper.Tests/ChaosScenarioTests.cs b/src/Zipper.Tests/ChaosScenarioTests.cs
+index e58e54f..c8ae847 100644
+--- a/src/Zipper.Tests/ChaosScenarioTests.cs
++++ b/src/Zipper.Tests/ChaosScenarioTests.cs
+@@ -16,7 +16,7 @@ public class ChaosScenarioTests
+             using var errWriter = new StringWriter();
+             Console.SetOut(outWriter);
+             Console.SetError(errWriter);
+-            int exitCode = await Program.Main(args);
++            int exitCode = await Program.Main(args).ConfigureAwait(false);
+             return (exitCode, outWriter.ToString(), errWriter.ToString());
+         }
+         finally
+@@ -33,7 +33,7 @@ public class ChaosScenarioTests
+         var scenario = ChaosScenarios.GetByName("structured-import-failures");
+         Assert.NotNull(scenario);
+         Assert.Equal("structured-import-failures", scenario.Name);
+-        Assert.Contains("mixed-delimiters", scenario.ChaosTypes);
++        Assert.Contains("mixed-delimiters", scenario.ChaosTypes, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -138,9 +138,9 @@ public class ChaosScenarioTests
+     {
+         var (exitCode, stdout, _) = await RunWithCapture(new[] { "--chaos-list" });
+         Assert.Equal(0, exitCode);
+-        Assert.Contains("Available Chaos Scenarios", stdout);
+-        Assert.Contains("structured-import-failures", stdout);
+-        Assert.Contains("full-chaos", stdout);
++        Assert.Contains("Available Chaos Scenarios", stdout, StringComparison.Ordinal);
++        Assert.Contains("structured-import-failures", stdout, StringComparison.Ordinal);
++        Assert.Contains("full-chaos", stdout, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -155,7 +155,7 @@ public class ChaosScenarioTests
+                 "--chaos-scenario", "structured-import-failures",
+             });
+             Assert.Equal(1, exitCode);
+-            Assert.Contains("--chaos-scenario requires --chaos-mode", stderr);
++            Assert.Contains("--chaos-scenario requires --chaos-mode", stderr, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -179,7 +179,7 @@ public class ChaosScenarioTests
+                 "--chaos-types", "quotes",
+             });
+             Assert.Equal(1, exitCode);
+-            Assert.Contains("conflicts with --chaos-types", stderr);
++            Assert.Contains("conflicts with --chaos-types", stderr, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -202,7 +202,7 @@ public class ChaosScenarioTests
+                 "--chaos-mode", "--chaos-scenario", "fake-scenario",
+             });
+             Assert.Equal(1, exitCode);
+-            Assert.Contains("Unknown chaos scenario 'fake-scenario'", stderr);
++            Assert.Contains("Unknown chaos scenario 'fake-scenario'", stderr, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -226,7 +226,7 @@ public class ChaosScenarioTests
+                 "--loadfile-format", "dat",
+             });
+             Assert.Equal(1, exitCode);
+-            Assert.Contains("requires --loadfile-format opt", stderr);
++            Assert.Contains("requires --loadfile-format opt", stderr, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -249,7 +249,7 @@ public class ChaosScenarioTests
+                 "--chaos-mode", "--chaos-scenario", "structured-import-failures", "--seed", "42",
+             });
+             Assert.Equal(0, exitCode);
+-            Assert.Contains("Chaos Scenario: structured-import-failures", stdout);
++            Assert.Contains("Chaos Scenario: structured-import-failures", stdout, StringComparison.Ordinal);
+ 
+             // Verify load file was created
+             var datFiles = Directory.GetFiles(tempPath, "*.dat");
+@@ -267,7 +267,7 @@ public class ChaosScenarioTests
+ 
+             // Verify anomaly types match scenario (mixed-delimiters, quotes, columns)
+             var anomalies = chaosMode.GetProperty("injectedAnomalies");
+-            var errorTypes = new HashSet<string>();
++            var errorTypes = new HashSet<string>(StringComparer.Ordinal);
+             foreach (var anomaly in anomalies.EnumerateArray())
+             {
+                 errorTypes.Add(anomaly.GetProperty("errorType").GetString()!);
+@@ -276,7 +276,7 @@ public class ChaosScenarioTests
+             // Should only contain types from the structured-import-failures scenario
+             Assert.Subset(
+                 errorTypes,
+-                new HashSet<string> { "mixed-delimiters", "quotes", "columns" });
++                new HashSet<string>(StringComparer.Ordinal) { "mixed-delimiters", "quotes", "columns" });
+         }
+         finally
+         {
+@@ -366,7 +366,7 @@ public class ChaosScenarioTests
+                 "--chaos-mode", "--chaos-scenario", "broken-boundaries", "--seed", "42",
+             });
+             Assert.Equal(0, exitCode);
+-            Assert.Contains("Chaos Scenario: broken-boundaries", stdout);
++            Assert.Contains("Chaos Scenario: broken-boundaries", stdout, StringComparison.Ordinal);
+ 
+             var optFiles = Directory.GetFiles(tempPath, "*.opt");
+             Assert.Single(optFiles);
+diff --git a/src/Zipper.Tests/CliPipelineTests.cs b/src/Zipper.Tests/CliPipelineTests.cs
+index 17ed565..4e48ee0 100644
+--- a/src/Zipper.Tests/CliPipelineTests.cs
++++ b/src/Zipper.Tests/CliPipelineTests.cs
+@@ -95,7 +95,7 @@ namespace Zipper
+         public void ValidateAndParseArguments_WithEmptyArgs_ShouldReturnNull()
+         {
+             // Arrange
+-            var args = new string[0];
++            var args = Array.Empty<string>();
+ 
+             // Act
+             var result = Cli.Pipeline.Build(args);
+@@ -379,7 +379,7 @@ namespace Zipper
+                 // Assert
+                 Assert.Null(result);
+                 var output = errorOutput.ToString();
+-                Assert.Contains("Error: Invalid TIFF pages range", output);
++                Assert.Contains("Error: Invalid TIFF pages range", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -425,7 +425,7 @@ namespace Zipper
+                 // Assert
+                 Assert.Null(result);
+                 var output = errorOutput.ToString();
+-                Assert.Contains("Error: Invalid load file format", output);
++                Assert.Contains("Error: Invalid load file format", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -493,7 +493,7 @@ namespace Zipper
+                 // Assert
+                 Assert.NotNull(result); // The valid args should still parse into a valid request
+                 var output = errorOutput.ToString();
+-                Assert.Contains("Warning: Unknown argument or unconsumed value '--unknown-arg' ignored.", output);
++                Assert.Contains("Warning: Unknown argument or unconsumed value '--unknown-arg' ignored.", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -685,7 +685,7 @@ namespace Zipper
+                 // Assert
+                 Assert.Null(result);
+                 var output = errorOutput.ToString();
+-                Assert.Contains("--count must be a positive number", output);
++                Assert.Contains("--count must be a positive number", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -712,7 +712,7 @@ namespace Zipper
+                 // Assert
+                 Assert.Null(result);
+                 var output = errorOutput.ToString();
+-                Assert.Contains("--count must be a positive number", output);
++                Assert.Contains("--count must be a positive number", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -739,7 +739,7 @@ namespace Zipper
+                 // Assert
+                 Assert.Null(result);
+                 var output = errorOutput.ToString();
+-                Assert.Contains("--count must not exceed", output);
++                Assert.Contains("--count must not exceed", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+diff --git a/src/Zipper.Tests/CliValidatorTests.cs b/src/Zipper.Tests/CliValidatorTests.cs
+index b2a6a82..df3c1ec 100644
+--- a/src/Zipper.Tests/CliValidatorTests.cs
++++ b/src/Zipper.Tests/CliValidatorTests.cs
+@@ -409,7 +409,7 @@ namespace Zipper.Tests
+                     var result = CliValidator.Validate(args);
+                     Assert.True(result);
+                     var output = errWriter.ToString();
+-                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
++                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
+                 }
+                 finally
+                 {
+@@ -436,7 +436,7 @@ namespace Zipper.Tests
+                     var result = CliValidator.Validate(args);
+                     Assert.True(result);
+                     var output = errWriter.ToString();
+-                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
++                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
+                 }
+                 finally
+                 {
+@@ -463,7 +463,7 @@ namespace Zipper.Tests
+                     var result = CliValidator.Validate(args);
+                     Assert.True(result);
+                     var output = errWriter.ToString();
+-                    Assert.DoesNotContain("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
++                    Assert.DoesNotContain("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
+                 }
+                 finally
+                 {
+@@ -489,7 +489,7 @@ namespace Zipper.Tests
+                     var result = CliValidator.Validate(args);
+                     Assert.True(result);
+                     var output = errWriter.ToString();
+-                    Assert.Contains("Warning: --with-families has no effect in --loadfile-only mode.", output);
++                    Assert.Contains("Warning: --with-families has no effect in --loadfile-only mode.", output, StringComparison.Ordinal);
+                 }
+                 finally
+                 {
+diff --git a/src/Zipper.Tests/ColumnProfileLoaderTests.cs b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+index 5aab45e..1fdb890 100644
+--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
++++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+@@ -1,3 +1,4 @@
++#pragma warning disable RS0030 // Do not use banned APIs
+ using System.Text.Json;
+ using Xunit;
+ using Zipper.Profiles;
+@@ -48,7 +49,7 @@ namespace Zipper
+                     new ColumnDefinition { Name = "DocID", Type = "identifier" },
+                     new ColumnDefinition { Name = "Title", Type = "text" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             var filePath = Path.Combine(this.tempDir, "test-profile.json");
+@@ -114,7 +115,7 @@ namespace Zipper
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.LoadFromFile(filePath));
+ 
+-            Assert.Contains("Invalid JSON", exception.Message);
++            Assert.Contains("Invalid JSON", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -129,7 +130,7 @@ namespace Zipper
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.LoadFromFile(filePath));
+ 
+-            Assert.Contains("Failed to parse", exception.Message);
++            Assert.Contains("Failed to parse", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -144,7 +145,7 @@ namespace Zipper
+                     new ColumnDefinition { Name = "DocID", Type = "identifier" },
+                     new ColumnDefinition { Name = "Text", Type = "text" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert - Should not throw
+@@ -162,14 +163,14 @@ namespace Zipper
+                 {
+                     new ColumnDefinition { Name = "ID", Type = "identifier" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("must have a name", exception.Message);
++            Assert.Contains("must have a name", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -180,14 +181,14 @@ namespace Zipper
+             {
+                 Name = "NoColumnsProfile",
+                 Columns = new List<ColumnDefinition>(),
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("at least one column", exception.Message);
++            Assert.Contains("at least one column", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -198,14 +199,14 @@ namespace Zipper
+             {
+                 Name = "NullColumnsProfile",
+                 Columns = null!,
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("at least one column", exception.Message);
++            Assert.Contains("at least one column", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -226,7 +227,7 @@ namespace Zipper
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("DataSources dictionary", exception.Message);
++            Assert.Contains("DataSources dictionary", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -247,14 +248,14 @@ namespace Zipper
+             {
+                 Name = "TooManyColumnsProfile",
+                 Columns = columns,
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("exceeds maximum of 200", exception.Message);
++            Assert.Contains("exceeds maximum of 200", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -269,14 +270,14 @@ namespace Zipper
+                     new ColumnDefinition { Name = "ID", Type = "identifier" },
+                     new ColumnDefinition { Name = "ID", Type = "text" }, // Duplicate!
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("Duplicate column name", exception.Message);
++            Assert.Contains("Duplicate column name", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -291,14 +292,14 @@ namespace Zipper
+                     new ColumnDefinition { Name = "ID", Type = "identifier" },
+                     new ColumnDefinition { Name = string.Empty, Type = "text" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("null or empty name", exception.Message);
++            Assert.Contains("null or empty name", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -313,14 +314,14 @@ namespace Zipper
+                     new ColumnDefinition { Name = "Text1", Type = "text" },
+                     new ColumnDefinition { Name = "Text2", Type = "text" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("'identifier' type column", exception.Message);
++            Assert.Contains("'identifier' type column", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -340,14 +341,14 @@ namespace Zipper
+                         DataSource = "categories", // References undefined data source
+                     },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(), // Empty!
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal), // Empty!
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("undefined data source", exception.Message);
++            Assert.Contains("undefined data source", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -362,14 +363,14 @@ namespace Zipper
+                     new ColumnDefinition { Name = "ID", Type = "identifier" },
+                     new ColumnDefinition { Name = "Invalid", Type = "invalid_type" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("invalid type", exception.Message);
++            Assert.Contains("invalid type", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -389,14 +390,14 @@ namespace Zipper
+                         EmptyPercentage = 150, // Invalid: > 100
+                     },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("invalid emptyPercentage", exception.Message);
++            Assert.Contains("invalid emptyPercentage", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -416,14 +417,14 @@ namespace Zipper
+                         TruePercentage = -10, // Invalid: < 0
+                     },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+ 
+             // Act & Assert
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("invalid truePercentage", exception.Message);
++            Assert.Contains("invalid truePercentage", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -454,8 +455,8 @@ namespace Zipper
+             });
+ 
+             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+-            Assert.Contains("BadDate", ex.Message);
+-            Assert.Contains("DateRange.Min", ex.Message);
++            Assert.Contains("BadDate", ex.Message, StringComparison.Ordinal);
++            Assert.Contains("DateRange.Min", ex.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -470,8 +471,8 @@ namespace Zipper
+             });
+ 
+             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+-            Assert.Contains("BadMax", ex.Message);
+-            Assert.Contains("DateRange.Max", ex.Message);
++            Assert.Contains("BadMax", ex.Message, StringComparison.Ordinal);
++            Assert.Contains("DateRange.Max", ex.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -486,8 +487,8 @@ namespace Zipper
+             });
+ 
+             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+-            Assert.Contains("Inverted", ex.Message);
+-            Assert.Contains("greater than", ex.Message);
++            Assert.Contains("Inverted", ex.Message, StringComparison.Ordinal);
++            Assert.Contains("greater than", ex.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -547,8 +548,8 @@ namespace Zipper
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("testDS", exception.Message);
+-            Assert.Contains("more weights than values", exception.Message);
++            Assert.Contains("testDS", exception.Message, StringComparison.Ordinal);
++            Assert.Contains("more weights than values", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -567,8 +568,8 @@ namespace Zipper
+             var exception = Assert.Throws<InvalidOperationException>(() =>
+                 ColumnProfileLoader.Validate(profile));
+ 
+-            Assert.Contains("testDS", exception.Message);
+-            Assert.Contains("more weights than values", exception.Message);
++            Assert.Contains("testDS", exception.Message, StringComparison.Ordinal);
++            Assert.Contains("more weights than values", exception.Message, StringComparison.Ordinal);
+         }
+ 
+         private static ColumnProfile CreateMinimalProfile()
+@@ -580,7 +581,7 @@ namespace Zipper
+                 {
+                     new() { Name = "DOCID", Type = "identifier" },
+                 },
+-                DataSources = new Dictionary<string, DataSourceConfig>(),
++                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             };
+         }
+     }
+diff --git a/src/Zipper.Tests/ColumnProfileTests.cs b/src/Zipper.Tests/ColumnProfileTests.cs
+index 0460569..4399ef5 100644
+--- a/src/Zipper.Tests/ColumnProfileTests.cs
++++ b/src/Zipper.Tests/ColumnProfileTests.cs
+@@ -19,9 +19,9 @@ public class ColumnProfileTests
+ 
+         Assert.Equal("minimal", profile.Name);
+         Assert.Equal(5, profile.Columns.Count);
+-        Assert.Contains(profile.Columns, c => c.Name == "DOCID");
+-        Assert.Contains(profile.Columns, c => c.Name == "FILEPATH");
+-        Assert.Contains(profile.Columns, c => c.Name == "CUSTODIAN");
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "DOCID", StringComparison.Ordinal));
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "FILEPATH", StringComparison.Ordinal));
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "CUSTODIAN", StringComparison.Ordinal));
+     }
+ 
+     /// <summary>
+@@ -34,9 +34,9 @@ public class ColumnProfileTests
+ 
+         Assert.Equal("standard", profile.Name);
+         Assert.Equal(24, profile.Columns.Count);
+-        Assert.Contains(profile.Columns, c => c.Name == "BEGBATES");
+-        Assert.Contains(profile.Columns, c => c.Name == "EMAILFROM");
+-        Assert.Contains(profile.Columns, c => c.Name == "RESPONSIVE");
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "BEGBATES", StringComparison.Ordinal));
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "EMAILFROM", StringComparison.Ordinal));
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "RESPONSIVE", StringComparison.Ordinal));
+     }
+ 
+     /// <summary>
+@@ -49,8 +49,8 @@ public class ColumnProfileTests
+ 
+         Assert.Equal("litigation", profile.Name);
+         Assert.Equal(48, profile.Columns.Count);
+-        Assert.Contains(profile.Columns, c => c.Name == "MD5HASH");
+-        Assert.Contains(profile.Columns, c => c.Name == "PRIVILEGE");
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "MD5HASH", StringComparison.Ordinal));
++        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "PRIVILEGE", StringComparison.Ordinal));
+     }
+ 
+     /// <summary>
+@@ -121,7 +121,7 @@ public class ColumnProfileTests
+         var profile = BuiltInProfiles.GetProfile(profileName);
+ 
+         Assert.NotNull(profile);
+-        Assert.Contains(profile.Columns, c => c.Type == "identifier");
++        Assert.Contains(profile.Columns, c => string.Equals(c.Type, "identifier", StringComparison.Ordinal));
+     }
+ 
+     /// <summary>
+diff --git a/src/Zipper.Tests/CsvLoadFileWriterTests.cs b/src/Zipper.Tests/CsvLoadFileWriterTests.cs
+index 8c0d32a..dfe8b71 100644
+--- a/src/Zipper.Tests/CsvLoadFileWriterTests.cs
++++ b/src/Zipper.Tests/CsvLoadFileWriterTests.cs
+@@ -9,10 +9,10 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+     {
+         var writer = new CsvComposingWriter();
+         using var stream = new MemoryStream();
+-        await writer.WriteAsync(stream, request, files);
++        await writer.WriteAsync(stream, request, files).ConfigureAwait(false);
+         stream.Position = 0;
+         using var reader = new StreamReader(stream);
+-        return await reader.ReadToEndAsync();
++        return await reader.ReadToEndAsync().ConfigureAwait(false);
+     }
+ 
+     [Fact]
+@@ -32,8 +32,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+         Assert.Equal(4, lines.Length);
+-        Assert.Contains("CONTROL NUMBER", lines[0]);
+-        Assert.Contains("DOC00000001", lines[1]);
++        Assert.Contains("CONTROL NUMBER", lines[0], StringComparison.Ordinal);
++        Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -63,7 +63,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+ 
+         var content = await File.ReadAllTextAsync(outputPath);
+ 
+-        Assert.Contains("\"\"", content);
++        Assert.Contains("\"\"", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -72,8 +72,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var request = this.CreateTestRequest();
+         var files = this.CreateTestFileData(2);
+         var content = await this.CaptureCsvOutput(request, files);
+-        Assert.Contains("DOC00000001", content);
+-        Assert.Contains("DOC00000002", content);
++        Assert.Contains("DOC00000001", content, StringComparison.Ordinal);
++        Assert.Contains("DOC00000002", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -84,7 +84,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var files = this.CreateTestFileData(1);
+         files[0] = files[0] with { WorkItem = files[0].WorkItem with { FilePathInZip = "folder_001/file_00000001.pdf" } };
+         var content = await this.CaptureCsvOutput(request, files);
+-        Assert.Contains("folder_001/file_00000001.txt", content);
++        Assert.Contains("folder_001/file_00000001.txt", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -94,16 +94,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         request.Metadata = request.Metadata with { WithMetadata = true };
+         var files = this.CreateTestFileData(1);
+         var contentWith = await this.CaptureCsvOutput(request, files);
+-        Assert.Contains("CUSTODIAN", contentWith);
++        Assert.Contains("CUSTODIAN", contentWith, StringComparison.Ordinal);
+ 
+         request.Metadata = request.Metadata with { WithMetadata = false };
+         var contentWithout = await this.CaptureCsvOutput(request, files);
+-        Assert.DoesNotContain("CUSTODIAN", contentWithout);
++        Assert.DoesNotContain("CUSTODIAN", contentWithout, StringComparison.Ordinal);
+ 
+         var emlRequest = this.CreateTestRequest("eml");
+         emlRequest.Metadata = emlRequest.Metadata with { WithMetadata = false };
+         var emlContent = await this.CaptureCsvOutput(emlRequest, files);
+-        Assert.Contains("CUSTODIAN", emlContent);
++        Assert.Contains("CUSTODIAN", emlContent, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -133,16 +133,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var files = this.CreateTestFileData(1);
+         files[0] = files[0] with { PageCount = 5 };
+         var contentWith = await this.CaptureCsvOutput(request, files);
+-        Assert.Contains("PAGE COUNT", contentWith);
++        Assert.Contains("PAGE COUNT", contentWith, StringComparison.Ordinal);
+ 
+         request.Tiff = request.Tiff with { PageRange = null };
+         var contentWithout = await this.CaptureCsvOutput(request, files);
+-        Assert.DoesNotContain("PAGE COUNT", contentWithout);
++        Assert.DoesNotContain("PAGE COUNT", contentWithout, StringComparison.Ordinal);
+ 
+         var pdfRequest = this.CreateTestRequest("pdf");
+         pdfRequest.Tiff = pdfRequest.Tiff with { PageRange = (1, 10) };
+         var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
+-        Assert.DoesNotContain("PAGE COUNT", pdfContent);
++        Assert.DoesNotContain("PAGE COUNT", pdfContent, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -159,7 +159,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var files = this.CreateTestFileData(1);
+         files[0] = files[0] with { WorkItem = files[0].WorkItem with { Index = 10 } };
+         var content = await this.CaptureCsvOutput(request, files);
+-        Assert.Contains("TEST001009", content);
++        Assert.Contains("TEST001009", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -171,8 +171,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         files[0] = files[0] with { DataLength = 1024, WorkItem = files[0].WorkItem with { FolderNumber = 5 } };
+         var content = await this.CaptureCsvOutput(request, files);
+         var dataLine = content.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1];
+-        Assert.Contains("Custodian 5", dataLine);
+-        Assert.Contains("1024", dataLine);
++        Assert.Contains("Custodian 5", dataLine, StringComparison.Ordinal);
++        Assert.Contains("1024", dataLine, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -196,7 +196,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         Assert.Equal(0xFE, bytes[1]);
+ 
+         var content = await File.ReadAllTextAsync(outputPath, System.Text.Encoding.Unicode);
+-        Assert.Contains("CONTROL NUMBER", content);
++        Assert.Contains("CONTROL NUMBER", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -232,6 +232,6 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
+         var content = encoding.GetString(bytes);
+         var roundTripBytes = encoding.GetBytes(content);
+         Assert.Equal(bytes, roundTripBytes);
+-        Assert.Contains("CONTROL NUMBER", content);
++        Assert.Contains("CONTROL NUMBER", content, StringComparison.Ordinal);
+     }
+ }
+diff --git a/src/Zipper.Tests/DatLoadFileWriterTests.cs b/src/Zipper.Tests/DatLoadFileWriterTests.cs
+index 800df41..ff507bb 100644
+--- a/src/Zipper.Tests/DatLoadFileWriterTests.cs
++++ b/src/Zipper.Tests/DatLoadFileWriterTests.cs
+@@ -34,10 +34,10 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
+         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+         Assert.Equal(6, lines.Length);
+-        Assert.Contains("Control Number", lines[0]);
+-        Assert.Contains("File Path", lines[0]);
+-        Assert.Contains("EmailSubject", lines[0]);
+-        Assert.Contains("ExtractedText", lines[0]);
++        Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
++        Assert.Contains("File Path", lines[0], StringComparison.Ordinal);
++        Assert.Contains("EmailSubject", lines[0], StringComparison.Ordinal);
++        Assert.Contains("ExtractedText", lines[0], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -113,11 +113,11 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
+         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+         Assert.Equal(6, lines.Length);
+-        Assert.Contains("DOCID", lines[0]);
+-        Assert.Contains("BATES_NUMBER", lines[0]);
+-        Assert.Contains("NATIVE_PATH", lines[0]);
+-        Assert.Contains("IMAGE_PATH", lines[0]);
+-        Assert.Contains("\r\n", content);
++        Assert.Contains("DOCID", lines[0], StringComparison.Ordinal);
++        Assert.Contains("BATES_NUMBER", lines[0], StringComparison.Ordinal);
++        Assert.Contains("NATIVE_PATH", lines[0], StringComparison.Ordinal);
++        Assert.Contains("IMAGE_PATH", lines[0], StringComparison.Ordinal);
++        Assert.Contains("\r\n", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -141,7 +141,7 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
+         stream.Position = 0;
+         var content = Encoding.UTF8.GetString(stream.ToArray());
+ 
+-        Assert.Contains("\r\n", content);
++        Assert.Contains("\r\n", content, StringComparison.Ordinal);
+     }
+ 
+ 
+diff --git a/src/Zipper.Tests/DatWriterTests.cs b/src/Zipper.Tests/DatWriterTests.cs
+index 19dd386..3e65cbf 100644
+--- a/src/Zipper.Tests/DatWriterTests.cs
++++ b/src/Zipper.Tests/DatWriterTests.cs
+@@ -15,9 +15,9 @@ namespace Zipper
+             var (_, lines) = await WriteAndCapture(DefaultRequest(), []);
+             var header = lines[0];
+ 
+-            Assert.Contains("Control Number", header);
+-            Assert.Contains("File Path", header);
+-            Assert.DoesNotContain("Custodian", header);
++            Assert.Contains("Control Number", header, StringComparison.Ordinal);
++            Assert.Contains("File Path", header, StringComparison.Ordinal);
++            Assert.DoesNotContain("Custodian", header, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -26,10 +26,10 @@ namespace Zipper
+             var request = DefaultRequest();
+             request.Metadata = request.Metadata with { WithMetadata = true };
+             var output = await WriteAndCaptureOutput(request, []);
+-            Assert.Contains("Custodian", output);
+-            Assert.Contains("Date Sent", output);
+-            Assert.Contains("Author", output);
+-            Assert.Contains("File Size", output);
++            Assert.Contains("Custodian", output, StringComparison.Ordinal);
++            Assert.Contains("Date Sent", output, StringComparison.Ordinal);
++            Assert.Contains("Author", output, StringComparison.Ordinal);
++            Assert.Contains("File Size", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -38,11 +38,11 @@ namespace Zipper
+             var request = DefaultRequest();
+             request.Output = request.Output with { FileType = "eml" };
+             var output = await WriteAndCaptureOutput(request, []);
+-            Assert.Contains("To", output);
+-            Assert.Contains("From", output);
+-            Assert.Contains("Subject", output);
+-            Assert.Contains("Sent Date", output);
+-            Assert.Contains("Attachment", output);
++            Assert.Contains("To", output, StringComparison.Ordinal);
++            Assert.Contains("From", output, StringComparison.Ordinal);
++            Assert.Contains("Subject", output, StringComparison.Ordinal);
++            Assert.Contains("Sent Date", output, StringComparison.Ordinal);
++            Assert.Contains("Attachment", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -57,7 +57,7 @@ namespace Zipper
+                 Increment = 1,
+             };
+             var output = await WriteAndCaptureOutput(request, []);
+-            Assert.Contains("Bates Number", output);
++            Assert.Contains("Bates Number", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -67,7 +67,7 @@ namespace Zipper
+             request.Output = request.Output with { FileType = "tiff" };
+             request.Tiff = request.Tiff with { PageRange = (1, 10) };
+             var output = await WriteAndCaptureOutput(request, []);
+-            Assert.Contains("Page Count", output);
++            Assert.Contains("Page Count", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -76,7 +76,7 @@ namespace Zipper
+             var request = DefaultRequest();
+             request.Output = request.Output with { WithText = true };
+             var output = await WriteAndCaptureOutput(request, []);
+-            Assert.Contains("Extracted Text", output);
++            Assert.Contains("Extracted Text", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -86,8 +86,8 @@ namespace Zipper
+             var files = new List<FileData> { MakeFileData(1), MakeFileData(2) };
+             var (_, lines) = await WriteAndCapture(request, files);
+             Assert.Equal(3, lines.Length);
+-            Assert.Contains("DOC00000001", lines[1]);
+-            Assert.Contains("DOC00000002", lines[2]);
++            Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
++            Assert.Contains("DOC00000002", lines[2], StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -98,8 +98,8 @@ namespace Zipper
+             var files = new List<FileData> { MakeFileData(1) };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains("Custodian 1", output);
+-            Assert.Contains("File Size", output);
++            Assert.Contains("Custodian 1", output, StringComparison.Ordinal);
++            Assert.Contains("File Size", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -133,10 +133,10 @@ namespace Zipper
+             };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains("test@example.com", output);
+-            Assert.Contains("sender@example.com", output);
+-            Assert.Contains("Test Subject", output);
+-            Assert.Contains("2026-01-15", output);
++            Assert.Contains("test@example.com", output, StringComparison.Ordinal);
++            Assert.Contains("sender@example.com", output, StringComparison.Ordinal);
++            Assert.Contains("Test Subject", output, StringComparison.Ordinal);
++            Assert.Contains("2026-01-15", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -153,7 +153,7 @@ namespace Zipper
+             var files = new List<FileData> { MakeFileData(1) };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains("DOC000100", output);
++            Assert.Contains("DOC000100", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -182,7 +182,7 @@ namespace Zipper
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+             var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
+-            Assert.EndsWith("þ3þ", dataLine);
++            Assert.EndsWith("þ3þ", dataLine, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -194,7 +194,7 @@ namespace Zipper
+             var files = new List<FileData> { MakeFileData(1) };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains(".txt", output);
++            Assert.Contains(".txt", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -243,8 +243,8 @@ namespace Zipper
+             };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains("recipient1@example.com", output);
+-            Assert.Contains("sender1@example.com", output);
++            Assert.Contains("recipient1@example.com", output, StringComparison.Ordinal);
++            Assert.Contains("sender1@example.com", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -257,7 +257,7 @@ namespace Zipper
+             var files = new List<FileData> { MakeFileData(1) };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.Contains("þ", output);
++            Assert.Contains("þ", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -283,8 +283,8 @@ namespace Zipper
+             };
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+-            Assert.DoesNotContain("line1\r\nline2", output);
+-            Assert.Contains("line1®line2", output);
++            Assert.DoesNotContain("line1\r\nline2", output, StringComparison.Ordinal);
++            Assert.Contains("line1®line2", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -310,7 +310,7 @@ namespace Zipper
+ 
+             var output = await WriteAndCaptureOutput(request, files);
+             var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
+-            Assert.Contains("line1®line2", dataLine);
++            Assert.Contains("line1®line2", dataLine, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -334,9 +334,9 @@ namespace Zipper
+             var header = lines[0];
+ 
+             // With no quote delimiter, fields must NOT be wrapped in any quote character
+-            Assert.DoesNotContain("þ", header);
+-            Assert.Contains("Control Number", header);
+-            Assert.Contains("File Path", header);
++            Assert.DoesNotContain("þ", header, StringComparison.Ordinal);
++            Assert.Contains("Control Number", header, StringComparison.Ordinal);
++            Assert.Contains("File Path", header, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -350,8 +350,8 @@ namespace Zipper
+             var dataRow = lines[1];
+ 
+             // DOC00000001 must appear unquoted — no þ wrapper
+-            Assert.DoesNotContain("þ", dataRow);
+-            Assert.Contains("DOC00000001", dataRow);
++            Assert.DoesNotContain("þ", dataRow, StringComparison.Ordinal);
++            Assert.Contains("DOC00000001", dataRow, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -365,8 +365,8 @@ namespace Zipper
+             var output = await WriteAndCaptureOutput(request, files);
+ 
+             // Metadata columns (Custodian, Date Sent, Author, File Size) must appear unquoted
+-            Assert.DoesNotContain("þ", output);
+-            Assert.Contains("Custodian", output);
++            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
++            Assert.Contains("Custodian", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -380,8 +380,8 @@ namespace Zipper
+             var output = await WriteAndCaptureOutput(request, files);
+ 
+             // Extracted Text column must appear unquoted
+-            Assert.DoesNotContain("þ", output);
+-            Assert.Contains(".txt", output);
++            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
++            Assert.Contains(".txt", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -395,8 +395,8 @@ namespace Zipper
+             var output = await WriteAndCaptureOutput(request, files);
+ 
+             // Bates Number column must appear unquoted
+-            Assert.DoesNotContain("þ", output);
+-            Assert.Contains("TEST", output);
++            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
++            Assert.Contains("TEST", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -414,7 +414,7 @@ namespace Zipper
+         {
+             using var stream = new MemoryStream();
+             var writer = new DatComposingWriter();
+-            await writer.WriteAsync(stream, request, files);
++            await writer.WriteAsync(stream, request, files).ConfigureAwait(false);
+ 
+             var output = Encoding.UTF8.GetString(stream.ToArray());
+             var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+@@ -423,7 +423,7 @@ namespace Zipper
+ 
+         private static async Task<string> WriteAndCaptureOutput(FileGenerationRequest request, List<FileData> files)
+         {
+-            var (output, _) = await WriteAndCapture(request, files);
++            var (output, _) = await WriteAndCapture(request, files).ConfigureAwait(false);
+             return output;
+         }
+ 
+@@ -493,7 +493,7 @@ namespace Zipper
+             Assert.All(chaosEngine.Anomalies, a => Assert.Equal("quotes", a.ErrorType));
+ 
+             var anomaly = chaosEngine.Anomalies.First();
+-            Assert.Contains("Omitted the closing", anomaly.Description);
++            Assert.Contains("Omitted the closing", anomaly.Description, StringComparison.Ordinal);
+             Assert.NotEqual("N/A", anomaly.Column);
+ 
+             var baseQuoteCount = baseOutput.Count(c => c == '\u00fe');
+@@ -532,7 +532,7 @@ namespace Zipper
+             Assert.True(chaosOutput.Contains(",") || chaosOutput.Contains("\t") || chaosOutput.Contains("|"), "Should contain alternative delimiters");
+ 
+             var anomaly = chaosEngine.Anomalies.First();
+-            Assert.Contains("Replaced delimiter", anomaly.Description);
++            Assert.Contains("Replaced delimiter", anomaly.Description, StringComparison.Ordinal);
+             Assert.NotEqual("N/A", anomaly.Column);
+ 
+             var baseDelimCount = baseOutput.Count(c => c == '\u0014');
+@@ -714,7 +714,7 @@ namespace Zipper
+             Assert.All(chaosEngine.Anomalies, a => Assert.Equal("quotes", a.ErrorType));
+ 
+             var anomaly = chaosEngine.Anomalies.First();
+-            Assert.Contains("Omitted the closing", anomaly.Description);
++            Assert.Contains("Omitted the closing", anomaly.Description, StringComparison.Ordinal);
+             Assert.NotEqual("N/A", anomaly.Column);
+ 
+             var baseQuoteCount = baseOutput.Count(c => c == '\u00fe');
+@@ -772,8 +772,8 @@ namespace Zipper
+ 
+             // The output should have anomalies injected for line 1 and line 4 (among others).
+             // This means there should be anomalies in the Audit log specifically for Boundary 1-2 and Boundary 4-5.
+-            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
+-            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
++            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 1-2", StringComparison.Ordinal));
++            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 4-5", StringComparison.Ordinal));
+ 
+             Assert.NotNull(headerAnomaly);
+             Assert.NotNull(lastLineAnomaly);
+@@ -796,10 +796,10 @@ namespace Zipper
+             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+             Assert.Equal(4, lines.Length);
+-            Assert.Contains("Control Number", lines[0]);
+-            Assert.Contains("DOC00000001", lines[1]);
+-            Assert.Contains("DOC00000002", lines[2]);
+-            Assert.Contains("DOC00000003", lines[3]);
++            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
++            Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
++            Assert.Contains("DOC00000002", lines[2], StringComparison.Ordinal);
++            Assert.Contains("DOC00000003", lines[3], StringComparison.Ordinal);
+         }
+ 
+         [Theory]
+@@ -832,7 +832,7 @@ namespace Zipper
+             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+             Assert.True(lines.Length >= 2);
+-            Assert.Contains("Control Number", lines[0]);
++            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -862,7 +862,7 @@ namespace Zipper
+ 
+             var output = await File.ReadAllTextAsync(outputPath);
+ 
+-            Assert.Contains("folderþþX/file.pdf", output);
++            Assert.Contains("folderþþX/file.pdf", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -905,7 +905,7 @@ namespace Zipper
+             stream.Position = 0;
+             var output = Encoding.UTF8.GetString(stream.ToArray());
+ 
+-            Assert.Contains("fileþþX.pdf", output);
++            Assert.Contains("fileþþX.pdf", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -941,17 +941,17 @@ namespace Zipper
+             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+             Assert.Equal(3, lines.Length);
+-            Assert.Contains("BEGATTACH", lines[0]);
+-            Assert.Contains("ENDATTACH", lines[0]);
+-            Assert.Contains("PARENTDOCID", lines[0]);
++            Assert.Contains("BEGATTACH", lines[0], StringComparison.Ordinal);
++            Assert.Contains("ENDATTACH", lines[0], StringComparison.Ordinal);
++            Assert.Contains("PARENTDOCID", lines[0], StringComparison.Ordinal);
+ 
+             var parentLine = lines[1];
+-            Assert.Contains("DOC00000001", parentLine);
+-            Assert.Contains("DOC00000001_A001", parentLine);
++            Assert.Contains("DOC00000001", parentLine, StringComparison.Ordinal);
++            Assert.Contains("DOC00000001_A001", parentLine, StringComparison.Ordinal);
+ 
+             var childLine = lines[2];
+-            Assert.Contains("DOC00000001_A001", childLine);
+-            Assert.Contains("DOC00000001", childLine);
++            Assert.Contains("DOC00000001_A001", childLine, StringComparison.Ordinal);
++            Assert.Contains("DOC00000001", childLine, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -998,15 +998,15 @@ namespace Zipper
+             var lines = content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+ 
+             Assert.Equal(3, lines.Length);
+-            Assert.Contains("BEGATTACH", lines[0]);
+-            Assert.Contains("ENDATTACH", lines[0]);
+-            Assert.Contains("PARENTDOCID", lines[0]);
++            Assert.Contains("BEGATTACH", lines[0], StringComparison.Ordinal);
++            Assert.Contains("ENDATTACH", lines[0], StringComparison.Ordinal);
++            Assert.Contains("PARENTDOCID", lines[0], StringComparison.Ordinal);
+ 
+-            Assert.Contains("TEST00000001", lines[1]);
+-            Assert.Contains("TEST00000001_A001", lines[1]);
++            Assert.Contains("TEST00000001", lines[1], StringComparison.Ordinal);
++            Assert.Contains("TEST00000001_A001", lines[1], StringComparison.Ordinal);
+ 
+-            Assert.Contains("TEST00000001_A001", lines[2]);
+-            Assert.Contains("TEST00000001", lines[2]);
++            Assert.Contains("TEST00000001_A001", lines[2], StringComparison.Ordinal);
++            Assert.Contains("TEST00000001", lines[2], StringComparison.Ordinal);
+         }
+     }
+ }
+diff --git a/src/Zipper.Tests/DataGeneratorTests.cs b/src/Zipper.Tests/DataGeneratorTests.cs
+index 5da9bec..d42b031 100644
+--- a/src/Zipper.Tests/DataGeneratorTests.cs
++++ b/src/Zipper.Tests/DataGeneratorTests.cs
+@@ -109,7 +109,7 @@ public class DataGeneratorTests
+         // ISRESPONSIVE is a boolean column with Format = "YN"
+         var responsiveValue = row["ISRESPONSIVE"];
+         Assert.True(
+-            responsiveValue == "Y" || responsiveValue == "N" || string.IsNullOrEmpty(responsiveValue),
++string.Equals(responsiveValue, "Y", StringComparison.Ordinal) || string.Equals(responsiveValue, "N", StringComparison.Ordinal) || string.IsNullOrEmpty(responsiveValue),
+             $"Expected Y, N, or empty but got {responsiveValue}");
+     }
+ 
+@@ -151,8 +151,8 @@ public class DataGeneratorTests
+         var emailValue = row["EMAILFROM"];
+         if (!string.IsNullOrEmpty(emailValue))
+         {
+-            Assert.Contains("@", emailValue);
+-            Assert.Contains(".", emailValue);
++            Assert.Contains("@", emailValue, StringComparison.Ordinal);
++            Assert.Contains(".", emailValue, StringComparison.Ordinal);
+         }
+     }
+ 
+@@ -199,7 +199,7 @@ public class DataGeneratorTests
+             var emailToValue = row["EMAILTO"];
+             if (!string.IsNullOrEmpty(emailToValue) && emailToValue.Contains(delimiter))
+             {
+-                Assert.Contains(delimiter, emailToValue);
++                Assert.Contains(delimiter, emailToValue, StringComparison.Ordinal);
+                 var parts = emailToValue.Split(delimiter);
+                 Assert.True(parts.Length >= 2);
+                 return;
+@@ -224,7 +224,7 @@ public class DataGeneratorTests
+ 
+         var fileSizeValue = row["FILESIZE"];
+         Assert.True(
+-            long.TryParse(fileSizeValue, out var size),
++            long.TryParse(fileSizeValue, System.Globalization.CultureInfo.InvariantCulture, out var size),
+             $"Expected valid number but got {fileSizeValue}");
+         Assert.True(size >= 0, "File size should be non-negative");
+     }
+@@ -239,6 +239,7 @@ public class DataGeneratorTests
+         {
+             Name = "test-every-kind",
+             DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+             {
+                 ["statusValues"] = new DataSourceConfig { Values = ["Active", "Inactive", "Pending", "Closed", "Archived"] },
+                 ["categoryValues"] = new DataSourceConfig { Values = ["CategoryA", "CategoryB", "CategoryC", "CategoryD"], Weights = [40, 30, 20, 10] },
+@@ -258,8 +259,8 @@ public class DataGeneratorTests
+             },
+         };
+         var generator = new DataGenerator(profile, seed: 42);
+-        var validCoded = new HashSet<string> { "Active", "Inactive", "Pending", "Closed", "Archived" };
+-        var validBool = new HashSet<string> { "Y", "N" };
++        var validCoded = new HashSet<string>(StringComparer.Ordinal) { "Active", "Inactive", "Pending", "Closed", "Archived" };
++        var validBool = new HashSet<string>(StringComparer.Ordinal) { "Y", "N" };
+ 
+         for (int i = 1; i <= 200; i++)
+         {
+@@ -281,13 +282,13 @@ public class DataGeneratorTests
+             // datetime: ISO 8601 with time component
+             if (!string.IsNullOrEmpty(row["DATETIMEFIELD"]))
+             {
+-                Assert.Contains("T", row["DATETIMEFIELD"]);
++                Assert.Contains("T", row["DATETIMEFIELD"], StringComparison.Ordinal);
+             }
+ 
+             // number: integer in valid range
+             if (!string.IsNullOrEmpty(row["NUMBERFIELD"]))
+             {
+-                Assert.True(int.TryParse(row["NUMBERFIELD"], out var numVal), $"NUMBERFIELD is not an integer: {row["NUMBERFIELD"]}");
++                Assert.True(int.TryParse(row["NUMBERFIELD"], System.Globalization.CultureInfo.InvariantCulture, out var numVal), $"NUMBERFIELD is not an integer: {row["NUMBERFIELD"]}");
+                 Assert.InRange(numVal, 0, 10000);
+             }
+ 
+@@ -324,7 +325,7 @@ public class DataGeneratorTests
+         var profile = new ColumnProfile
+         {
+             Name = $"test-empty-{emptyPct}",
+-            DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>(),
++            DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             Columns = new System.Collections.Generic.List<ColumnDefinition>
+             {
+                 new() { Name = "DOCID", Type = "identifier", Required = true },
+@@ -374,6 +375,7 @@ public class DataGeneratorTests
+         {
+             Name = "test-weighted-bias",
+             DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+             {
+                 ["weightedDS"] = new DataSourceConfig
+                 {
+@@ -402,11 +404,11 @@ public class DataGeneratorTests
+             var row = generator.GenerateRow(workItem, fileData);
+ 
+             var value = row["WEIGHTEDFIELD"];
+-            if (value == "A")
++            if (string.Equals(value, "A", StringComparison.Ordinal))
+             {
+                 aCount++;
+             }
+-            else if (value == "B")
++            else if (string.Equals(value, "B", StringComparison.Ordinal))
+             {
+                 bCount++;
+             }
+@@ -432,9 +434,9 @@ public class DataGeneratorTests
+         // Use 500 rows (seeded) to ensure all 3 values appear given pareto distribution.
+         var profile = BuiltInProfiles.Standard;
+         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 3);
+-        var validValues = new HashSet<string> { "Custodian_1", "Custodian_2", "Custodian_3" };
++        var validValues = new HashSet<string>(StringComparer.Ordinal) { "Custodian_1", "Custodian_2", "Custodian_3" };
+ 
+-        var custodianValues = new HashSet<string>();
++        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
+ 
+         for (int i = 1; i <= 500; i++)
+         {
+@@ -472,7 +474,7 @@ public class DataGeneratorTests
+         {
+             Name = "no-custodians",
+             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+-            DataSources = new Dictionary<string, DataSourceConfig>(),
++            DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
+             Columns = new List<ColumnDefinition>
+             {
+                 new() { Name = "DOCID", Type = "identifier", Required = true },
+@@ -499,6 +501,7 @@ public class DataGeneratorTests
+             Name = "values-custodians",
+             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+             DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+             {
+                 ["custodians"] = new DataSourceConfig
+                 {
+@@ -515,7 +518,7 @@ public class DataGeneratorTests
+ 
+         // Override to 2: only "Alice" and "Bob" should ever appear
+         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
+-        var custodianValues = new HashSet<string>();
++        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
+ 
+         for (int i = 1; i <= 200; i++)
+         {
+@@ -530,7 +533,7 @@ public class DataGeneratorTests
+             $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+         foreach (var v in custodianValues)
+         {
+-            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value: {v}");
++            Assert.True(string.Equals(v, "Alice", StringComparison.Ordinal) || string.Equals(v, "Bob", StringComparison.Ordinal), $"Unexpected custodian value: {v}");
+         }
+     }
+ 
+@@ -547,6 +550,7 @@ public class DataGeneratorTests
+             Name = "weighted-values-custodians",
+             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+             DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+             {
+                 ["custodians"] = new DataSourceConfig
+                 {
+@@ -566,7 +570,7 @@ public class DataGeneratorTests
+         // If Weights was NOT truncated, PrecomputeIndices would sum all 5 weights (100)
+         // but only 2 values exist, causing index-out-of-range fallback to the last value.
+         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
+-        var custodianValues = new HashSet<string>();
++        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
+ 
+         for (int i = 1; i <= 200; i++)
+         {
+@@ -581,7 +585,7 @@ public class DataGeneratorTests
+             $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
+         foreach (var v in custodianValues)
+         {
+-            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value after weight truncation: {v}");
++            Assert.True(string.Equals(v, "Alice", StringComparison.Ordinal) || string.Equals(v, "Bob", StringComparison.Ordinal), $"Unexpected custodian value after weight truncation: {v}");
+         }
+     }
+ 
+@@ -598,6 +602,7 @@ public class DataGeneratorTests
+             Name = "generated-weighted-custodians",
+             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+             DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+             {
+                 ["custodians"] = new DataSourceConfig
+                 {
+@@ -628,11 +633,11 @@ public class DataGeneratorTests
+             var row = generator.GenerateRow(workItem, fileData);
+ 
+             var value = row["CUSTODIAN"];
+-            if (value == "Cust_1")
++            if (string.Equals(value, "Cust_1", StringComparison.Ordinal))
+             {
+                 cust1Count++;
+             }
+-            else if (value == "Cust_2")
++            else if (string.Equals(value, "Cust_2", StringComparison.Ordinal))
+             {
+                 cust2Count++;
+             }
+diff --git a/src/Zipper.Tests/Emails/EmailFactoryTests.cs b/src/Zipper.Tests/Emails/EmailFactoryTests.cs
+index 0e19305..b07858b 100644
+--- a/src/Zipper.Tests/Emails/EmailFactoryTests.cs
++++ b/src/Zipper.Tests/Emails/EmailFactoryTests.cs
+@@ -51,8 +51,8 @@ namespace Zipper
+             // Assert — basic RFC-5321 shape: local@domain
+             Assert.Matches(@"^[^@]+@[^@]+\.[^@]+$", template.To);
+             Assert.Matches(@"^[^@]+@[^@]+\.[^@]+$", template.From);
+-            Assert.Contains($"recipient{recipientIndex:D3}@", template.To);
+-            Assert.Contains($"sender{senderIndex:D3}@", template.From);
++            Assert.Contains($"recipient{recipientIndex:D3}@", template.To, StringComparison.Ordinal);
++            Assert.Contains($"sender{senderIndex:D3}@", template.From, StringComparison.Ordinal);
+         }
+ 
+         [Theory]
+@@ -71,7 +71,7 @@ namespace Zipper
+         public void Create_SentDate_WithinCategoryRange(EmailCategory category, int maxDaysAgo)
+         {
+             // Arrange
+-            var now = DateTime.Now;
++            var now = DateTime.UtcNow;
+             const int iterations = 50;
+ 
+             for (int i = 0; i < iterations; i++)
+@@ -276,8 +276,8 @@ namespace Zipper
+         [Fact]
+         public void GenerateEmailAddress_ProducesExpectedFormat()
+         {
+-            Assert.Contains("recipient042@", EmailFactory.GenerateEmailAddress(42, "recipient"));
+-            Assert.Contains("sender001@", EmailFactory.GenerateEmailAddress(1, "sender"));
++            Assert.Contains("recipient042@", EmailFactory.GenerateEmailAddress(42, "recipient"), StringComparison.Ordinal);
++            Assert.Contains("sender001@", EmailFactory.GenerateEmailAddress(1, "sender"), StringComparison.Ordinal);
+         }
+ 
+         // Tests redistributed from EmailTemplateSystemTests
+@@ -294,7 +294,7 @@ namespace Zipper
+             Assert.False(string.IsNullOrEmpty(email.From));
+             Assert.False(string.IsNullOrEmpty(email.Subject));
+             Assert.False(string.IsNullOrEmpty(email.Body));
+-            Assert.True(email.SentDate <= DateTime.Now);
++            Assert.True(email.SentDate <= DateTime.UtcNow);
+         }
+ 
+         [Theory]
+@@ -318,8 +318,8 @@ namespace Zipper
+             var email = EmailFactory.Create(recipientIndex, senderIndex, category, new Random(99));
+ 
+             Assert.NotNull(email);
+-            Assert.Contains($"recipient{recipientIndex:D3}@", email.To);
+-            Assert.Contains($"sender{senderIndex:D3}@", email.From);
++            Assert.Contains($"recipient{recipientIndex:D3}@", email.To, StringComparison.Ordinal);
++            Assert.Contains($"sender{senderIndex:D3}@", email.From, StringComparison.Ordinal);
+             this.output.WriteLine($"Category: {category}, Subject: {email.Subject}");
+         }
+ 
+@@ -335,7 +335,7 @@ namespace Zipper
+                 subjects[i] = email.Subject;
+             }
+ 
+-            var uniqueSubjects = subjects.Distinct().Count();
++            var uniqueSubjects = subjects.Distinct(StringComparer.Ordinal).Count();
+             Assert.True(uniqueSubjects > 1, "Expected multiple different subjects");
+             Assert.True(uniqueSubjects >= iterations * 0.3, $"Expected at least 30% variety, got {uniqueSubjects}/{iterations}");
+         }
+@@ -352,8 +352,8 @@ namespace Zipper
+                 emailAddresses[i] = (email.To, email.From);
+             }
+ 
+-            var uniqueToAddresses = emailAddresses.Select(e => e.to).Distinct().Count();
+-            var uniqueFromAddresses = emailAddresses.Select(e => e.from).Distinct().Count();
++            var uniqueToAddresses = emailAddresses.Select(e => e.to).Distinct(StringComparer.Ordinal).Count();
++            var uniqueFromAddresses = emailAddresses.Select(e => e.from).Distinct(StringComparer.Ordinal).Count();
+ 
+             Assert.Equal(iterations, uniqueToAddresses);
+             Assert.Equal(iterations, uniqueFromAddresses);
+@@ -376,8 +376,8 @@ namespace Zipper
+             var email = EmailFactory.CreateContextual(context, new Random(42));
+ 
+             Assert.NotNull(email);
+-            Assert.Contains("recipient005@", email.To);
+-            Assert.Contains("sender010@", email.From);
++            Assert.Contains("recipient005@", email.To, StringComparison.Ordinal);
++            Assert.Contains("sender010@", email.From, StringComparison.Ordinal);
+             Assert.Equal(new DateTime(2023, 6, 15), email.SentDate);
+             Assert.True(email.IsHighPriority);
+             Assert.True(email.RequestReadReceipt);
+@@ -438,7 +438,7 @@ namespace Zipper
+                 var email = EmailFactory.Create(i + 1, i + 2, category, new Random(i));
+                 foreach (var placeholder in bodyPlaceholders)
+                 {
+-                    Assert.DoesNotContain(placeholder, email.Body);
++                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
+                 }
+             }
+         }
+@@ -452,8 +452,8 @@ namespace Zipper
+             var email = EmailFactory.Create(largeRecipientIndex, largeSenderIndex, null, new Random(1));
+ 
+             Assert.NotNull(email);
+-            Assert.Contains($"recipient{largeRecipientIndex:D6}@", email.To);
+-            Assert.Contains($"sender{largeSenderIndex:D6}@", email.From);
++            Assert.Contains($"recipient{largeRecipientIndex:D6}@", email.To, StringComparison.Ordinal);
++            Assert.Contains($"sender{largeSenderIndex:D6}@", email.From, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -467,13 +467,13 @@ namespace Zipper
+                 var email = EmailFactory.Create(i + 1, i + 2, null, new Random(i));
+                 foreach (var placeholder in commonPlaceholders)
+                 {
+-                    Assert.DoesNotContain(placeholder, email.Subject);
+-                    Assert.DoesNotContain(placeholder, email.Body);
++                    Assert.DoesNotContain(placeholder, email.Subject, StringComparison.Ordinal);
++                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
+                 }
+ 
+                 foreach (var placeholder in bodyOnlyPlaceholders)
+                 {
+-                    Assert.DoesNotContain(placeholder, email.Body);
++                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
+                 }
+             }
+         }
+diff --git a/src/Zipper.Tests/Emails/EmailSerializerTests.cs b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+index 02844b8..1f86ce7 100644
+--- a/src/Zipper.Tests/Emails/EmailSerializerTests.cs
++++ b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+@@ -21,13 +21,13 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("From: sender@example.com", content);
+-            Assert.Contains("To: recipient@example.com", content);
+-            Assert.Contains("Subject: RFC 2822 Test", content);
+-            Assert.Contains("Date: Fri, 15 Mar 2024 10:30:00", content);
+-            Assert.Contains("MIME-Version: 1.0", content);
+-            Assert.Contains("Content-Type: text/plain; charset=utf-8", content);
+-            Assert.Contains("Content-Transfer-Encoding: 8bit", content);
++            Assert.Contains("From: sender@example.com", content, StringComparison.Ordinal);
++            Assert.Contains("To: recipient@example.com", content, StringComparison.Ordinal);
++            Assert.Contains("Subject: RFC 2822 Test", content, StringComparison.Ordinal);
++            Assert.Contains("Date: Fri, 15 Mar 2024 10:30:00", content, StringComparison.Ordinal);
++            Assert.Contains("MIME-Version: 1.0", content, StringComparison.Ordinal);
++            Assert.Contains("Content-Type: text/plain; charset=utf-8", content, StringComparison.Ordinal);
++            Assert.Contains("Content-Transfer-Encoding: 8bit", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -51,7 +51,7 @@ namespace Zipper
+                 var content = Encoding.UTF8.GetString(result);
+ 
+                 // Must use English abbreviations per RFC 2822
+-                Assert.Contains("Date: Mon, 15 Jan 2024 14:00:00", content);
++                Assert.Contains("Date: Mon, 15 Jan 2024 14:00:00", content, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -75,8 +75,8 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains(unicodeBody, content);
+-            Assert.Contains("Unicode Subject: ñoño", content);
++            Assert.Contains(unicodeBody, content, StringComparison.Ordinal);
++            Assert.Contains("Unicode Subject: ñoño", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -99,10 +99,10 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, attachment);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("multipart/mixed", content);
+-            Assert.Contains("Content-Transfer-Encoding: base64", content);
+-            Assert.Contains("Content-Disposition: attachment; filename=\"data.pdf\"", content);
+-            Assert.Contains("application/pdf", content);
++            Assert.Contains("multipart/mixed", content, StringComparison.Ordinal);
++            Assert.Contains("Content-Transfer-Encoding: base64", content, StringComparison.Ordinal);
++            Assert.Contains("Content-Disposition: attachment; filename=\"data.pdf\"", content, StringComparison.Ordinal);
++            Assert.Contains("application/pdf", content, StringComparison.Ordinal);
+             Assert.True(result.Length > 0);
+         }
+ 
+@@ -122,8 +122,8 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("X-Priority: 1", content);
+-            Assert.Contains("Priority: Urgent", content);
++            Assert.Contains("X-Priority: 1", content, StringComparison.Ordinal);
++            Assert.Contains("Priority: Urgent", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -142,7 +142,7 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Disposition-Notification-To: sender@example.com", content);
++            Assert.Contains("Disposition-Notification-To: sender@example.com", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -161,7 +161,7 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Cc: cc@example.com", content);
++            Assert.Contains("Cc: cc@example.com", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -180,7 +180,7 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Reply-To: reply@example.com", content);
++            Assert.Contains("Reply-To: reply@example.com", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -205,8 +205,8 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.DoesNotContain("X-Priority:", content);
+-            Assert.DoesNotContain("Priority: Urgent", content);
++            Assert.DoesNotContain("X-Priority:", content, StringComparison.Ordinal);
++            Assert.DoesNotContain("Priority: Urgent", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -231,8 +231,8 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, attachment);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Content-ID: <img-001>", content);
+-            Assert.Contains("Content-Disposition: inline; filename=\"image.png\"", content);
++            Assert.Contains("Content-ID: <img-001>", content, StringComparison.Ordinal);
++            Assert.Contains("Content-Disposition: inline; filename=\"image.png\"", content, StringComparison.Ordinal);
+         }
+ 
+         // Tests redistributed from EmailBuilderTests
+@@ -253,8 +253,8 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, null);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Cc: cc@example.com", content);
+-            Assert.Contains("Bcc: bcc@example.com", content);
++            Assert.Contains("Cc: cc@example.com", content, StringComparison.Ordinal);
++            Assert.Contains("Bcc: bcc@example.com", content, StringComparison.Ordinal);
+         }
+ 
+         [Theory]
+@@ -284,7 +284,7 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, attachment);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains(expectedContentType, content);
++            Assert.Contains(expectedContentType, content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -308,7 +308,7 @@ namespace Zipper
+             var result = EmailSerializer.ToEml(email, attachment);
+ 
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("application/custom-type", content);
++            Assert.Contains("application/custom-type", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -334,7 +334,7 @@ namespace Zipper
+ 
+             Assert.True(result.Length > largeContent.Length);
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("base64", content.ToLowerInvariant());
++            Assert.Contains("base64", content.ToLowerInvariant(), StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -354,7 +354,7 @@ namespace Zipper
+             Assert.NotNull(result);
+             Assert.True(result.Length > 0);
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Subject:", content);
++            Assert.Contains("Subject:", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -373,7 +373,7 @@ namespace Zipper
+ 
+             Assert.NotNull(result);
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("Date:", content);
++            Assert.Contains("Date:", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -397,7 +397,7 @@ namespace Zipper
+ 
+             Assert.NotNull(result);
+             var content = Encoding.UTF8.GetString(result);
+-            Assert.Contains("multipart/mixed", content);
++            Assert.Contains("multipart/mixed", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+diff --git a/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs b/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs
+index 108bb99..a2b117a 100644
+--- a/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs
++++ b/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs
+@@ -31,12 +31,12 @@ public class EmlFileGeneratorDeterminismTests
+ 
+         // Correctness assertions (M3)
+         var emlText = System.Text.Encoding.UTF8.GetString(result1.Content);
+-        Assert.Contains("To: recipient005@", emlText);
+-        Assert.Contains("From: sender005@", emlText);
+-        Assert.Contains("Subject: ", emlText);
+-        Assert.Contains("MIME-Version: 1.0", emlText);
+-        Assert.Contains("Date: ", emlText);
+-        Assert.Contains("Content-Type: text/plain", emlText);
++        Assert.Contains("To: recipient005@", emlText, StringComparison.Ordinal);
++        Assert.Contains("From: sender005@", emlText, StringComparison.Ordinal);
++        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
++        Assert.Contains("MIME-Version: 1.0", emlText, StringComparison.Ordinal);
++        Assert.Contains("Date: ", emlText, StringComparison.Ordinal);
++        Assert.Contains("Content-Type: text/plain", emlText, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -66,11 +66,11 @@ public class EmlFileGeneratorDeterminismTests
+ 
+         // Correctness assertions (M3)
+         var emlText = System.Text.Encoding.UTF8.GetString(result1.Content);
+-        Assert.Contains("To: recipient003@", emlText);
+-        Assert.Contains("From: sender003@", emlText);
+-        Assert.Contains("Subject: ", emlText);
+-        Assert.Contains("MIME-Version: 1.0", emlText);
+-        Assert.Contains("Content-Type: multipart/mixed", emlText);
++        Assert.Contains("To: recipient003@", emlText, StringComparison.Ordinal);
++        Assert.Contains("From: sender003@", emlText, StringComparison.Ordinal);
++        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
++        Assert.Contains("MIME-Version: 1.0", emlText, StringComparison.Ordinal);
++        Assert.Contains("Content-Type: multipart/mixed", emlText, StringComparison.Ordinal);
+         Assert.NotNull(result1.Attachment);
+         Assert.NotEmpty(result1.Attachment.Value.filename);
+         Assert.NotEmpty(result1.Attachment.Value.content);
+@@ -89,9 +89,9 @@ public class EmlFileGeneratorDeterminismTests
+         var emlText = System.Text.Encoding.UTF8.GetString(result.Content);
+ 
+         // Headers presence check
+-        Assert.Contains("From: ", emlText);
+-        Assert.Contains("To: ", emlText);
+-        Assert.Contains("Subject: ", emlText);
++        Assert.Contains("From: ", emlText, StringComparison.Ordinal);
++        Assert.Contains("To: ", emlText, StringComparison.Ordinal);
++        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
+ 
+         // Date should be RFC 2822 formatted with InvariantCulture
+         Assert.Matches(@"Date: (Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} [+-]\d{2}:\d{2}", emlText);
+diff --git a/src/Zipper.Tests/EncodingDataTests.cs b/src/Zipper.Tests/EncodingDataTests.cs
+index 4673a87..2285445 100644
+--- a/src/Zipper.Tests/EncodingDataTests.cs
++++ b/src/Zipper.Tests/EncodingDataTests.cs
+@@ -6,7 +6,7 @@ namespace Zipper.Tests;
+ public class EncodingDataTests
+ {
+     private static readonly System.Collections.Generic.HashSet<string> ValidEncodings =
+-        new() { "UTF-8", "ASCII", "UTF-16", "ISO-8859-1", "Windows-1252" };
++        new(StringComparer.Ordinal) { "UTF-8", "ASCII", "UTF-16", "ISO-8859-1", "Windows-1252" };
+ 
+     [Fact]
+     public void GetRandom_ReturnsNonEmptyString()
+diff --git a/src/Zipper.Tests/FieldNamingTests.cs b/src/Zipper.Tests/FieldNamingTests.cs
+index f7e9622..71e8c4c 100644
+--- a/src/Zipper.Tests/FieldNamingTests.cs
++++ b/src/Zipper.Tests/FieldNamingTests.cs
+@@ -151,7 +151,7 @@ public class FieldNamingTests : IDisposable
+         };
+ 
+         var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
+-        Assert.Contains("has an invalid fieldNamingConvention", ex.Message);
++        Assert.Contains("has an invalid fieldNamingConvention", ex.Message, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/GenerationRunnerTests.cs b/src/Zipper.Tests/GenerationRunnerTests.cs
+index 5268a1e..6e90114 100644
+--- a/src/Zipper.Tests/GenerationRunnerTests.cs
++++ b/src/Zipper.Tests/GenerationRunnerTests.cs
+@@ -33,14 +33,14 @@ namespace Zipper
+         public async Task RunAsync_ThrowingMode_PrintsLegacyErrorFormatToStderr()
+         {
+             var (_, _, err) = await RunWithCapture(new ThrowingMode("disk full"), DefaultRequest());
+-            Assert.Contains("\nAn error occurred: disk full", err);
++            Assert.Contains("\nAn error occurred: disk full", err, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+         public async Task RunAsync_ThrowingMode_DoesNotWriteErrorToStdout()
+         {
+             var (_, output, _) = await RunWithCapture(new ThrowingMode("boom"), DefaultRequest());
+-            Assert.DoesNotContain("An error occurred", output);
++            Assert.DoesNotContain("An error occurred", output, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -106,7 +106,7 @@ namespace Zipper
+                 using var errWriter = new StringWriter();
+                 Console.SetOut(outWriter);
+                 Console.SetError(errWriter);
+-                int exit = await GenerationRunner.RunAsync(mode, request);
++                int exit = await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
+                 return (exit, outWriter.ToString(), errWriter.ToString());
+             }
+             finally
+diff --git a/src/Zipper.Tests/HelpTextGeneratorTests.cs b/src/Zipper.Tests/HelpTextGeneratorTests.cs
+index e01774c..41d8e97 100644
+--- a/src/Zipper.Tests/HelpTextGeneratorTests.cs
++++ b/src/Zipper.Tests/HelpTextGeneratorTests.cs
+@@ -18,21 +18,21 @@ namespace Zipper.Tests
+                 HelpTextGenerator.Show();
+ 
+                 var output = errorOutput.ToString();
+-                Assert.Contains("Error: Missing required arguments.", output);
+-                Assert.Contains("Usage:", output);
+-                Assert.Contains("--type <pdf|jpg|tiff|eml|docx|xlsx>", output);
+-                Assert.Contains("--count <number>", output);
+-                Assert.Contains("--output-path <path>", output);
+-                Assert.Contains("Optional Arguments:", output);
+-                Assert.Contains("Required Arguments:", output);
+-                Assert.Contains("Load File Options:", output);
+-                Assert.Contains("Loadfile-Only Options:", output);
+-                Assert.Contains("Chaos Engine Options:", output);
+-                Assert.Contains("Production Set Options:", output);
+-                Assert.Contains("Bates Numbering:", output);
+-                Assert.Contains("TIFF Options:", output);
+-                Assert.Contains("Column Profile Options:", output);
+-                Assert.Contains("Utility Options:", output);
++                Assert.Contains("Error: Missing required arguments.", output, StringComparison.Ordinal);
++                Assert.Contains("Usage:", output, StringComparison.Ordinal);
++                Assert.Contains("--type <pdf|jpg|tiff|eml|docx|xlsx>", output, StringComparison.Ordinal);
++                Assert.Contains("--count <number>", output, StringComparison.Ordinal);
++                Assert.Contains("--output-path <path>", output, StringComparison.Ordinal);
++                Assert.Contains("Optional Arguments:", output, StringComparison.Ordinal);
++                Assert.Contains("Required Arguments:", output, StringComparison.Ordinal);
++                Assert.Contains("Load File Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Loadfile-Only Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Chaos Engine Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Production Set Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Bates Numbering:", output, StringComparison.Ordinal);
++                Assert.Contains("TIFF Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Column Profile Options:", output, StringComparison.Ordinal);
++                Assert.Contains("Utility Options:", output, StringComparison.Ordinal);
+             }
+             finally
+             {
+diff --git a/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs b/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
+index 5a714a0..4b3b7b6 100644
+--- a/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
++++ b/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
+@@ -41,10 +41,10 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
+ 
+         Assert.Equal(2, lines.Length);
+ 
+-        Assert.Contains("\u00feCONTROLNUMBER\u00fe", lines[0]);
+-        Assert.Contains("\u00fePATH\u00fe", lines[0]);
+-        Assert.Contains("\u00feDOC00000001\u00fe", lines[1]);
+-        Assert.Contains("\u00fefolder/doc1.pdf\u00fe", lines[1]);
++        Assert.Contains("\u00feCONTROLNUMBER\u00fe", lines[0], StringComparison.Ordinal);
++        Assert.Contains("\u00fePATH\u00fe", lines[0], StringComparison.Ordinal);
++        Assert.Contains("\u00feDOC00000001\u00fe", lines[1], StringComparison.Ordinal);
++        Assert.Contains("\u00fefolder/doc1.pdf\u00fe", lines[1], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -76,7 +76,7 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
+         var dataLine = content.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1];
+         var fields = dataLine.Split('\u0014');
+ 
+-        Assert.Contains("\u00fe\u00fe", fields[3]);
++        Assert.Contains("\u00fe\u00fe", fields[3], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -95,11 +95,11 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
+         var content = await File.ReadAllTextAsync(outputPath);
+         var colDelim = '\u0014';
+         Assert.Contains(colDelim, content);
+-        Assert.Contains("CONTROLNUMBER", content);
++        Assert.Contains("CONTROLNUMBER", content, StringComparison.Ordinal);
+ 
+         var lines_split = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+-        Assert.Contains("BEGATTY", lines_split[0]);
+-        Assert.Contains("CONTROLNUMBER", lines_split[0]);
+-        Assert.Contains("PATH", lines_split[0]);
++        Assert.Contains("BEGATTY", lines_split[0], StringComparison.Ordinal);
++        Assert.Contains("CONTROLNUMBER", lines_split[0], StringComparison.Ordinal);
++        Assert.Contains("PATH", lines_split[0], StringComparison.Ordinal);
+     }
+ }
+diff --git a/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs b/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
+index d3b00bb..cc3d831 100644
+--- a/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
++++ b/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
+@@ -14,10 +14,10 @@ public class DatSerializerTests
+ 
+         var content = serializer.RenderHeader(columns);
+ 
+-        Assert.Contains("DOCID", content);
+-        Assert.Contains("FILEPATH", content);
+-        Assert.Contains("CUSTODIAN", content);
+-        Assert.Contains("\x14", content); // column delimiter
++        Assert.Contains("DOCID", content, StringComparison.Ordinal);
++        Assert.Contains("FILEPATH", content, StringComparison.Ordinal);
++        Assert.Contains("CUSTODIAN", content, StringComparison.Ordinal);
++        Assert.Contains("\x14", content, StringComparison.Ordinal); // column delimiter
+     }
+ 
+     [Fact]
+@@ -29,6 +29,7 @@ public class DatSerializerTests
+         {
+             Columns = columns,
+             Values = new Dictionary<string, string>
++(StringComparer.Ordinal)
+             {
+                 ["DOCID"] = "DOC001",
+                 ["FILEPATH"] = "folder/file.pdf",
+@@ -37,9 +38,9 @@ public class DatSerializerTests
+ 
+         var content = serializer.RenderRecord(record);
+ 
+-        Assert.Contains("DOC001", content);
+-        Assert.Contains("folder/file.pdf", content);
+-        Assert.Contains("\x14", content); // column delimiter
++        Assert.Contains("DOC001", content, StringComparison.Ordinal);
++        Assert.Contains("folder/file.pdf", content, StringComparison.Ordinal);
++        Assert.Contains("\x14", content, StringComparison.Ordinal); // column delimiter
+     }
+ 
+     [Fact]
+@@ -50,6 +51,7 @@ public class DatSerializerTests
+         {
+             Columns = new List<string> { "VALUE" },
+             Values = new Dictionary<string, string>
++(StringComparer.Ordinal)
+             {
+                 ["VALUE"] = "has\xfequote",
+             },
+@@ -58,7 +60,7 @@ public class DatSerializerTests
+         var content = serializer.RenderRecord(record);
+ 
+         // Quote delimiter should be doubled
+-        Assert.Contains("\xfe\xfe", content);
++        Assert.Contains("\xfe\xfe", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -69,6 +71,7 @@ public class DatSerializerTests
+         {
+             Columns = new List<string> { "TEXT" },
+             Values = new Dictionary<string, string>
++(StringComparer.Ordinal)
+             {
+                 ["TEXT"] = "line1\nline2",
+             },
+@@ -76,8 +79,8 @@ public class DatSerializerTests
+ 
+         var content = serializer.RenderRecord(record);
+ 
+-        Assert.DoesNotContain("\n", content);
+-        Assert.Contains("\xae", content);
++        Assert.DoesNotContain("\n", content, StringComparison.Ordinal);
++        Assert.Contains("\xae", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -87,7 +90,7 @@ public class DatSerializerTests
+         var record = new LoadFileRecord
+         {
+             Columns = new List<string> { "A", "B" },
+-            Values = new Dictionary<string, string> { ["A"] = "x", ["B"] = "y" },
++            Values = new Dictionary<string, string>(StringComparer.Ordinal) { ["A"] = "x", ["B"] = "y" },
+         };
+ 
+         var content = serializer.RenderRecord(record);
+@@ -102,7 +105,7 @@ public class DatSerializerTests
+         var record = new LoadFileRecord
+         {
+             Columns = new List<string> { "A", "MISSING", "B" },
+-            Values = new Dictionary<string, string> { ["A"] = "x", ["B"] = "y" },
++            Values = new Dictionary<string, string>(StringComparer.Ordinal) { ["A"] = "x", ["B"] = "y" },
+         };
+ 
+         var content = serializer.RenderRecord(record);
+diff --git a/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs b/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs
+index 81847f4..35c2352 100644
+--- a/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs
++++ b/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs
+@@ -28,7 +28,7 @@ public class LoadFileEmitterTests
+     private static LoadFileRecord Rec(string id, params (string Col, string Val)[] cells) => new()
+     {
+         Columns = cells.Select(c => c.Col).ToList(),
+-        Values = cells.ToDictionary(c => c.Col, c => c.Val),
++        Values = cells.ToDictionary(c => c.Col, c => c.Val, StringComparer.Ordinal),
+         RecordId = id,
+     };
+ 
+@@ -75,7 +75,7 @@ public class LoadFileEmitterTests
+     public async Task NoChaos_StreamsLargeInputWithoutLoss()
+     {
+         using var ms = new MemoryStream();
+-        var records = Enumerable.Range(0, 5000).Select(i => Rec(i.ToString(), ("A", $"v{i}")));
++        var records = Enumerable.Range(0, 5000).Select(i => Rec(i.ToString(System.Globalization.CultureInfo.InvariantCulture), ("A", $"v{i}")));
+ 
+         await LoadFileEmitter.EmitAsync(ms, new FakeSerializer(), Array.Empty<string>(), records, NoBom, "\n", chaosEngine: null);
+ 
+diff --git a/src/Zipper.Tests/LoadFiles/OptWriterTests.cs b/src/Zipper.Tests/LoadFiles/OptWriterTests.cs
+index 3ac82f3..3f1b4ea 100644
+--- a/src/Zipper.Tests/LoadFiles/OptWriterTests.cs
++++ b/src/Zipper.Tests/LoadFiles/OptWriterTests.cs
+@@ -54,8 +54,8 @@ public class OptWriterTests : TempDirectoryTestBase
+         var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+ 
+         Assert.Equal(2, lines.Length);
+-        Assert.StartsWith("DOC00000001_001,VOL001,IMAGES\\DOC00000001_001.tif,Y", lines[0]);
+-        Assert.StartsWith("DOC00000001_002,VOL001,IMAGES\\DOC00000001_002.tif,", lines[1]);
++        Assert.StartsWith("DOC00000001_001,VOL001,IMAGES\\DOC00000001_001.tif,Y", lines[0], StringComparison.Ordinal);
++        Assert.StartsWith("DOC00000001_002,VOL001,IMAGES\\DOC00000001_002.tif,", lines[1], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+index 4f77e2c..3bfe24d 100644
+--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
++++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+@@ -72,24 +72,24 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
+ 
+         var content = await File.ReadAllTextAsync(outputPath);
+ 
+-        Assert.Contains("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>", content.ToLowerInvariant());
+-        Assert.Contains("<Root DataInterchangeType=\"Export\" MajorVersion=\"1\" MinorVersion=\"2\">", content);
+-        Assert.Contains("<Batch>", content);
+-        Assert.DoesNotContain("<Documents>", content);
+-        Assert.DoesNotContain("</Documents>", content);
+-        Assert.Contains("<Document DocID=\"DOC00000001\">", content);
+-        Assert.Contains("<Files>", content);
+-        Assert.Contains("<File FileType=\"Native\">", content);
+-        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.pdf\" FileName=\"file_00000001.pdf\" FileSize=\"14\" Hash=\"", content);
+-        Assert.Contains("<File FileType=\"Text\">", content);
+-        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content);
+-        Assert.Contains("<Tags>", content);
+-        Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content);
+-        Assert.DoesNotContain("<Fields>", content);
+-        Assert.DoesNotContain("<Field ", content);
+-        Assert.Contains("</Document>", content);
+-        Assert.Contains("</Batch>", content);
+-        Assert.Contains("</Root>", content);
++        Assert.Contains("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>", content.ToLowerInvariant(), StringComparison.Ordinal);
++        Assert.Contains("<Root DataInterchangeType=\"Export\" MajorVersion=\"1\" MinorVersion=\"2\">", content, StringComparison.Ordinal);
++        Assert.Contains("<Batch>", content, StringComparison.Ordinal);
++        Assert.DoesNotContain("<Documents>", content, StringComparison.Ordinal);
++        Assert.DoesNotContain("</Documents>", content, StringComparison.Ordinal);
++        Assert.Contains("<Document DocID=\"DOC00000001\">", content, StringComparison.Ordinal);
++        Assert.Contains("<Files>", content, StringComparison.Ordinal);
++        Assert.Contains("<File FileType=\"Native\">", content, StringComparison.Ordinal);
++        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.pdf\" FileName=\"file_00000001.pdf\" FileSize=\"14\" Hash=\"", content, StringComparison.Ordinal);
++        Assert.Contains("<File FileType=\"Text\">", content, StringComparison.Ordinal);
++        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content, StringComparison.Ordinal);
++        Assert.Contains("<Tags>", content, StringComparison.Ordinal);
++        Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content, StringComparison.Ordinal);
++        Assert.DoesNotContain("<Fields>", content, StringComparison.Ordinal);
++        Assert.DoesNotContain("<Field ", content, StringComparison.Ordinal);
++        Assert.Contains("</Document>", content, StringComparison.Ordinal);
++        Assert.Contains("</Batch>", content, StringComparison.Ordinal);
++        Assert.Contains("</Root>", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+index b467ab1..9662619 100644
+--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
++++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+@@ -69,11 +69,11 @@ namespace Zipper
+             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+ 
+             var firstLine = (await File.ReadAllLinesAsync(result.LoadFilePath))[0];
+-            Assert.Contains("Control Number", firstLine);
+-            Assert.Contains("File Path", firstLine);
+-            Assert.Contains("Custodian", firstLine);
+-            Assert.Contains("EmailSubject", firstLine);
+-            Assert.Contains("ExtractedText", firstLine);
++            Assert.Contains("Control Number", firstLine, StringComparison.Ordinal);
++            Assert.Contains("File Path", firstLine, StringComparison.Ordinal);
++            Assert.Contains("Custodian", firstLine, StringComparison.Ordinal);
++            Assert.Contains("EmailSubject", firstLine, StringComparison.Ordinal);
++            Assert.Contains("ExtractedText", firstLine, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -134,9 +134,9 @@ namespace Zipper
+             var parts = firstLine.Split(',');
+ 
+             Assert.Equal(7, parts.Length);
+-            Assert.StartsWith("IMG", parts[0]); // Bates Number
++            Assert.StartsWith("IMG", parts[0], StringComparison.Ordinal); // Bates Number
+             Assert.Equal("VOL001", parts[1]); // Volume
+-            Assert.Contains("IMAGES", parts[2]); // ImagePath
++            Assert.Contains("IMAGES", parts[2], StringComparison.Ordinal); // ImagePath
+             Assert.Equal("Y", parts[3]); // DocBreak
+         }
+ 
+@@ -183,8 +183,8 @@ namespace Zipper
+             var content = Encoding.UTF8.GetString(bytes);
+ 
+             // Should contain LF but not CRLF
+-            Assert.Contains("\n", content);
+-            Assert.DoesNotContain("\r\n", content);
++            Assert.Contains("\n", content, StringComparison.Ordinal);
++            Assert.DoesNotContain("\r\n", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -236,7 +236,7 @@ namespace Zipper
+             var lines = await File.ReadAllLinesAsync(result.LoadFilePath);
+ 
+             Assert.Equal(2, lines.Length);
+-            Assert.Contains("Control Number", lines[0]);
++            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -252,13 +252,13 @@ namespace Zipper
+ 
+             var parts1 = lines[0].Split(',');
+             Assert.Equal(7, parts1.Length);
+-            Assert.StartsWith("IMG", parts1[0]);
++            Assert.StartsWith("IMG", parts1[0], StringComparison.Ordinal);
+             Assert.Equal("VOL001", parts1[1]);
+             Assert.Equal("Y", parts1[3]); // First page is doc break
+ 
+             var parts2 = lines[1].Split(',');
+             Assert.Equal(7, parts2.Length);
+-            Assert.StartsWith("IMG", parts2[0]);
++            Assert.StartsWith("IMG", parts2[0], StringComparison.Ordinal);
+             Assert.Equal("VOL001", parts2[1]);
+             Assert.Equal(string.Empty, parts2[3]); // Subsequent pages are not doc break
+         }
+@@ -273,8 +273,8 @@ namespace Zipper
+             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+             var content = System.Text.Encoding.UTF8.GetString(bytes);
+ 
+-            Assert.Contains("\r", content);
+-            Assert.DoesNotContain("\n", content);
++            Assert.Contains("\r", content, StringComparison.Ordinal);
++            Assert.DoesNotContain("\n", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -287,7 +287,7 @@ namespace Zipper
+             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+             var content = System.Text.Encoding.UTF8.GetString(bytes);
+ 
+-            Assert.Contains("\r\n", content);
++            Assert.Contains("\r\n", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -300,8 +300,8 @@ namespace Zipper
+             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+             var content = System.Text.Encoding.UTF8.GetString(bytes);
+ 
+-            Assert.Contains("\n", content);
+-            Assert.DoesNotContain("\r\n", content);
++            Assert.Contains("\n", content, StringComparison.Ordinal);
++            Assert.DoesNotContain("\r\n", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -332,7 +332,7 @@ namespace Zipper
+             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
+             var content = System.Text.Encoding.UTF8.GetString(bytes);
+ 
+-            Assert.Contains("\r\n", content);
++            Assert.Contains("\r\n", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -362,8 +362,8 @@ namespace Zipper
+             var content2 = await File.ReadAllTextAsync(result2.LoadFilePath);
+ 
+             // DAT should have header, OPT should not
+-            Assert.Contains("Control Number", content1);
+-            Assert.DoesNotContain("Control Number", content2);
++            Assert.Contains("Control Number", content1, StringComparison.Ordinal);
++            Assert.DoesNotContain("Control Number", content2, StringComparison.Ordinal);
+         }
+ 
+         /// <summary>
+@@ -556,7 +556,7 @@ namespace Zipper
+ 
+             // Verify first page of first document
+             var parts1 = lines[0].Split(',');
+-            Assert.StartsWith("ABC001_00001", parts1[0]);
++            Assert.StartsWith("ABC001_00001", parts1[0], StringComparison.Ordinal);
+             if (parts1[0].Contains("_"))
+             {
+                 Assert.Equal("ABC001_00001_001", parts1[0]);
+@@ -565,7 +565,7 @@ namespace Zipper
+             Assert.Equal("Y", parts1[3]); // doc break
+ 
+             // If there's a second page for first document, verify no doc break
+-            if (lines.Length > 1 && lines[1].StartsWith("ABC001_00001"))
++            if (lines.Length > 1 && lines[1].StartsWith("ABC001_00001", StringComparison.Ordinal))
+             {
+                 var parts2 = lines[1].Split(',');
+                 Assert.Equal("ABC001_00001_002", parts2[0]);
+@@ -635,7 +635,7 @@ namespace Zipper
+                 }
+ 
+                 this.TrackMemory();
+-                await this.inner.WriteAsync(buffer, offset, count, cancellationToken);
++                await inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+             }
+ 
+             public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+@@ -648,7 +648,7 @@ namespace Zipper
+                 }
+ 
+                 this.TrackMemory();
+-                await this.inner.WriteAsync(buffer, cancellationToken);
++                await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+             }
+ 
+             private void TrackMemory()
+diff --git a/src/Zipper.Tests/LoremIpsumDataTests.cs b/src/Zipper.Tests/LoremIpsumDataTests.cs
+index ddae2ee..4186ab5 100644
+--- a/src/Zipper.Tests/LoremIpsumDataTests.cs
++++ b/src/Zipper.Tests/LoremIpsumDataTests.cs
+@@ -23,7 +23,7 @@ public class LoremIpsumDataTests
+     public void GetSentence_EndsWithPeriod()
+     {
+         var result = LoremIpsum.GetSentence(new Random(42));
+-        Assert.EndsWith(".", result);
++        Assert.EndsWith(".", result, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/MetadataRowBuilderTests.cs b/src/Zipper.Tests/MetadataRowBuilderTests.cs
+index 23525f2..630e3e5 100644
+--- a/src/Zipper.Tests/MetadataRowBuilderTests.cs
++++ b/src/Zipper.Tests/MetadataRowBuilderTests.cs
+@@ -104,7 +104,7 @@ namespace Zipper
+         {
+             var gen = new LegacyRandomFileSizeGenerator();
+             var result = gen.Generate(MakeContext(seed: 42));
+-            var parsed = int.Parse(result);
++            var parsed = int.Parse(result, System.Globalization.CultureInfo.InvariantCulture);
+             Assert.InRange(parsed, 1024, 10485760);
+         }
+ 
+diff --git a/src/Zipper.Tests/OfficeFileGeneratorTests.cs b/src/Zipper.Tests/OfficeFileGeneratorTests.cs
+index fad31dc..c5b04a6 100644
+--- a/src/Zipper.Tests/OfficeFileGeneratorTests.cs
++++ b/src/Zipper.Tests/OfficeFileGeneratorTests.cs
+@@ -126,7 +126,7 @@ namespace Zipper
+             var content = reader.ReadToEnd();
+ 
+             // O(1): pre-computed content is identical for all files
+-            Assert.Contains("eDiscovery testing", content);
++            Assert.Contains("eDiscovery testing", content, StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -174,7 +174,7 @@ namespace Zipper
+             Assert.NotNull(archive);
+ 
+             // XLSX files should contain workbook entries
+-            var xlEntry = archive.Entries.FirstOrDefault(e => e.FullName.StartsWith("xl/"));
++            var xlEntry = archive.Entries.FirstOrDefault(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal));
+             Assert.NotNull(xlEntry);
+         }
+ 
+diff --git a/src/Zipper.Tests/OptLoadFileWriterTests.cs b/src/Zipper.Tests/OptLoadFileWriterTests.cs
+index dea01f9..d08553c 100644
+--- a/src/Zipper.Tests/OptLoadFileWriterTests.cs
++++ b/src/Zipper.Tests/OptLoadFileWriterTests.cs
+@@ -98,7 +98,7 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         Assert.Equal(3, lines.Length);
+         Assert.Contains(',', lines[0]);
+         Assert.DoesNotContain('\t', lines[0]);
+-        Assert.DoesNotContain("Control Number", lines[0]);
++        Assert.DoesNotContain("Control Number", lines[0], StringComparison.Ordinal);
+         Assert.Equal(6, lines[0].Count(c => c == ','));
+     }
+ 
+@@ -165,16 +165,16 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         var optContentWithAnsi = await File.ReadAllTextAsync(optOutputPath, optTargetEncoding);
+ 
+         Assert.NotEmpty(optContentWithAnsi);
+-        Assert.Contains(",", optContentWithAnsi);
++        Assert.Contains(",", optContentWithAnsi, StringComparison.Ordinal);
+ 
+         var datContentWithUtf8 = await File.ReadAllTextAsync(datOutputPath, Encoding.UTF8);
+         Assert.NotEmpty(datContentWithUtf8);
+ 
+         var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optOutputPath, request, fileData.Count, null, LoadFileFormat.Opt);
+-        Assert.Contains("\"encoding\": \"ANSI\"", optAuditJson);
++        Assert.Contains("\"encoding\": \"ANSI\"", optAuditJson, StringComparison.Ordinal);
+ 
+         var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datOutputPath, request, fileData.Count, null, LoadFileFormat.Dat);
+-        Assert.Contains("\"encoding\": \"UTF-8\"", datAuditJson);
++        Assert.Contains("\"encoding\": \"UTF-8\"", datAuditJson, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -204,8 +204,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         {
+             int commaCount = line.Count(c => c == ',');
+             Assert.Equal(6, commaCount);
+-            Assert.StartsWith("IMG", line);
+-            Assert.Contains("VOL001", line);
++            Assert.StartsWith("IMG", line, StringComparison.Ordinal);
++            Assert.Contains("VOL001", line, StringComparison.Ordinal);
+         }
+     }
+ 
+@@ -254,12 +254,12 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         Assert.Equal(3, lines.Length);
+         foreach (var line in lines)
+         {
+-            Assert.StartsWith("PROD", line);
+-            Assert.Contains(".tif", line);
+-            Assert.Contains("VOL001", line);
++            Assert.StartsWith("PROD", line, StringComparison.Ordinal);
++            Assert.Contains(".tif", line, StringComparison.Ordinal);
++            Assert.Contains("VOL001", line, StringComparison.Ordinal);
+         }
+ 
+-        Assert.Contains("\r\n", content);
++        Assert.Contains("\r\n", content, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -296,8 +296,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         var decodedWithAnsi = Encoding.GetEncoding(1252).GetString(bytes);
+         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
+ 
+-        Assert.Contains("TEST_ü", decodedWithAnsi);
+-        Assert.DoesNotContain("TEST_ü", decodedWithUtf8);
++        Assert.Contains("TEST_ü", decodedWithAnsi, StringComparison.Ordinal);
++        Assert.DoesNotContain("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -331,7 +331,7 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         var bytes = stream.ToArray();
+         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
+ 
+-        Assert.Contains("TEST_ü", decodedWithUtf8);
++        Assert.Contains("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -368,8 +368,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         var decodedWithAnsi = Encoding.GetEncoding(1252).GetString(bytes);
+         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
+ 
+-        Assert.Contains("TEST_ü", decodedWithAnsi);
+-        Assert.DoesNotContain("TEST_ü", decodedWithUtf8);
++        Assert.Contains("TEST_ü", decodedWithAnsi, StringComparison.Ordinal);
++        Assert.DoesNotContain("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -403,6 +403,6 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
+         var bytes = stream.ToArray();
+         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
+ 
+-        Assert.Contains("TEST_ü", decodedWithUtf8);
++        Assert.Contains("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
+     }
+ }
+diff --git a/src/Zipper.Tests/ParallelFileGeneratorTests.cs b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+index 05f825b..c3d95d9 100644
+--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
++++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+@@ -128,7 +128,7 @@ namespace Zipper
+                         },
+                     }));
+ 
+-                Assert.Contains("target ZIP size", ex.Message);
++                Assert.Contains("target ZIP size", ex.Message, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -324,7 +324,7 @@ namespace Zipper
+                         },
+                     }));
+ 
+-                Assert.Contains("File count must be positive", ex.Message);
++                Assert.Contains("File count must be positive", ex.Message, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -392,7 +392,7 @@ namespace Zipper
+                         },
+                     }));
+ 
+-                Assert.Contains("Unknown file type", ex.Message);
++                Assert.Contains("Unknown file type", ex.Message, StringComparison.Ordinal);
+             }
+             finally
+             {
+@@ -531,7 +531,7 @@ namespace Zipper
+                             Folders = 2,
+                             Concurrency = 4,
+                         },
+-                    });
++                    }).ConfigureAwait(false);
+                 });
+             }
+             finally
+diff --git a/src/Zipper.Tests/PathValidatorTests.cs b/src/Zipper.Tests/PathValidatorTests.cs
+index 291d4fb..3281f4b 100644
+--- a/src/Zipper.Tests/PathValidatorTests.cs
++++ b/src/Zipper.Tests/PathValidatorTests.cs
+@@ -205,7 +205,7 @@ namespace Zipper
+                 $"..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}windows{Path.DirectorySeparatorChar}system32",
+                 "test/../../sensitive/../../../data",
+                 "/folder/../../etc/shadow",
+-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:\\folder\\..\\..\\sensitive" : "/folder/../../sensitive",
++                OperatingSystem.IsWindows() ? "C:\\folder\\..\\..\\sensitive" : "/folder/../../sensitive",
+             };
+ 
+             // Act & Assert
+diff --git a/src/Zipper.Tests/PlaceholderFilesTests.cs b/src/Zipper.Tests/PlaceholderFilesTests.cs
+index 3b66e7c..47ba737 100644
+--- a/src/Zipper.Tests/PlaceholderFilesTests.cs
++++ b/src/Zipper.Tests/PlaceholderFilesTests.cs
+@@ -104,8 +104,8 @@ public class PlaceholderFilesTests
+         var nullableAttachment = PlaceholderFiles.GetRandomAttachment();
+         Assert.NotNull(nullableAttachment);
+         var attachment = nullableAttachment.Value;
+-        Assert.StartsWith("attachment.", attachment.filename);
+-        Assert.True(attachment.filename.EndsWith(".jpg") || attachment.filename.EndsWith(".pdf") || attachment.filename.EndsWith(".tiff"));
++        Assert.StartsWith("attachment.", attachment.filename, StringComparison.Ordinal);
++        Assert.True(attachment.filename.EndsWith(".jpg", StringComparison.Ordinal) || attachment.filename.EndsWith(".pdf", StringComparison.Ordinal) || attachment.filename.EndsWith(".tiff", StringComparison.Ordinal));
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/ProductionSetTests.cs b/src/Zipper.Tests/ProductionSetTests.cs
+index 26fbdab..08e698c 100644
+--- a/src/Zipper.Tests/ProductionSetTests.cs
++++ b/src/Zipper.Tests/ProductionSetTests.cs
+@@ -141,7 +141,7 @@ public class ProductionSetTests : IDisposable
+ 
+         var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.*", SearchOption.AllDirectories)
+             .Select(Path.GetFileNameWithoutExtension)
+-            .OrderBy(f => f)
++            .OrderBy(f => f, StringComparer.Ordinal)
+             .ToArray();
+ 
+         Assert.Equal("DOC000001", nativeFiles[0]);
+@@ -160,7 +160,7 @@ public class ProductionSetTests : IDisposable
+ 
+         var volDirs = Directory.GetDirectories(Path.Combine(result.ProductionPath, "NATIVES"));
+         Assert.Equal(4, volDirs.Length);
+-        Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL001");
++        Assert.Contains(volDirs, d => string.Equals(Path.GetFileName(d), "VOL001", StringComparison.Ordinal));
+         Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL004");
+     }
+ 
+@@ -177,10 +177,10 @@ public class ProductionSetTests : IDisposable
+ 
+         // Header should contain expected columns
+         var header = datContent[0];
+-        Assert.Contains("DOCID", header);
+-        Assert.Contains("BATES_NUMBER", header);
+-        Assert.Contains("NATIVE_PATH", header);
+-        Assert.Contains("IMAGE_PATH", header);
++        Assert.Contains("DOCID", header, StringComparison.Ordinal);
++        Assert.Contains("BATES_NUMBER", header, StringComparison.Ordinal);
++        Assert.Contains("NATIVE_PATH", header, StringComparison.Ordinal);
++        Assert.Contains("IMAGE_PATH", header, StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -195,8 +195,8 @@ public class ProductionSetTests : IDisposable
+         Assert.Equal(5, optContent.Length);
+ 
+         // Each line should contain the Bates number
+-        Assert.StartsWith("TEST", optContent[0]);
+-        Assert.Contains(".tif", optContent[0]);
++        Assert.StartsWith("TEST", optContent[0], StringComparison.Ordinal);
++        Assert.Contains(".tif", optContent[0], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -325,10 +325,10 @@ public class ProductionSetTests : IDisposable
+         foreach (var file in nativeFiles)
+         {
+             var content = await File.ReadAllTextAsync(file);
+-            Assert.Contains("From:", content);
+-            Assert.Contains("To:", content);
+-            Assert.Contains("Subject:", content);
+-            Assert.Contains("Date:", content);
++            Assert.Contains("From:", content, StringComparison.Ordinal);
++            Assert.Contains("To:", content, StringComparison.Ordinal);
++            Assert.Contains("Subject:", content, StringComparison.Ordinal);
++            Assert.Contains("Date:", content, StringComparison.Ordinal);
+         }
+     }
+ 
+@@ -444,7 +444,7 @@ public class ProductionSetTests : IDisposable
+         var result = await ProductionSetGenerator.GenerateAsync(request);
+ 
+         var datContent = await File.ReadAllTextAsync(result.DatFilePath, System.Text.Encoding.Unicode);
+-        Assert.Contains("DOCID", datContent);
++        Assert.Contains("DOCID", datContent, StringComparison.Ordinal);
+         Assert.Equal(4, datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+     }
+ 
+@@ -518,7 +518,7 @@ public class ProductionSetTests : IDisposable
+             Assert.True(vol2Deleted, "Test did not induce the intended VOL002 deletion failure.");
+ 
+             // The generation task should now fail mid-write (when it tries to write to VOL002)
+-            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(async () => await generateTask);
++            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(async () => await generateTask.ConfigureAwait(false));
+ 
+             // Verify: no PRODUCTION_* directory should remain
+             var productionDirs = Directory.GetDirectories(outputPath, "PRODUCTION_*");
+diff --git a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+index f6996fd..6f51727 100644
+--- a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
++++ b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+@@ -37,7 +37,7 @@ namespace Zipper
+         {
+             var writer = new DatComposingWriter(Zipper.LoadFiles.WriterMode.LoadfileOnly);
+             using var stream = new MemoryStream();
+-            await writer.WriteAsync(stream, request, new List<FileData>());
++            await writer.WriteAsync(stream, request, new List<FileData>()).ConfigureAwait(false);
+             stream.Position = 0;
+             return Encoding.UTF8.GetString(stream.ToArray());
+         }
+@@ -52,8 +52,8 @@ namespace Zipper
+ 
+             // Header + 3 data rows
+             Assert.Equal(4, lines.Length);
+-            Assert.Contains("DOCID", lines[0]);
+-            Assert.Contains("FILEPATH", lines[0]);
++            Assert.Contains("DOCID", lines[0], StringComparison.Ordinal);
++            Assert.Contains("FILEPATH", lines[0], StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -65,7 +65,7 @@ namespace Zipper
+             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+ 
+             // Each data field should be wrapped in the quote delimiter (\u00fe)
+-            Assert.Contains("\u00fe", lines[1]);
++            Assert.Contains("\u00fe", lines[1], StringComparison.Ordinal);
+         }
+ 
+         [Fact]
+@@ -76,6 +76,7 @@ namespace Zipper
+                 Name = "escape-test",
+                 Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+                 DataSources = new Dictionary<string, DataSourceConfig>
++(StringComparer.Ordinal)
+                 {
+                     ["quoteValues"] = new DataSourceConfig
+                     {
+@@ -93,7 +94,7 @@ namespace Zipper
+             var content = await CaptureOutputAsync(request);
+ 
+             // \u00fe inside the field value must be doubled to \u00fe\u00fe per Concordance escaping
+-            Assert.Contains("val\u00fe\u00feSpecial", content);
++            Assert.Contains("val\u00fe\u00feSpecial", content, StringComparison.Ordinal);
+         }
+ 
+         /// <summary>
+@@ -119,7 +120,7 @@ namespace Zipper
+             var custodianIdx = headers.IndexOf("CUSTODIAN");
+             Assert.True(custodianIdx >= 0, "CUSTODIAN column not found in profile output");
+ 
+-            var custodianValues = new HashSet<string>();
++            var custodianValues = new HashSet<string>(StringComparer.Ordinal);
+             foreach (var line in lines.Skip(1))
+             {
+                 var fields = line.Split(colDelim);
+@@ -172,8 +173,8 @@ namespace Zipper
+             await new DatComposingWriter(Zipper.LoadFiles.WriterMode.LoadfileOnly).WriteAsync(chaosStream, request, [], chaosEngine);
+             var chaosBytes = chaosStream.ToArray();
+ 
+-            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
+-            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
++            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 1-2", StringComparison.Ordinal));
++            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 4-5", StringComparison.Ordinal));
+ 
+             Assert.NotNull(headerAnomaly);
+             Assert.NotNull(lastLineAnomaly);
+diff --git a/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
+index 1ee8fcf..417b474 100644
+--- a/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
+@@ -75,7 +75,7 @@ public class AdditionalGeneratorTests
+             Range = new RangeConfig { Min = 100, Max = 200 }
+         };
+         var genRange = new NumberGenerator(colRange);
+-        var val = int.Parse(genRange.Generate(context));
++        var val = int.Parse(genRange.Generate(context), System.Globalization.CultureInfo.InvariantCulture);
+         Assert.InRange(val, 100, 200);
+ 
+         // Exponential distribution
+@@ -86,7 +86,7 @@ public class AdditionalGeneratorTests
+             Range = new RangeConfig { Min = 50, Max = 150 }
+         };
+         var genExp = new NumberGenerator(colExp);
+-        var expVal = int.Parse(genExp.Generate(context));
++        var expVal = int.Parse(genExp.Generate(context), System.Globalization.CultureInfo.InvariantCulture);
+         Assert.InRange(expVal, 50, 150);
+     }
+ 
+@@ -100,7 +100,7 @@ public class AdditionalGeneratorTests
+         var colSingle = new ColumnDefinition { MultiValue = false };
+         var genSingle = new EmailAddressGenerator(colSingle, settings);
+         var email = genSingle.Generate(context);
+-        Assert.Contains("@", email);
++        Assert.Contains("@", email, StringComparison.Ordinal);
+ 
+         // Multi value
+         var colMulti = new ColumnDefinition
+@@ -112,8 +112,8 @@ public class AdditionalGeneratorTests
+         var emails = genMulti.Generate(context);
+         var parts = emails.Split(';');
+         Assert.Equal(2, parts.Length);
+-        Assert.Contains("@", parts[0]);
+-        Assert.Contains("@", parts[1]);
++        Assert.Contains("@", parts[0], StringComparison.Ordinal);
++        Assert.Contains("@", parts[1], StringComparison.Ordinal);
+     }
+ 
+     [Fact]
+@@ -138,7 +138,7 @@ public class AdditionalGeneratorTests
+         var dateCreated = new LegacyDateCreatedGenerator().Generate(context);
+         Assert.NotNull(dateCreated);
+ 
+-        Assert.StartsWith("Author ", new LegacyAuthorGenerator().Generate(context));
++        Assert.StartsWith("Author ", new LegacyAuthorGenerator().Generate(context), StringComparison.Ordinal);
+         Assert.Equal("2048", new LegacyFileSizeFromDataGenerator().Generate(context));
+         Assert.NotEmpty(new LegacyRandomFileSizeGenerator().Generate(context));
+ 
+@@ -168,7 +168,7 @@ public class AdditionalGeneratorTests
+         // Paragraphs generator
+         var colPara = new ColumnDefinition
+         {
+-            GeneratorParams = new Dictionary<string, object> { { "min", 2 }, { "max", 2 } }
++            GeneratorParams = new Dictionary<string, object>(StringComparer.Ordinal) { { "min", 2 }, { "max", 2 } }
+         };
+         var genPara = new LongTextGenerator(colPara);
+         var text = genPara.Generate(context);
+diff --git a/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs
+index 0679795..dbd1437 100644
+--- a/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs
+@@ -30,7 +30,7 @@ public class BooleanGeneratorTests
+         var col = new ColumnDefinition { Name = "Test", Format = "yn", TruePercentage = 50 };
+         var generator = new BooleanGenerator(col);
+ 
+-        var results = new HashSet<string>();
++        var results = new HashSet<string>(StringComparer.Ordinal);
+         for (int i = 0; i < 50; i++)
+         {
+             results.Add(generator.Generate(MakeContext(i)));
+@@ -38,7 +38,7 @@ public class BooleanGeneratorTests
+ 
+         Assert.Contains("Y", results);
+         Assert.Contains("N", results);
+-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
++        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
+     }
+ 
+     /// <summary>
+@@ -50,7 +50,7 @@ public class BooleanGeneratorTests
+         var col = new ColumnDefinition { Name = "Test", Format = "truefalse", TruePercentage = 50 };
+         var generator = new BooleanGenerator(col);
+ 
+-        var results = new HashSet<string>();
++        var results = new HashSet<string>(StringComparer.Ordinal);
+         for (int i = 0; i < 50; i++)
+         {
+             results.Add(generator.Generate(MakeContext(i)));
+@@ -58,7 +58,7 @@ public class BooleanGeneratorTests
+ 
+         Assert.Contains("True", results);
+         Assert.Contains("False", results);
+-        Assert.Subset(new HashSet<string> { "True", "False" }, results);
++        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "True", "False" }, results);
+     }
+ 
+     /// <summary>
+@@ -70,7 +70,7 @@ public class BooleanGeneratorTests
+         var col = new ColumnDefinition { Name = "Test", Format = "10", TruePercentage = 50 };
+         var generator = new BooleanGenerator(col);
+ 
+-        var results = new HashSet<string>();
++        var results = new HashSet<string>(StringComparer.Ordinal);
+         for (int i = 0; i < 50; i++)
+         {
+             results.Add(generator.Generate(MakeContext(i)));
+@@ -78,7 +78,7 @@ public class BooleanGeneratorTests
+ 
+         Assert.Contains("1", results);
+         Assert.Contains("0", results);
+-        Assert.Subset(new HashSet<string> { "1", "0" }, results);
++        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "1", "0" }, results);
+     }
+ 
+     /// <summary>
+@@ -90,7 +90,7 @@ public class BooleanGeneratorTests
+         var col = new ColumnDefinition { Name = "Test", Format = null, TruePercentage = 50 };
+         var generator = new BooleanGenerator(col);
+ 
+-        var results = new HashSet<string>();
++        var results = new HashSet<string>(StringComparer.Ordinal);
+         for (int i = 0; i < 50; i++)
+         {
+             results.Add(generator.Generate(MakeContext(i)));
+@@ -98,7 +98,7 @@ public class BooleanGeneratorTests
+ 
+         Assert.Contains("Y", results);
+         Assert.Contains("N", results);
+-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
++        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
+     }
+ 
+     /// <summary>
+@@ -110,7 +110,7 @@ public class BooleanGeneratorTests
+         var col = new ColumnDefinition { Name = "Test", Format = "unknown", TruePercentage = 50 };
+         var generator = new BooleanGenerator(col);
+ 
+-        var results = new HashSet<string>();
++        var results = new HashSet<string>(StringComparer.Ordinal);
+         for (int i = 0; i < 50; i++)
+         {
+             results.Add(generator.Generate(MakeContext(i)));
+@@ -118,7 +118,7 @@ public class BooleanGeneratorTests
+ 
+         Assert.Contains("Y", results);
+         Assert.Contains("N", results);
+-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
++        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
+     }
+ 
+     /// <summary>
+diff --git a/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
+index c01b571..2a57ffa 100644
+--- a/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
+@@ -45,7 +45,7 @@ public class CodedGeneratorTests
+ 
+         var parts = result.Split(';');
+         Assert.InRange(parts.Length, 2, 3);
+-        Assert.Equal(parts.Length, parts.Distinct().Count());
++        Assert.Equal(parts.Length, parts.Distinct(StringComparer.Ordinal).Count());
+     }
+ 
+     [Fact(Timeout = 2000)]
+@@ -62,7 +62,7 @@ public class CodedGeneratorTests
+ 
+         var parts = result.Split(';');
+         Assert.InRange(parts.Length, 2, 3);
+-        Assert.Equal(parts.Length, parts.Distinct().Count());
++        Assert.Equal(parts.Length, parts.Distinct(StringComparer.Ordinal).Count());
+     }
+ 
+     [Fact]
+diff --git a/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs b/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs
+index 9de324c..1bf28f3 100644
+--- a/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs
+@@ -59,6 +59,6 @@ public class ColumnValueGeneratorRegistryTests
+     public void KnownTypes_HasNoUnknownDuplicates()
+     {
+         // Each entry should be distinct (HashSet enforces uniqueness)
+-        Assert.Equal(ColumnValueGeneratorRegistry.KnownTypes.Count, ColumnValueGeneratorRegistry.KnownTypes.ToHashSet().Count);
++        Assert.Equal(ColumnValueGeneratorRegistry.KnownTypes.Count, ColumnValueGeneratorRegistry.KnownTypes.ToHashSet(StringComparer.Ordinal).Count);
+     }
+ }
+diff --git a/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
+index 7e83b0d..2db8c94 100644
+--- a/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
+@@ -1,3 +1,4 @@
++#pragma warning disable RS0030 // Do not use banned APIs
+ using System.Globalization;
+ using Xunit;
+ using Zipper.Profiles;
+diff --git a/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
+index cce59e3..486c464 100644
+--- a/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
+@@ -1,3 +1,4 @@
++#pragma warning disable RS0030 // Do not use banned APIs
+ using System.Globalization;
+ using Xunit;
+ using Zipper.Profiles;
+@@ -105,7 +106,7 @@ public class DateTimeColumnGeneratorTests
+         var settings = new ProfileSettings { DateTimeFormat = "yyyy-MM-dd HH:mm" };
+         var generator = new DateTimeColumnGenerator(col, settings);
+ 
+-        var generatedTimes = new HashSet<string>();
++        var generatedTimes = new HashSet<string>(StringComparer.Ordinal);
+         var context = MakeContext();
+         for (int i = 0; i < 50; i++)
+         {
+diff --git a/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs b/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs
+index 49da053..88d313e 100644
+--- a/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs
++++ b/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs
+@@ -36,7 +36,7 @@ public class NumberGeneratorTests
+ 
+         for (int i = 0; i < 50; i++)
+         {
+-            var result = int.Parse(generator.Generate(MakeContext(i)));
++            var result = int.Parse(generator.Generate(MakeContext(i)), System.Globalization.CultureInfo.InvariantCulture);
+             Assert.InRange(result, 10, 20);
+         }
+     }
+@@ -55,7 +55,7 @@ public class NumberGeneratorTests
+         var generator = new NumberGenerator(col);
+ 
+         var context = MakeContext();
+-        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context))).ToList();
++        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context), System.Globalization.CultureInfo.InvariantCulture)).ToList();
+ 
+         Assert.Contains(results, x => x == 1);
+         Assert.Contains(results, x => x == 10);
+@@ -77,7 +77,7 @@ public class NumberGeneratorTests
+         var generator = new NumberGenerator(col);
+ 
+         var context = MakeContext();
+-        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context))).ToList();
++        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context), System.Globalization.CultureInfo.InvariantCulture)).ToList();
+ 
+         Assert.All(results, x => Assert.InRange(x, 0, 100));
+         var average = results.Average();
+diff --git a/src/Zipper.Tests/ProgramTests.cs b/src/Zipper.Tests/ProgramTests.cs
+index 315c6bd..5efb42a 100644
+--- a/src/Zipper.Tests/ProgramTests.cs
++++ b/src/Zipper.Tests/ProgramTests.cs
+@@ -15,7 +15,7 @@ namespace Zipper
+                 using var errWriter = new StringWriter();
+                 Console.SetOut(outWriter);
+                 Console.SetError(errWriter);
+-                return await action();
++                return await action().ConfigureAwait(false);
+             }
+             finally
+             {
+@@ -41,7 +41,7 @@ namespace Zipper
+         public async Task Main_WithInvalidArguments_ReturnsErrorCode()
+         {
+             // Arrange - Missing required arguments
+-            string[] args = { };
++            string[] args = Array.Empty<string>();
+ 
+             // Act
+             int exitCode = await RunWithRedirectedConsole(() => Program.Main(args));
+@@ -197,13 +197,13 @@ namespace Zipper
+                                       .Where(f => !f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
+                                                   !f.EndsWith(".dat", StringComparison.OrdinalIgnoreCase) &&
+                                                   !f.Contains("_properties.json", StringComparison.OrdinalIgnoreCase))
+-                                      .OrderBy(n => n).ToList();
++                                      .OrderBy(n => n, StringComparer.Ordinal).ToList();
+                 var files2 = Directory.GetFiles(tempPath2, "*.*", SearchOption.AllDirectories)
+                                       .Select(f => Path.GetRelativePath(tempPath2, f))
+                                       .Where(f => !f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
+                                                   !f.EndsWith(".dat", StringComparison.OrdinalIgnoreCase) &&
+                                                   !f.Contains("_properties.json", StringComparison.OrdinalIgnoreCase))
+-                                      .OrderBy(n => n).ToList();
++                                      .OrderBy(n => n, StringComparer.Ordinal).ToList();
+ 
+                 Assert.Equal(files1, files2);
+ 
+@@ -313,8 +313,8 @@ namespace Zipper
+                 using (var archive1 = System.IO.Compression.ZipFile.OpenRead(zipFile1))
+                 using (var archive2 = System.IO.Compression.ZipFile.OpenRead(zipFile2))
+                 {
+-                    var entries1 = archive1.Entries.OrderBy(e => e.FullName).ToList();
+-                    var entries2 = archive2.Entries.OrderBy(e => e.FullName).ToList();
++                    var entries1 = archive1.Entries.OrderBy(e => e.FullName, StringComparer.Ordinal).ToList();
++                    var entries2 = archive2.Entries.OrderBy(e => e.FullName, StringComparer.Ordinal).ToList();
+ 
+                     Assert.Equal(entries1.Count, entries2.Count);
+                     for (int i = 0; i < entries1.Count; i++)
+diff --git a/src/Zipper.Tests/ReviewNoteDataTests.cs b/src/Zipper.Tests/ReviewNoteDataTests.cs
+index 714de8a..2e3053a 100644
+--- a/src/Zipper.Tests/ReviewNoteDataTests.cs
++++ b/src/Zipper.Tests/ReviewNoteDataTests.cs
+@@ -24,6 +24,6 @@ public class ReviewNoteDataTests
+     public void GetRandomNote_EndsWithPeriod()
+     {
+         var result = ReviewNotes.GetRandomNote(new Random(42));
+-        Assert.EndsWith(".", result);
++        Assert.EndsWith(".", result, StringComparison.Ordinal);
+     }
+ }
+diff --git a/src/Zipper.Tests/SmokeTests.cs b/src/Zipper.Tests/SmokeTests.cs
+index 389ba1a..3a589e6 100644
+--- a/src/Zipper.Tests/SmokeTests.cs
++++ b/src/Zipper.Tests/SmokeTests.cs
+@@ -28,7 +28,7 @@ public class SmokeTests
+             var datContent = await File.ReadAllTextAsync(datFiles[0]);
+             var datLines = datContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+             Assert.Equal(101, datLines.Length); // 100 records + 1 header
+-            Assert.Contains("DOC00000001", datContent);
++            Assert.Contains("DOC00000001", datContent, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -61,8 +61,8 @@ public class SmokeTests
+             var datFiles = Directory.GetFiles(tempDir, "*.dat");
+             Assert.Single(datFiles);
+             var datContent = await File.ReadAllTextAsync(datFiles[0]);
+-            Assert.Contains("Attachment", datContent);
+-            Assert.Contains("Subject", datContent);
++            Assert.Contains("Attachment", datContent, StringComparison.Ordinal);
++            Assert.Contains("Subject", datContent, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -95,7 +95,7 @@ public class SmokeTests
+             var datFiles = Directory.GetFiles(tempDir, "*.dat");
+             Assert.Single(datFiles);
+             var datContent = await File.ReadAllTextAsync(datFiles[0]);
+-            Assert.Contains("Page Count", datContent);
++            Assert.Contains("Page Count", datContent, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -126,17 +126,17 @@ public class SmokeTests
+             var datContent = await File.ReadAllTextAsync(datFiles[0]);
+             var datLines = datContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+             Assert.Equal(11, datLines.Length); // 10 records + 1 header
+-            Assert.Contains("DOC00000001", datContent);
++            Assert.Contains("DOC00000001", datContent, StringComparison.Ordinal);
+ 
+             // Verify load file column structure
+             var header = datLines[0];
+-            Assert.Contains("\x14", header);
+-            Assert.Contains("\xFE", header);
++            Assert.Contains("\x14", header, StringComparison.Ordinal);
++            Assert.Contains("\xFE", header, StringComparison.Ordinal);
+ 
+             var propFiles = Directory.GetFiles(tempDir, "*_properties.json");
+             Assert.Single(propFiles);
+             var propContent = await File.ReadAllTextAsync(propFiles[0]);
+-            Assert.Contains("DAT (Metadata)", propContent);
++            Assert.Contains("DAT (Metadata)", propContent, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -170,7 +170,7 @@ public class SmokeTests
+             var propFiles = Directory.GetFiles(tempDir, "*_properties.json");
+             Assert.Single(propFiles);
+             var propContent = await File.ReadAllTextAsync(propFiles[0]);
+-            Assert.Contains("\"enabled\": true", propContent);
++            Assert.Contains("\"enabled\": true", propContent, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -275,8 +275,8 @@ public class SmokeTests
+             Assert.Single(optFiles);
+ 
+             var optContent = await File.ReadAllTextAsync(optFiles[0]);
+-            Assert.Contains("DOC00000001", optContent);
+-            Assert.Contains("VOL001", optContent);
++            Assert.Contains("DOC00000001", optContent, StringComparison.Ordinal);
++            Assert.Contains("VOL001", optContent, StringComparison.Ordinal);
+ 
+             // Clean up files in tempDir
+             foreach (var file in Directory.GetFiles(tempDir))
+@@ -296,7 +296,7 @@ public class SmokeTests
+             Assert.Single(optFiles);
+ 
+             var optContentJpg = await File.ReadAllTextAsync(optFiles[0]);
+-            Assert.Contains("DOC00000001", optContentJpg);
++            Assert.Contains("DOC00000001", optContentJpg, StringComparison.Ordinal);
+         }
+         finally
+         {
+@@ -329,9 +329,9 @@ public class SmokeTests
+             var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+             Assert.True(lines.Length > 0);
+             var header = lines[0];
+-            Assert.Contains("BEGATTACH", header);
+-            Assert.Contains("ENDATTACH", header);
+-            Assert.Contains("PARENTDOCID", header);
++            Assert.Contains("BEGATTACH", header, StringComparison.Ordinal);
++            Assert.Contains("ENDATTACH", header, StringComparison.Ordinal);
++            Assert.Contains("PARENTDOCID", header, StringComparison.Ordinal);
+ 
+             // Assert there are more rows than emails since there are child attachment rows
+             Assert.True(lines.Length > 6);
+diff --git a/src/Zipper.Tests/TimeZoneDataTests.cs b/src/Zipper.Tests/TimeZoneDataTests.cs
+index b7b73f5..5e8c275 100644
+--- a/src/Zipper.Tests/TimeZoneDataTests.cs
++++ b/src/Zipper.Tests/TimeZoneDataTests.cs
+@@ -6,7 +6,7 @@ namespace Zipper.Tests;
+ public class TimeZoneDataTests
+ {
+     private static readonly System.Collections.Generic.HashSet<string> ValidTimeZones =
+-        new() { "UTC", "America/New_York", "America/Los_Angeles", "America/Chicago", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Shanghai" };
++        new(StringComparer.Ordinal) { "UTC", "America/New_York", "America/Los_Angeles", "America/Chicago", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Shanghai" };
+ 
+     [Fact]
+     public void GetRandom_ReturnsNonEmptyString()
+diff --git a/src/Zipper.Tests/ZipArchiveServiceTests.cs b/src/Zipper.Tests/ZipArchiveServiceTests.cs
+index 02de1be..d3282f7 100644
+--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
++++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
+@@ -46,7 +46,7 @@ namespace Zipper.Tests
+             // Assert
+             Assert.True(File.Exists(zipPath));
+             using var archive = ZipFile.OpenRead(zipPath);
+-            Assert.Equal(5, archive.Entries.Count(e => e.FullName.EndsWith(".pdf")));
++            Assert.Equal(5, archive.Entries.Count(e => e.FullName.EndsWith(".pdf", StringComparison.Ordinal)));
+         }
+ 
+         [Fact]
+@@ -134,7 +134,7 @@ namespace Zipper.Tests
+             Assert.Equal(6, archive.Entries.Count); // 3 PDF files + 3 text files
+ 
+             // Verify text files exist
+-            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt")).ToList();
++            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+             Assert.Equal(3, textEntries.Count);
+         }
+ 
+@@ -178,7 +178,7 @@ namespace Zipper.Tests
+             using var archive = ZipFile.OpenRead(zipPath);
+ 
+             // Should have 2 EML files and 2 attachments
+-            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml")).ToList();
++            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
+             var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment")).ToList();
+ 
+             Assert.Equal(2, emlEntries.Count);
+@@ -228,8 +228,8 @@ namespace Zipper.Tests
+             // Should have: 2 PDF files + 2 text files + 1 load file + 1 properties file = 6 total files
+             Assert.Equal(6, archive.Entries.Count);
+ 
+-            var pdfEntries = archive.Entries.Where(e => e.FullName.EndsWith(".pdf")).ToList();
+-            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt")).ToList();
++            var pdfEntries = archive.Entries.Where(e => e.FullName.EndsWith(".pdf", StringComparison.Ordinal)).ToList();
++            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+             var loadEntry = archive.GetEntry("load.dat");
+ 
+             Assert.Equal(2, pdfEntries.Count);
+@@ -314,10 +314,10 @@ namespace Zipper.Tests
+             // Should have: 2 EML files + 2 EML text files + 2 attachments + 2 attachment text files = 8 total
+             Assert.Equal(8, archive.Entries.Count);
+ 
+-            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml")).ToList();
+-            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt") && !e.FullName.Contains("attachment")).ToList();
+-            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && !e.FullName.EndsWith(".txt")).ToList();
+-            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && e.FullName.EndsWith(".txt")).ToList();
++            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
++            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal) && !e.FullName.Contains("attachment")).ToList();
++            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && !e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
++            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+ 
+             Assert.Equal(2, emlEntries.Count);
+             Assert.Equal(2, emlTextEntries.Count);
+diff --git a/src/Zipper.Tests/packages.lock.json b/src/Zipper.Tests/packages.lock.json
+index ab2f2fb..77f16e8 100644
+--- a/src/Zipper.Tests/packages.lock.json
++++ b/src/Zipper.Tests/packages.lock.json
+@@ -14,6 +14,18 @@
+         "resolved": "4.1.0",
+         "contentHash": "DsED7jD2lJK8K3Chpex38yNH2UmuKck1ML4QtSeBVk+eH7uVJL95peTmg6sxEje93IOu9bn1dMfXPqtsfAWcBg=="
+       },
++      "Meziantou.Analyzer": {
++        "type": "Direct",
++        "requested": "[3.0.102, )",
++        "resolved": "3.0.102",
++        "contentHash": "WhGaJ3QsULOtDUXqZIDMZqTnZ68wvl6UMvPjkdxcZVIe/n3sfJyd2rDRVO3Ea7KitP0xUn3M85L/t7+JGkt63w=="
++      },
++      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
++        "type": "Direct",
++        "requested": "[3.3.4, )",
++        "resolved": "3.3.4",
++        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
++      },
+       "Microsoft.NET.Test.Sdk": {
+         "type": "Direct",
+         "requested": "[18.6.0, )",
+diff --git a/src/packages.lock.json b/src/packages.lock.json
+index 075ea4b..82b7ccc 100644
+--- a/src/packages.lock.json
++++ b/src/packages.lock.json
+@@ -15,6 +15,18 @@
+           "SixLabors.Fonts": "1.0.0"
+         }
+       },
++      "Meziantou.Analyzer": {
++        "type": "Direct",
++        "requested": "[3.0.102, )",
++        "resolved": "3.0.102",
++        "contentHash": "WhGaJ3QsULOtDUXqZIDMZqTnZ68wvl6UMvPjkdxcZVIe/n3sfJyd2rDRVO3Ea7KitP0xUn3M85L/t7+JGkt63w=="
++      },
++      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
++        "type": "Direct",
++        "requested": "[3.3.4, )",
++        "resolved": "3.3.4",
++        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
++      },
+       "Microsoft.NET.ILLink.Tasks": {
+         "type": "Direct",
+         "requested": "[10.0.8, )",

--- a/src/ChaosEngine.cs
+++ b/src/ChaosEngine.cs
@@ -150,7 +150,7 @@ internal class ChaosEngine
             // Unpaired high surrogate in little-endian: 0x00D8 as LE bytes
             invalidBytes = new byte[] { 0x00, 0xD8 };
         }
-        else if (encodingName.Contains("UTF-8", StringComparison.Ordinal) || encodingName == "UTF-8")
+        else if (encodingName.Contains("UTF-8", StringComparison.Ordinal))
         {
             // Invalid UTF-8 continuation byte without start byte
             invalidBytes = new byte[] { 0xFE, 0xFF };
@@ -183,13 +183,13 @@ internal class ChaosEngine
 
         if (chaosAmount.EndsWith('%'))
         {
-            if (double.TryParse(chaosAmount.TrimEnd('%'), out var pct))
+            if (double.TryParse(chaosAmount.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture, out var pct))
             {
                 return Math.Max(1, (int)(totalLines * pct / 100.0));
             }
         }
 
-        if (int.TryParse(chaosAmount, out var exact))
+        if (int.TryParse(chaosAmount, System.Globalization.CultureInfo.InvariantCulture, out var exact))
         {
             return Math.Min(exact, totalLines);
         }
@@ -347,7 +347,7 @@ internal class ChaosEngine
         delimiterIndex = this.random.Next(positions.Count) + 1;
         int targetPos = positions[delimiterIndex - 1];
 
-        var alternatives = AlternativeDelimiters.Where(c => c.ToString() != this.columnDelimiter).ToArray();
+        var alternatives = AlternativeDelimiters.Where(c => !string.Equals(c.ToString(), this.columnDelimiter, StringComparison.Ordinal)).ToArray();
         if (alternatives.Length == 0)
         {
             return line;
@@ -444,7 +444,7 @@ internal class ChaosEngine
         var parts = line.Split(',');
         if (parts.Length >= 4)
         {
-            parts[3] = parts[3].Trim() == "Y" ? string.Empty : "Y";
+            parts[3] = string.Equals(parts[3].Trim(), "Y", StringComparison.Ordinal) ? string.Empty : "Y";
             return string.Join(",", parts);
         }
 

--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -28,7 +28,7 @@ public static class CliParser
                 case "--count":
                     if (TryGetValue(args, i, out var countStr))
                     {
-                        if (long.TryParse(countStr, out var count))
+                        if (long.TryParse(countStr, System.Globalization.CultureInfo.InvariantCulture, out var count))
                         {
                             parsed.Count = count;
                             i++;
@@ -68,7 +68,7 @@ public static class CliParser
                 case "--folders":
                     if (TryGetValue(args, i, out var foldersStr))
                     {
-                        if (int.TryParse(foldersStr, out var folders))
+                        if (int.TryParse(foldersStr, System.Globalization.CultureInfo.InvariantCulture, out var folders))
                         {
                             parsed.Folders = folders;
                         }
@@ -123,7 +123,7 @@ public static class CliParser
                 case "--attachment-rate":
                     if (TryGetValue(args, i, out var attRateStr))
                     {
-                        if (int.TryParse(attRateStr, out var attachmentRate))
+                        if (int.TryParse(attRateStr, System.Globalization.CultureInfo.InvariantCulture, out var attachmentRate))
                         {
                             parsed.AttachmentRate = attachmentRate;
                         }
@@ -188,7 +188,7 @@ public static class CliParser
                 case "--bates-start":
                     if (TryGetValue(args, i, out var batesStartStr))
                     {
-                        if (long.TryParse(batesStartStr, out var batesStart))
+                        if (long.TryParse(batesStartStr, System.Globalization.CultureInfo.InvariantCulture, out var batesStart))
                         {
                             parsed.BatesStart = batesStart;
                         }
@@ -210,7 +210,7 @@ public static class CliParser
                 case "--bates-digits":
                     if (TryGetValue(args, i, out var batesDigitsStr))
                     {
-                        if (int.TryParse(batesDigitsStr, out var batesDigits))
+                        if (int.TryParse(batesDigitsStr, System.Globalization.CultureInfo.InvariantCulture, out var batesDigits))
                         {
                             parsed.BatesDigits = batesDigits;
                         }
@@ -258,7 +258,7 @@ public static class CliParser
                 case "--seed":
                     if (TryGetValue(args, i, out var seedStr))
                     {
-                        if (int.TryParse(seedStr, out var seed))
+                        if (int.TryParse(seedStr, System.Globalization.CultureInfo.InvariantCulture, out var seed))
                         {
                             parsed.Seed = seed;
                         }
@@ -293,7 +293,7 @@ public static class CliParser
                 case "--empty-percentage":
                     if (TryGetValue(args, i, out var emptyPctStr))
                     {
-                        if (int.TryParse(emptyPctStr, out var emptyPct))
+                        if (int.TryParse(emptyPctStr, System.Globalization.CultureInfo.InvariantCulture, out var emptyPct))
                         {
                             parsed.EmptyPercentage = emptyPct;
                         }
@@ -315,7 +315,7 @@ public static class CliParser
                 case "--custodian-count":
                     if (TryGetValue(args, i, out var custCountStr))
                     {
-                        if (int.TryParse(custCountStr, out var custCount))
+                        if (int.TryParse(custCountStr, System.Globalization.CultureInfo.InvariantCulture, out var custCount))
                         {
                             parsed.CustodianCount = custCount;
                         }
@@ -549,7 +549,7 @@ public static class CliParser
                 case "--volume-size":
                     if (TryGetValue(args, i, out var volumeSizeVal))
                     {
-                        if (int.TryParse(volumeSizeVal, out var volumeSize))
+                        if (int.TryParse(volumeSizeVal, System.Globalization.CultureInfo.InvariantCulture, out var volumeSize))
                         {
                             parsed.VolumeSize = volumeSize;
                         }

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -197,7 +197,7 @@ public static class CliValidator
         if (!string.IsNullOrEmpty(parsed.DatDelimiters))
         {
             var delim = parsed.DatDelimiters.ToLowerInvariant();
-            if (delim != "standard" && delim != "csv")
+            if (!string.Equals(delim, "standard", StringComparison.Ordinal) && !string.Equals(delim, "csv", StringComparison.Ordinal))
             {
                 Console.Error.WriteLine("Error: DAT delimiters must be 'standard' or 'csv'.");
                 return false;
@@ -235,7 +235,7 @@ public static class CliValidator
                 return false;
             }
 
-            if (parsed.BatesPrefix == ".." || parsed.BatesPrefix.Contains("../", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("..\\", StringComparison.Ordinal))
+            if (string.Equals(parsed.BatesPrefix, "..", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("../", StringComparison.Ordinal) || parsed.BatesPrefix.Contains("..\\", StringComparison.Ordinal))
             {
                 Console.Error.WriteLine("Error: --bates-prefix must not contain directory traversal sequences.");
                 return false;
@@ -456,7 +456,7 @@ public static class CliValidator
         if (!string.IsNullOrEmpty(parsed.Eol))
         {
             var eolUpper = parsed.Eol.ToUpperInvariant();
-            if (eolUpper != "CRLF" && eolUpper != "LF" && eolUpper != "CR")
+            if (!string.Equals(eolUpper, "CRLF", StringComparison.Ordinal) && !string.Equals(eolUpper, "LF", StringComparison.Ordinal) && !string.Equals(eolUpper, "CR", StringComparison.Ordinal))
             {
                 Console.Error.WriteLine("Error: --eol must be CRLF, LF, or CR.");
                 return false;
@@ -490,7 +490,7 @@ public static class CliValidator
         if (value.StartsWith("ascii:", StringComparison.OrdinalIgnoreCase))
         {
             var numPart = value.Substring(6);
-            return int.TryParse(numPart, out var code) && code >= 0 && code <= 255;
+            return int.TryParse(numPart, System.Globalization.CultureInfo.InvariantCulture, out var code) && code >= 0 && code <= 255;
         }
 
         if (value.StartsWith("char:", StringComparison.OrdinalIgnoreCase))
@@ -505,9 +505,9 @@ public static class CliValidator
     {
         if (value.EndsWith('%'))
         {
-            return double.TryParse(value.TrimEnd('%'), out var pct) && pct > 0;
+            return double.TryParse(value.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture, out var pct) && pct > 0;
         }
 
-        return int.TryParse(value, out var count) && count > 0;
+        return int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var count) && count > 0;
     }
 }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -42,7 +42,7 @@ public static class RequestBuilder
         else if (!parsed.IsLoadFileFormatExplicit)
         {
             var fileType = (parsed.FileType ?? "pdf").ToLowerInvariant();
-            if (fileType == "tiff" || fileType == "jpg")
+            if (string.Equals(fileType, "tiff", StringComparison.Ordinal) || string.Equals(fileType, "jpg", StringComparison.Ordinal))
             {
                 multiFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt };
             }
@@ -188,7 +188,7 @@ public static class RequestBuilder
             if (size.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
             {
                 var numberPart = size.Substring(0, size.Length - suffix.Length);
-                return long.TryParse(numberPart, out var value) ? value * multiplier : null;
+                return long.TryParse(numberPart, System.Globalization.CultureInfo.InvariantCulture, out var value) ? value * multiplier : null;
             }
         }
 
@@ -229,27 +229,27 @@ public static class RequestBuilder
             throw new ArgumentException("Delimiter argument cannot be empty.");
         }
 
-        if (arg == "\\t")
+        if (string.Equals(arg, "\\t", StringComparison.Ordinal))
         {
             return "\t";
         }
 
-        if (arg == "\\n")
+        if (string.Equals(arg, "\\n", StringComparison.Ordinal))
         {
             return "\n";
         }
 
-        if (arg == "\\r")
+        if (string.Equals(arg, "\\r", StringComparison.Ordinal))
         {
             return "\r";
         }
 
-        if (arg == "\\r\\n")
+        if (string.Equals(arg, "\\r\\n", StringComparison.Ordinal))
         {
             return "\r\n";
         }
 
-        if (int.TryParse(arg, out var asciiCode) && asciiCode >= 0 && asciiCode <= 255)
+        if (int.TryParse(arg, System.Globalization.CultureInfo.InvariantCulture, out var asciiCode) && asciiCode >= 0 && asciiCode <= 255)
         {
             return ((char)asciiCode).ToString();
         }
@@ -267,7 +267,7 @@ public static class RequestBuilder
         if (arg.StartsWith("ascii:", StringComparison.OrdinalIgnoreCase))
         {
             var numPart = arg.Substring(6);
-            if (int.TryParse(numPart, out var code) && code >= 0 && code <= 255)
+            if (int.TryParse(numPart, System.Globalization.CultureInfo.InvariantCulture, out var code) && code >= 0 && code <= 255)
             {
                 return ((char)code).ToString();
             }

--- a/src/Config/OutputConfig.cs
+++ b/src/Config/OutputConfig.cs
@@ -20,7 +20,7 @@ public record OutputConfig
 
     public string FileTypeLower => this.FileType.ToLowerInvariant();
 
-    public bool IsEml => this.FileTypeLower == "eml";
+    public bool IsEml => string.Equals(this.FileTypeLower, "eml", StringComparison.Ordinal);
 
-    public bool IsTiff => this.FileTypeLower == "tiff";
+    public bool IsTiff => string.Equals(this.FileTypeLower, "tiff", StringComparison.Ordinal);
 }

--- a/src/DiskBackedFileDataList.cs
+++ b/src/DiskBackedFileDataList.cs
@@ -10,7 +10,7 @@ namespace Zipper
         private FileStream? writeStream;
         private BinaryWriter? writer;
         private int count;
-        private readonly object syncRoot = new object();
+        private readonly Lock syncRoot = new();
 
         public DiskBackedFileDataList()
         {

--- a/src/Emails/Email.cs
+++ b/src/Emails/Email.cs
@@ -11,7 +11,7 @@ public record Email
 
     public string Subject { get; init; } = string.Empty;
 
-    public DateTime SentDate { get; init; } = DateTime.Now;
+    public DateTime SentDate { get; init; } = DateTime.UtcNow;
 
     public string Body { get; init; } = string.Empty;
 

--- a/src/Emails/EmailFactory.cs
+++ b/src/Emails/EmailFactory.cs
@@ -145,14 +145,14 @@ internal static class EmailFactory
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(seeded);
         var referenceDate = request.Metadata.Seed.HasValue
-            ? new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local)
-            : DateTime.Now;
+            ? new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc)
+            : DateTime.UtcNow;
         return Create((int)item.Index, (int)item.Index, category: null, seeded, referenceDate);
     }
 
     internal static Email Create(int recipientIndex, int senderIndex, EmailCategory? category, Random random)
     {
-        return Create(recipientIndex, senderIndex, category, random, DateTime.Now);
+        return Create(recipientIndex, senderIndex, category, random, DateTime.UtcNow);
     }
 
     internal static Email Create(int recipientIndex, int senderIndex, EmailCategory? category, Random random, DateTime referenceDate)
@@ -179,7 +179,7 @@ internal static class EmailFactory
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(random);
-        var referenceDate = DateTime.Now;
+        var referenceDate = DateTime.UtcNow;
         var baseTemplate = GetContextualBaseTemplate(context);
         return new Email
         {
@@ -237,6 +237,7 @@ internal static class EmailFactory
     private static Dictionary<string, string> BuildReplacements(int recipientIndex, int senderIndex, Random random, DateTime referenceDate)
     {
         return new Dictionary<string, string>
+(StringComparer.Ordinal)
         {
             ["{recipient}"] = $"Recipient {recipientIndex:D3}",
             ["{sender}"] = $"Sender {senderIndex:D3}",

--- a/src/GenerationRunner.cs
+++ b/src/GenerationRunner.cs
@@ -15,7 +15,7 @@ namespace Zipper
         {
             try
             {
-                await mode.RunAsync(request);
+                await mode.RunAsync(request).ConfigureAwait(false);
                 return 0;
             }
             catch (Exception ex)

--- a/src/LoadFiles/ConcordanceComposingWriter.cs
+++ b/src/LoadFiles/ConcordanceComposingWriter.cs
@@ -23,6 +23,6 @@ internal sealed class ConcordanceComposingWriter : ILoadFileWriter
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         await LoadFileEmitter.EmitAsync(
-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null);
+            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/CsvComposingWriter.cs
+++ b/src/LoadFiles/CsvComposingWriter.cs
@@ -22,6 +22,6 @@ internal sealed class CsvComposingWriter : ILoadFileWriter
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         await LoadFileEmitter.EmitAsync(
-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null);
+            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/DatComposingWriter.cs
+++ b/src/LoadFiles/DatComposingWriter.cs
@@ -41,6 +41,6 @@ internal sealed class DatComposingWriter : ILoadFileWriter
             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
 
         var records = composer.Compose(processedFiles);
-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine);
+        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/LoadFileEmitter.cs
+++ b/src/LoadFiles/LoadFileEmitter.cs
@@ -46,11 +46,11 @@ internal static class LoadFileEmitter
 
         if (chaosEngine == null)
         {
-            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol);
+            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol).ConfigureAwait(false);
         }
         else
         {
-            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine);
+            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
         }
     }
 
@@ -66,21 +66,23 @@ internal static class LoadFileEmitter
         // A StreamWriter owns the encoding preamble (written once) and chunks output to the
         // underlying stream by its internal buffer, so records stream out without the whole
         // file ever being materialized in memory.
-        await using var writer = new StreamWriter(stream, encoding, leaveOpen: true);
-
-        if (hasHeader)
+        var writer = new StreamWriter(stream, encoding, leaveOpen: true);
+        await using (writer.ConfigureAwait(false))
         {
-            await writer.WriteAsync(serializer.RenderHeader(headerColumns));
-            await writer.WriteAsync(eol);
-        }
+            if (hasHeader)
+            {
+                await writer.WriteAsync(serializer.RenderHeader(headerColumns)).ConfigureAwait(false);
+                await writer.WriteAsync(eol).ConfigureAwait(false);
+            }
 
-        foreach (var record in records)
-        {
-            await writer.WriteAsync(serializer.RenderRecord(record));
-            await writer.WriteAsync(eol);
-        }
+            foreach (var record in records)
+            {
+                await writer.WriteAsync(serializer.RenderRecord(record)).ConfigureAwait(false);
+                await writer.WriteAsync(eol).ConfigureAwait(false);
+            }
 
-        await writer.FlushAsync();
+            await writer.FlushAsync().ConfigureAwait(false);
+        }
     }
 
     private static async Task EmitWithChaosAsync(
@@ -99,19 +101,19 @@ internal static class LoadFileEmitter
         var preamble = encoding.GetPreamble();
         if (preamble.Length > 0)
         {
-            await stream.WriteAsync(preamble);
+            await stream.WriteAsync(preamble).ConfigureAwait(false);
         }
 
         long lineNumber = 1;
         if (hasHeader)
         {
-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol);
+            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol).ConfigureAwait(false);
             lineNumber++;
         }
 
         foreach (var record in records)
         {
-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol);
+            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol).ConfigureAwait(false);
             lineNumber++;
         }
     }
@@ -129,12 +131,12 @@ internal static class LoadFileEmitter
             ? chaosEngine.Intercept(lineNumber, originalLine, recordId)
             : originalLine;
 
-        await stream.WriteAsync(encoding.GetBytes(text + eol));
+        await stream.WriteAsync(encoding.GetBytes(text + eol)).ConfigureAwait(false);
 
         var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
         if (anomaly != null)
         {
-            await stream.WriteAsync(anomaly);
+            await stream.WriteAsync(anomaly).ConfigureAwait(false);
         }
     }
 }

--- a/src/LoadFiles/LoadFileRecordBuilder.cs
+++ b/src/LoadFiles/LoadFileRecordBuilder.cs
@@ -14,7 +14,7 @@ internal static class LoadFileRecordBuilder
                 $"Load file value count {orderedValues.Count} does not match header column count {headerColumns.Count}.");
         }
 
-        var values = new Dictionary<string, string>(headerColumns.Count);
+        var values = new Dictionary<string, string>(headerColumns.Count, StringComparer.Ordinal);
         for (int i = 0; i < headerColumns.Count; i++)
         {
             values[headerColumns[i]] = orderedValues[i];

--- a/src/LoadFiles/OptComposingWriter.cs
+++ b/src/LoadFiles/OptComposingWriter.cs
@@ -49,7 +49,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
 
         var records = composer.Compose(processedFiles);
-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos);
+        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
     private static Encoding GetOptEncoding(FileGenerationRequest request)
     {
         var resolvedEncoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
-        return request.LoadFile.IsEncodingExplicit || resolvedEncoding != Encoding.UTF8
+        return request.LoadFile.IsEncodingExplicit || !object.Equals(resolvedEncoding, Encoding.UTF8)
             ? resolvedEncoding
             : EncodingHelper.GetEncoding("ANSI") ?? Encoding.UTF8;
     }

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -32,45 +32,47 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
             CloseOutput = false,
         };
 
-        await using var writer = System.Xml.XmlWriter.Create(stream, settings);
-
-        try
+        var writer = System.Xml.XmlWriter.Create(stream, settings);
+        await using (writer.ConfigureAwait(false))
         {
-            // Match the original XDeclaration("1.0", "UTF-8", "yes")
-            await writer.WriteStartDocumentAsync(standalone: true);
-            await writer.WriteStartElementAsync(null, "Root", null);
-            await writer.WriteAttributeStringAsync(null, "DataInterchangeType", null, "Export");
-            await writer.WriteAttributeStringAsync(null, "MajorVersion", null, "1");
-            await writer.WriteAttributeStringAsync(null, "MinorVersion", null, "2");
+            try
+            {
+                // Match the original XDeclaration("1.0", "UTF-8", "yes")
+                await writer.WriteStartDocumentAsync(standalone: true);
+                await writer.WriteStartElementAsync(null, "Root", null);
+                await writer.WriteAttributeStringAsync(null, "DataInterchangeType", null, "Export");
+                await writer.WriteAttributeStringAsync(null, "MajorVersion", null, "1");
+                await writer.WriteAttributeStringAsync(null, "MinorVersion", null, "2");
 
-            await writer.WriteStartElementAsync(null, "Batch", null);
+                await writer.WriteStartElementAsync(null, "Batch", null);
 
 #pragma warning disable S2245
-            var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
+                var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : Random.Shared;
 #pragma warning restore S2245
-            var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
+                var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
-            foreach (var fileData in processedFiles)
-            {
-                var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
-                await element.WriteToAsync(writer, CancellationToken.None);
+                foreach (var fileData in processedFiles)
+                {
+                    var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
+                    await element.WriteToAsync(writer, CancellationToken.None);
+                }
+
+                await writer.WriteEndElementAsync(); // </Batch>
+                await writer.WriteEndElementAsync(); // </Root>
+                await writer.WriteEndDocumentAsync();
+
+                await writer.FlushAsync();
             }
-
-            await writer.WriteEndElementAsync(); // </Batch>
-            await writer.WriteEndElementAsync(); // </Root>
-            await writer.WriteEndDocumentAsync();
-
-            await writer.FlushAsync();
-        }
-        catch (Exception ex)
-        {
-            if (ex is OperationCanceledException)
+            catch (Exception ex)
             {
-                throw;
-            }
+                if (ex is OperationCanceledException)
+                {
+                    throw;
+                }
 
-            throw new InvalidOperationException(
-                $"Failed to write XML load file: {ex.Message}", ex);
+                throw new InvalidOperationException(
+                    $"Failed to write XML load file: {ex.Message}", ex);
+            }
         }
     }
 

--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -33,7 +33,7 @@ internal static class LoadfileAuditWriter
     {
         var propertiesPath = Path.ChangeExtension(outputPath, null) + "_properties.json";
         var json = GenerateAuditJson(outputPath, request, totalRecords, anomalies, format);
-        await File.WriteAllTextAsync(propertiesPath, json);
+        await File.WriteAllTextAsync(propertiesPath, json).ConfigureAwait(false);
         return propertiesPath;
     }
 
@@ -85,7 +85,7 @@ internal static class LoadfileAuditWriter
         var encodingName = request.LoadFile.Encoding;
         if (activeFormat == LoadFileFormat.Opt)
         {
-            if (!request.LoadFile.IsEncodingExplicit && request.LoadFile.Encoding == "UTF-8")
+            if (!request.LoadFile.IsEncodingExplicit && string.Equals(request.LoadFile.Encoding, "UTF-8", StringComparison.Ordinal))
             {
                 encodingName = "ANSI";
             }

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -22,7 +22,7 @@ internal static class LoadfileOnlyGenerator
 
         Directory.CreateDirectory(request.Output.OutputPath);
 
-        var baseFileName = $"loadfile_{DateTime.Now:yyyyMMdd_HHmmss}";
+        var baseFileName = $"loadfile_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
 
         var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
             ? request.LoadFile.LoadFileFormats
@@ -71,9 +71,10 @@ internal static class LoadfileOnlyGenerator
                 format == LoadFileFormat.Opt ? LoadFileFormat.Opt : LoadFileFormat.Dat,
                 WriterMode.LoadfileOnly);
 
-            await using (var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
+            var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
+            await using (fileStream.ConfigureAwait(false))
             {
-                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine);
+                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine).ConfigureAwait(false);
             }
 
             string propertiesPath;
@@ -84,7 +85,7 @@ internal static class LoadfileOnlyGenerator
                     request,
                     request.Output.FileCount,
                     chaosEngine?.Anomalies,
-                    format);
+                    format).ConfigureAwait(false);
             }
             catch
             {

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -23,7 +23,7 @@ namespace Zipper
                 }
             }
 
-            var result = await LoadfileOnlyGenerator.GenerateAsync(request);
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Load file: {0}", result.LoadFilePath));

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -15,6 +15,9 @@ namespace Zipper
 
         public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request)
         {
+            string? zipFilePath = null;
+            string? loadFilePath = null;
+
             ArgumentNullException.ThrowIfNull(request);
 
             // Clone to avoid mutating the caller's request object
@@ -45,10 +48,10 @@ namespace Zipper
 
                 Directory.CreateDirectory(request.Output.OutputPath);
 
-                var baseFileName = $"archive_{DateTime.Now:yyyyMMdd_HHmmss}";
-                var zipFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}.zip");
+                var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+                zipFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}.zip");
                 var loadFileName = $"{baseFileName}.dat";
-                var loadFilePath = Path.Combine(request.Output.OutputPath, loadFileName);
+                loadFilePath = Path.Combine(request.Output.OutputPath, loadFileName);
 
                 var placeholderContent = fileGenerator.IsPlaceholderBased
                     ? PlaceholderFiles.GetContent(request.Output.FileTypeLower)
@@ -83,14 +86,14 @@ namespace Zipper
                 Exception? producerException = null;
                 try
                 {
-                    var completed = await Task.WhenAny(allProducersTask, consumerTask);
+                    var completed = await Task.WhenAny(allProducersTask, consumerTask).ConfigureAwait(false);
                     if (completed == consumerTask && consumerTask.IsFaulted)
                     {
                         // Consumer died — complete channel with its exception to unblock producers
                         resultChannel.Writer.TryComplete(consumerTask.Exception);
                         try
                         {
-                            await allProducersTask;
+                            await allProducersTask.ConfigureAwait(false);
                         }
                         catch
                         {
@@ -100,7 +103,7 @@ namespace Zipper
                     else
                     {
                         // Producers finished first (normal path)
-                        await allProducersTask;
+                        await allProducersTask.ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
@@ -114,7 +117,7 @@ namespace Zipper
                 }
 
                 // Always wait for consumer (releases zip file handles)
-                var actualLoadFilePath = await consumerTask;
+                var actualLoadFilePath = await consumerTask.ConfigureAwait(false);
 
                 RethrowIfNotNull(producerException);
 
@@ -133,6 +136,12 @@ namespace Zipper
             catch
             {
                 this.performanceMonitor.Stop();
+                try
+                {
+                    if (zipFilePath != null && File.Exists(zipFilePath)) File.Delete(zipFilePath);
+                    if (loadFilePath != null && File.Exists(loadFilePath)) File.Delete(loadFilePath);
+                }
+                catch { }
                 throw;
             }
         }
@@ -163,7 +172,7 @@ namespace Zipper
                             FolderName = folderName,
                             FileName = fileName,
                             FilePathInZip = filePathInZip,
-                        });
+                        }).ConfigureAwait(false);
                     }
 
                     writer.Complete();
@@ -181,12 +190,12 @@ namespace Zipper
         {
             long filesProcessed = 0;
 
-            await foreach (var workItem in reader.ReadAllAsync())
+            await foreach (var workItem in reader.ReadAllAsync().ConfigureAwait(false))
             {
                 var fileData = this.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
                 try
                 {
-                    await writer.WriteAsync(fileData);
+                    await writer.WriteAsync(fileData).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -141,7 +141,10 @@ namespace Zipper
                     if (zipFilePath != null && File.Exists(zipFilePath)) File.Delete(zipFilePath);
                     if (loadFilePath != null && File.Exists(loadFilePath)) File.Delete(loadFilePath);
                 }
-                catch { }
+                catch
+                {
+                    // Suppressed: cleanup failures shouldn't mask the original exception
+                }
                 throw;
             }
         }

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 
 namespace Zipper
 {

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -36,7 +36,7 @@ namespace Zipper
                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
-                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    StringComparison comparison = OperatingSystem.IsWindows()
                         ? StringComparison.OrdinalIgnoreCase
                         : StringComparison.Ordinal;
 
@@ -96,7 +96,7 @@ namespace Zipper
                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                     string baseDirWithTrailing = restrictToBase.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
-                    StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    StringComparison comparison = OperatingSystem.IsWindows()
                         ? StringComparison.OrdinalIgnoreCase
                         : StringComparison.Ordinal;
 

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -15,10 +15,10 @@ namespace Zipper
             Console.WriteLine("=== Performance Benchmark Suite ===");
             Console.WriteLine();
 
-            await BenchmarkParallelVsSequential();
-            await BenchmarkMemoryPooling();
-            await BenchmarkScalability();
-            await BenchmarkAllocation();
+            await BenchmarkParallelVsSequential().ConfigureAwait(false);
+            await BenchmarkMemoryPooling().ConfigureAwait(false);
+            await BenchmarkScalability().ConfigureAwait(false);
+            await BenchmarkAllocation().ConfigureAwait(false);
 
             Console.WriteLine("=== Benchmark Suite Complete ===");
         }
@@ -58,7 +58,7 @@ namespace Zipper
                     LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
                 };
 
-                await generator.GenerateFilesAsync(request);
+                await generator.GenerateFilesAsync(request).ConfigureAwait(false);
 
                 var allocatedAfter = GC.GetTotalAllocatedBytes(precise: true);
                 var totalAllocated = allocatedAfter - allocatedBefore;
@@ -94,7 +94,7 @@ namespace Zipper
             {
                 // Sequential baseline
                 var sw = Stopwatch.StartNew();
-                await GenerateSequentialFiles(fileCount, outputPath1);
+                await GenerateSequentialFiles(fileCount, outputPath1).ConfigureAwait(false);
                 sw.Stop();
                 var sequentialTime = sw.ElapsedMilliseconds;
 
@@ -113,7 +113,7 @@ namespace Zipper
                     },
                     LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
                 };
-                await generator.GenerateFilesAsync(request);
+                await generator.GenerateFilesAsync(request).ConfigureAwait(false);
                 sw.Stop();
                 var parallelTime = sw.ElapsedMilliseconds;
 
@@ -224,7 +224,7 @@ namespace Zipper
                         LoadFile = new LoadFileConfig { Distribution = DistributionType.Proportional },
                     };
 
-                    var result = await generator.GenerateFilesAsync(request);
+                    var result = await generator.GenerateFilesAsync(request).ConfigureAwait(false);
                     sw.Stop();
 
                     var throughput = result.FilesPerSecond;
@@ -246,7 +246,7 @@ namespace Zipper
         {
             return Task.Run(async () =>
             {
-                var baseFileName = $"archive_{DateTime.Now:yyyyMMdd_HHmmss}";
+                var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
                 var zipFilePath = Path.Combine(outputPath, $"{baseFileName}.zip");
 
                 using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
@@ -259,7 +259,7 @@ namespace Zipper
                     var fileName = $"{i:D8}.pdf";
                     var entry = archive.CreateEntry(fileName, CompressionLevel.Optimal);
                     using var entryStream = entry.Open();
-                    await entryStream.WriteAsync(placeholderContent);
+                    await entryStream.WriteAsync(placeholderContent).ConfigureAwait(false);
                 }
             });
         }

--- a/src/PerformanceMonitor.cs
+++ b/src/PerformanceMonitor.cs
@@ -13,7 +13,7 @@ namespace Zipper
         private long totalFiles;
         private DateTime lastProgressUpdate = DateTime.UtcNow;
         private double lastDisplayedPercentage;
-        private readonly object syncRoot = new object();
+        private readonly Lock syncRoot = new();
 
         /// <summary>
         /// Starts performance monitoring for a new operation.
@@ -64,7 +64,7 @@ namespace Zipper
         public void ReportProgress(long completed, long total)
         {
             // Disable progress bar in CI environments to prevent hangs
-            if (Environment.GetEnvironmentVariable("CI") == "true")
+            if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.Ordinal))
             {
                 return;
             }
@@ -91,7 +91,7 @@ namespace Zipper
         public void FinalizeProgress()
         {
             // Disable in CI environments
-            if (Environment.GetEnvironmentVariable("CI") == "true")
+            if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/ProductionManifestWriter.cs
+++ b/src/ProductionManifestWriter.cs
@@ -72,7 +72,7 @@ internal static class ProductionManifestWriter
         };
 
         var json = JsonSerializer.Serialize(manifest, ManifestSerializerOptions);
-        await File.WriteAllTextAsync(manifestPath, json);
+        await File.WriteAllTextAsync(manifestPath, json).ConfigureAwait(false);
 
         return manifestPath;
     }

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -25,12 +25,12 @@ internal static class ProductionSetGenerator
 
         var stopwatch = Stopwatch.StartNew();
 
-        var productionName = $"PRODUCTION_{DateTime.Now:yyyyMMdd_HHmmss}";
+        var productionName = $"PRODUCTION_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
         var productionPath = Path.Combine(request.Output.OutputPath, productionName);
 
         try
         {
-            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch);
+            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch).ConfigureAwait(false);
         }
         catch
         {
@@ -103,11 +103,11 @@ internal static class ProductionSetGenerator
             var generated = fileGenerator.Generate(workItem, request);
             var nativeContent = generated.Content;
 
-            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.NativeRelPath), nativeContent);
+            await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.NativeRelPath), nativeContent).ConfigureAwait(false);
 
             var textContent = $"Extracted text for document {plan.BatesNumber}. " +
                               Profiles.LoremIpsum.GetParagraph(random);
-            await File.WriteAllTextAsync(Path.Combine(productionPath, plan.TextRelPath), textContent, encoding);
+            await File.WriteAllTextAsync(Path.Combine(productionPath, plan.TextRelPath), textContent, encoding).ConfigureAwait(false);
 
             // Write placeholder TIFF image (single-pixel stub)
             if (generated.PageCount > 1)
@@ -120,12 +120,12 @@ internal static class ProductionSetGenerator
                 for (int pageIdx = 1; pageIdx <= generated.PageCount; pageIdx++)
                 {
                     var pageImageRelPath = $"{imagePathWithoutExt}_{pageIdx:D3}{imageExt}";
-                    await File.WriteAllBytesAsync(Path.Combine(productionPath, pageImageRelPath), PlaceholderFiles.GetContent("tiff"));
+                    await File.WriteAllBytesAsync(Path.Combine(productionPath, pageImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
                 }
             }
             else
             {
-                await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff"));
+                await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
             }
 
             fileDataList.Add(new FileData
@@ -147,12 +147,12 @@ internal static class ProductionSetGenerator
                 var childTextRelPath = Path.Combine("TEXT", plan.VolumeName, $"{childBates}.txt");
                 var childImageRelPath = Path.Combine("IMAGES", plan.VolumeName, $"{childBates}.tif");
 
-                await File.WriteAllBytesAsync(Path.Combine(productionPath, childNativeRelPath), attach.content);
+                await File.WriteAllBytesAsync(Path.Combine(productionPath, childNativeRelPath), attach.content).ConfigureAwait(false);
 
                 var childTextContent = $"Extracted text for attachment {childBates}.";
-                await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding);
+                await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding).ConfigureAwait(false);
 
-                await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff"));
+                await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
             }
 
             // Progress reporting
@@ -175,13 +175,14 @@ internal static class ProductionSetGenerator
         var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
         long datTotalLines = totalRecords + 1; // header + data rows
         var datChaosEngine = ChaosEngineBuilder.Build(request, datTotalLines, LoadFileFormat.Dat);
-        await using (var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
+        var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
+        await using (datStream.ConfigureAwait(false))
         {
-            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine);
+            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine).ConfigureAwait(false);
         }
 
         var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, totalRecords, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson);
+        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson).ConfigureAwait(false);
 
         // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
@@ -190,21 +191,22 @@ internal static class ProductionSetGenerator
             (request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
             + (request.Metadata.WithFamilies && request.Output.IsEml && f.Attachment.HasValue ? 1 : 0));
         var optChaosEngine = ChaosEngineBuilder.Build(request, optTotalLines, LoadFileFormat.Opt);
-        await using (var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, 65536, true))
+        var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
+        await using (optStream.ConfigureAwait(false))
         {
-            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine);
+            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine).ConfigureAwait(false);
         }
 
         var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, optTotalLines, optChaosEngine?.Anomalies, LoadFileFormat.Opt);
 
         // Save OPT properties with a slightly different name to avoid overwriting DAT properties
-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson);
+        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson).ConfigureAwait(false);
 
         // Write manifest
         var batesStart = plans[0].BatesNumber;
         var batesEnd = plans[^1].BatesNumber;
         var manifestPath = await ProductionManifestWriter.WriteAsync(
-            productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed);
+            productionPath, request, batesStart, batesEnd, volumeCount, stopwatch.Elapsed).ConfigureAwait(false);
 
         // Optionally wrap in ZIP
         string? zipPath = null;

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -21,7 +21,7 @@ namespace Zipper
                 Console.WriteLine("  ZIP Output: Enabled");
             }
 
-            var result = await ProductionSetGenerator.GenerateAsync(request);
+            var result = await ProductionSetGenerator.GenerateAsync(request).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Production: {0}", result.ProductionPath));

--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -25,6 +25,7 @@ public static class BuiltInProfiles
             DateFormat = "yyyy-MM-dd",
         },
         DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
         {
             ["custodians"] = new DataSourceConfig { Count = 10, Distribution = "pareto", Prefix = "Custodian_" },
         },
@@ -54,6 +55,7 @@ public static class BuiltInProfiles
             DateFormat = "yyyy-MM-dd",
         },
         DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
         {
             ["custodians"] = new DataSourceConfig { Count = 25, Distribution = "pareto", Prefix = "Custodian_" },
             ["authors"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Author_" },
@@ -114,6 +116,7 @@ public static class BuiltInProfiles
             DateFormat = "yyyy-MM-dd",
         },
         DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
         {
             ["custodians"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Custodian_" },
             ["authors"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Author_" },
@@ -143,6 +146,7 @@ public static class BuiltInProfiles
             DateFormat = "yyyy-MM-dd",
         },
         DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
         {
             ["custodians"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Custodian_" },
             ["authors"] = new DataSourceConfig { Count = 200, Distribution = "pareto", Prefix = "Author_" },
@@ -188,7 +192,7 @@ public static class BuiltInProfiles
         Version = "1.0",
         FieldNamingConvention = null,
         Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-        DataSources = new Dictionary<string, DataSourceConfig>(),
+        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
         Columns = new List<ColumnDefinition>
         {
             new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
@@ -209,7 +213,7 @@ public static class BuiltInProfiles
         Version = "1.0",
         FieldNamingConvention = null,
         Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-        DataSources = new Dictionary<string, DataSourceConfig>(),
+        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
         Columns = new List<ColumnDefinition>
         {
             new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
@@ -370,7 +374,7 @@ public static class BuiltInProfiles
                 Name = $"NOTES{i:D2}",
                 Type = "longtext",
                 Generator = "loremParagraphs",
-                GeneratorParams = new Dictionary<string, object> { ["min"] = 1, ["max"] = 3 },
+                GeneratorParams = new Dictionary<string, object>(StringComparer.Ordinal) { ["min"] = 1, ["max"] = 3 },
                 EmptyPercentage = 70 + (i * 2),
             });
         }

--- a/src/Profiles/ColumnProfile.cs
+++ b/src/Profiles/ColumnProfile.cs
@@ -41,7 +41,7 @@ public class ColumnProfile
     /// Gets or sets the data sources for value generation.
     /// </summary>
     [JsonPropertyName("dataSources")]
-    public Dictionary<string, DataSourceConfig> DataSources { get; set; } = new();
+    public Dictionary<string, DataSourceConfig> DataSources { get; set; } = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets or sets the column definitions.
@@ -76,7 +76,7 @@ public class ColumnProfile
                     Prefix = kv.Value.Prefix,
                     Values = kv.Value.Values != null ? new List<string>(kv.Value.Values) : null,
                     Weights = kv.Value.Weights != null ? new List<int>(kv.Value.Weights) : null,
-                }),
+                }, StringComparer.Ordinal),
             Columns = this.Columns.Select(col => new ColumnDefinition
             {
                 Name = col.Name,
@@ -93,7 +93,7 @@ public class ColumnProfile
                 TruePercentage = col.TruePercentage,
                 Weights = col.Weights != null ? new List<int>(col.Weights) : null,
                 Generator = col.Generator,
-                GeneratorParams = col.GeneratorParams != null ? new Dictionary<string, object>(col.GeneratorParams) : null,
+                GeneratorParams = col.GeneratorParams != null ? new Dictionary<string, object>(col.GeneratorParams, StringComparer.Ordinal) : null,
             }).ToList(),
         };
         return cloned;

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -55,9 +55,9 @@ internal class DataGenerator
 #pragma warning disable S2245
         this.random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
 #pragma warning restore S2245
-        this.dataSources = new Dictionary<string, string[]>();
-        this.distributionIndices = new Dictionary<string, int[]>();
-        this.columnGenerators = new Dictionary<string, IColumnValueGenerator>();
+        this.dataSources = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        this.distributionIndices = new Dictionary<string, int[]>(StringComparer.Ordinal);
+        this.columnGenerators = new Dictionary<string, IColumnValueGenerator>(StringComparer.Ordinal);
         this.now = now ?? DateTime.UtcNow;
         this.InitializeDataSources();
         this.InitializeColumnGenerators();
@@ -122,7 +122,7 @@ internal class DataGenerator
             Now = this.now,
             FileData = fileData,
         };
-        var row = new Dictionary<string, string>(this.profile.Columns.Count);
+        var row = new Dictionary<string, string>(this.profile.Columns.Count, StringComparer.Ordinal);
         foreach (var col in this.profile.Columns)
         {
             var emptyPct = col.EmptyPercentage ?? this.profile.Settings.EmptyValuePercentage;
@@ -150,7 +150,7 @@ internal class DataGenerator
                 ? cfg.Values
                 : Enumerable.Range(1, cfg.Count).Select(i => $"{cfg.Prefix}{i}")).ToArray();
             this.dataSources[name] = vals;
-            if (cfg.Distribution == "pareto" || cfg.Distribution == "weighted")
+            if (string.Equals(cfg.Distribution, "pareto", StringComparison.Ordinal) || string.Equals(cfg.Distribution, "weighted", StringComparison.Ordinal))
             {
                 this.distributionIndices[name] = this.PrecomputeIndices(vals.Length, cfg);
             }
@@ -203,7 +203,7 @@ internal class DataGenerator
     private int[] PrecomputeIndices(int count, DataSourceConfig cfg)
     {
         var indices = new int[1000];
-        if (cfg.Distribution == "weighted" && cfg.Weights?.Count > 0)
+        if (string.Equals(cfg.Distribution, "weighted", StringComparison.Ordinal) && cfg.Weights?.Count > 0)
         {
             var total = cfg.Weights.Take(count).Sum();
             if (total <= 0)

--- a/src/Profiles/Generation/CodedGenerator.cs
+++ b/src/Profiles/Generation/CodedGenerator.cs
@@ -34,7 +34,7 @@ internal sealed class CodedGenerator : IColumnValueGenerator
                 return string.Empty;
             }
 
-            var selected = new HashSet<string>();
+            var selected = new HashSet<string>(StringComparer.Ordinal);
             selected.Add(this.PickValue(context));
             while (selected.Count < count && selected.Count < this.values.Length)
             {

--- a/src/Profiles/Generation/LongTextGenerator.cs
+++ b/src/Profiles/Generation/LongTextGenerator.cs
@@ -27,7 +27,7 @@ internal sealed class LongTextGenerator : IColumnValueGenerator
 
     public string Generate(ColumnGenerationContext context)
     {
-        if (this.generatorName == "reviewNote")
+        if (string.Equals(this.generatorName, "reviewNote", StringComparison.Ordinal))
         {
             return ReviewNotes.GetRandomNote(context.Seeded);
         }

--- a/src/Profiles/Generation/NumberGenerator.cs
+++ b/src/Profiles/Generation/NumberGenerator.cs
@@ -50,14 +50,14 @@ internal sealed class NumberGenerator : IColumnValueGenerator
             return this.min.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
-        if (this.distribution == "exponential")
+        if (string.Equals(this.distribution, "exponential", StringComparison.Ordinal))
         {
             var lambda = 3.0 / (this.max - this.min);
             var value = this.min + (int)(-Math.Log(1 - context.Seeded.NextDouble()) / lambda);
             return Math.Min(value, this.max).ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
-        if (this.distribution == "gaussian" || this.distribution == "normal")
+        if (string.Equals(this.distribution, "gaussian", StringComparison.Ordinal) || string.Equals(this.distribution, "normal", StringComparison.Ordinal))
         {
             double u1 = 1.0 - context.Seeded.NextDouble();
             double u2 = 1.0 - context.Seeded.NextDouble();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -16,7 +16,7 @@ namespace Zipper
             {
                 try
                 {
-                    await PerformanceBenchmarkRunner.RunBenchmarks();
+                    await PerformanceBenchmarkRunner.RunBenchmarks().ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)
@@ -39,7 +39,7 @@ namespace Zipper
             }
 
             IGenerationMode mode = SelectMode(request);
-            return await GenerationRunner.RunAsync(mode, request);
+            return await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -42,7 +42,7 @@ namespace Zipper
             // Use parallel file generator for improved performance
             var generator = new ParallelFileGenerator();
 
-            var result = await generator.GenerateFilesAsync(request);
+            var result = await generator.GenerateFilesAsync(request).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Archive created: {0}", result.ZipFilePath));
@@ -61,13 +61,13 @@ namespace Zipper
                 {
                     await Console.Error.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture,
                         "  Warning: archive size {0:N0} bytes is outside the +/-10% target tolerance ({1:N0} bytes, deviation {2:P1}).",
-                        actual, target, deviation));
+                        actual, target, deviation)).ConfigureAwait(false);
                 }
                 else
                 {
                     await Console.Out.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture,
                         "  Target ZIP size met: {0:N0} bytes (within +/-10% of {1:N0} bytes, deviation {2:P1}).",
-                        actual, target, deviation));
+                        actual, target, deviation)).ConfigureAwait(false);
                 }
             }
 

--- a/src/TiffMultiPageGenerator.cs
+++ b/src/TiffMultiPageGenerator.cs
@@ -75,7 +75,7 @@ internal static class TiffMultiPageGenerator
             return null;
         }
 
-        if (!int.TryParse(parts[0], out var min) || !int.TryParse(parts[1], out var max))
+        if (!int.TryParse(parts[0], System.Globalization.CultureInfo.InvariantCulture, out var min) || !int.TryParse(parts[1], System.Globalization.CultureInfo.InvariantCulture, out var max))
         {
             return null;
         }

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -45,7 +45,7 @@ namespace Zipper
 
             try
             {
-                await foreach (var incomingFileData in fileDataReader.ReadAllAsync())
+                await foreach (var incomingFileData in fileDataReader.ReadAllAsync().ConfigureAwait(false))
                 {
                     if (incomingFileData.WorkItem.Index == nextExpectedIndex)
                     {
@@ -106,7 +106,7 @@ namespace Zipper
                     var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
                     using (var loadFileStream = loadFileEntry.Open())
                     {
-                        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine);
+                        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
                     }
 
                     // Write audit file to ZIP
@@ -115,7 +115,7 @@ namespace Zipper
                     using (var propertiesStream = propertiesEntry.Open())
                     using (var propertiesWriter = new StreamWriter(propertiesStream))
                     {
-                        await propertiesWriter.WriteAsync(auditJson);
+                        await propertiesWriter.WriteAsync(auditJson).ConfigureAwait(false);
                     }
 
                     // Return path within the ZIP archive when load file is included
@@ -124,15 +124,18 @@ namespace Zipper
                 else
                 {
                     var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
-                    await using var fileStream = new FileStream(currentFilePath, FileMode.Create);
-                    await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine);
-                    await fileStream.FlushAsync();
+                    var fileStream = new FileStream(currentFilePath, FileMode.Create);
+                    await using (fileStream.ConfigureAwait(false))
+                    {
+                        await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine);
+                        await fileStream.FlushAsync();
 
-                    // Write audit file to disk
-                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
-                    await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
+                        // Write audit file to disk
+                        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
+                        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
 
-                    actualLoadFilePath = currentFilePath;
+                        actualLoadFilePath = currentFilePath;
+                    }
                 }
             }
 

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -127,12 +127,12 @@ namespace Zipper
                     var fileStream = new FileStream(currentFilePath, FileMode.Create);
                     await using (fileStream.ConfigureAwait(false))
                     {
-                        await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine);
-                        await fileStream.FlushAsync();
+                        await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+                        await fileStream.FlushAsync().ConfigureAwait(false);
 
                         // Write audit file to disk
                         var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
-                        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson);
+                        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
 
                         actualLoadFilePath = currentFilePath;
                     }

--- a/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
+++ b/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
@@ -147,7 +147,7 @@ public sealed class FgrFlatAccessAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (symbol.ContainingType?.Name != "FileGenerationRequest")
+        if (!string.Equals(symbol.ContainingType?.Name, "FileGenerationRequest", StringComparison.Ordinal))
         {
             return;
         }

--- a/src/Zipper.Tests/AllWritersTests.cs
+++ b/src/Zipper.Tests/AllWritersTests.cs
@@ -55,8 +55,8 @@ public class AllWritersTests : TempDirectoryTestBase
 
             var content = await File.ReadAllTextAsync(outputPath);
 
-            Assert.Contains("TEST", content);
-            Assert.Contains("000001", content);
+            Assert.Contains("TEST", content, StringComparison.Ordinal);
+            Assert.Contains("000001", content, StringComparison.Ordinal);
         }
     }
 
@@ -85,9 +85,9 @@ public class AllWritersTests : TempDirectoryTestBase
 
             if (format == LoadFileFormat.EdrmXml)
             {
-                var doc1Index = content.IndexOf("DocID=\"DOC00000001\"");
-                var doc2Index = content.IndexOf("DocID=\"DOC00000002\"");
-                var doc3Index = content.IndexOf("DocID=\"DOC00000003\"");
+                var doc1Index = content.IndexOf("DocID=\"DOC00000001\"", StringComparison.Ordinal);
+                var doc2Index = content.IndexOf("DocID=\"DOC00000002\"", StringComparison.Ordinal);
+                var doc3Index = content.IndexOf("DocID=\"DOC00000003\"", StringComparison.Ordinal);
 
                 Assert.True(doc1Index != -1);
                 Assert.True(doc2Index != -1);
@@ -97,28 +97,28 @@ public class AllWritersTests : TempDirectoryTestBase
                 var doc2Content = content.Substring(doc2Index, doc3Index - doc2Index);
                 var doc3Content = content.Substring(doc3Index);
 
-                Assert.Contains("TagName=\"PageCount\"", doc1Content);
-                Assert.Contains("TagValue=\"5\"", doc1Content);
+                Assert.Contains("TagName=\"PageCount\"", doc1Content, StringComparison.Ordinal);
+                Assert.Contains("TagValue=\"5\"", doc1Content, StringComparison.Ordinal);
 
-                Assert.Contains("TagName=\"PageCount\"", doc2Content);
-                Assert.Contains("TagValue=\"7\"", doc2Content);
+                Assert.Contains("TagName=\"PageCount\"", doc2Content, StringComparison.Ordinal);
+                Assert.Contains("TagValue=\"7\"", doc2Content, StringComparison.Ordinal);
 
-                Assert.Contains("TagName=\"PageCount\"", doc3Content);
-                Assert.Contains("TagValue=\"3\"", doc3Content);
+                Assert.Contains("TagName=\"PageCount\"", doc3Content, StringComparison.Ordinal);
+                Assert.Contains("TagValue=\"3\"", doc3Content, StringComparison.Ordinal);
             }
             else if (format == LoadFileFormat.Opt)
             {
-                var line1 = lines.FirstOrDefault(l => l.StartsWith("DOC00000001_001"));
-                var line2 = lines.FirstOrDefault(l => l.StartsWith("DOC00000002_001"));
-                var line3 = lines.FirstOrDefault(l => l.StartsWith("DOC00000003_001"));
+                var line1 = lines.FirstOrDefault(l => l.StartsWith("DOC00000001_001", StringComparison.Ordinal));
+                var line2 = lines.FirstOrDefault(l => l.StartsWith("DOC00000002_001", StringComparison.Ordinal));
+                var line3 = lines.FirstOrDefault(l => l.StartsWith("DOC00000003_001", StringComparison.Ordinal));
 
                 Assert.NotNull(line1);
                 Assert.NotNull(line2);
                 Assert.NotNull(line3);
 
-                Assert.EndsWith(",5", line1);
-                Assert.EndsWith(",7", line2);
-                Assert.EndsWith(",3", line3);
+                Assert.EndsWith(",5", line1, StringComparison.Ordinal);
+                Assert.EndsWith(",7", line2, StringComparison.Ordinal);
+                Assert.EndsWith(",3", line3, StringComparison.Ordinal);
             }
             else
             {

--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -53,8 +53,11 @@ public class BuildPropsTests
     /// <param name="doc">The XML document to search.</param>
     /// <param name="propertyName">The local name of the property element to find.</param>
     /// <returns>The <see cref="XElement"/> if found; otherwise, <c>null</c>.</returns>
+    private static IEnumerable<XElement> GetPropertyElements(XDocument doc, string propertyName)
+        => doc.Descendants().Where(e => string.Equals(e.Name.LocalName, propertyName, StringComparison.Ordinal));
+
     private static XElement? GetPropertyElement(XDocument doc, string propertyName)
-        => doc.Descendants().FirstOrDefault(e => e.Name.LocalName == propertyName);
+        => GetPropertyElements(doc, propertyName).FirstOrDefault();
 
     /// <summary>
     /// Gets the string value of the specified property element.
@@ -87,9 +90,7 @@ public class BuildPropsTests
         var doc = LoadBuildProps();
 
         // Exactly one element: no accidental unconditional duplicate that would cause NETSDK1211
-        var elements = doc.Descendants()
-            .Where(e => e.Name.LocalName == "EnableSingleFileAnalyzer")
-            .ToList();
+        var elements = GetPropertyElements(doc, "EnableSingleFileAnalyzer").ToList();
         var element = Assert.Single(elements);
         Assert.Equal("true", element.Value.Trim(), ignoreCase: true);
 

--- a/src/Zipper.Tests/ChaosEngineBuilderTests.cs
+++ b/src/Zipper.Tests/ChaosEngineBuilderTests.cs
@@ -98,7 +98,7 @@ public class ChaosEngineBuilderTests
         Assert.NotNull(enabledTypes);
         Assert.Equal(expectedTypes, enabledTypes);
 
-        var pct = double.Parse(scenario.DefaultAmount.TrimEnd('%'));
+        var pct = double.Parse(scenario.DefaultAmount.TrimEnd('%'), System.Globalization.CultureInfo.InvariantCulture);
         var expectedCount = Math.Max(1, (int)(100 * pct / 100.0));
 
         Assert.NotNull(targetLines);

--- a/src/Zipper.Tests/ChaosEngineTests.cs
+++ b/src/Zipper.Tests/ChaosEngineTests.cs
@@ -18,7 +18,7 @@ namespace Zipper
                 eol: "\r\n",
                 seed: 42));
 
-            Assert.Contains("Chaos Engine does not support load files larger than Int32.MaxValue lines", ex.Message);
+            Assert.Contains("Chaos Engine does not support load files larger than Int32.MaxValue lines", ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -138,8 +138,8 @@ namespace Zipper
                 if (engine.ShouldIntercept(i))
                 {
                     string modified = engine.Intercept(i, line, $"DOC{i:D8}");
-                    Assert.Contains("\n", modified);
-                    Assert.DoesNotContain("\r\n", modified);
+                    Assert.Contains("\n", modified, StringComparison.Ordinal);
+                    Assert.DoesNotContain("\r\n", modified, StringComparison.Ordinal);
                     break;
                 }
             }
@@ -284,7 +284,7 @@ namespace Zipper
                     string lastField = modified.Split(',').Last();
 
                     // Should be either "ABC" or "-1"
-                    Assert.True(lastField == "ABC" || lastField == "-1", $"Last field was '{lastField}'");
+                    Assert.True(string.Equals(lastField, "ABC", StringComparison.Ordinal) || string.Equals(lastField, "-1", StringComparison.Ordinal), $"Last field was '{lastField}'");
                     break;
                 }
             }
@@ -418,7 +418,7 @@ namespace Zipper
                 {
                     string modified = engine.Intercept(i, line, "IMG001");
                     var parts = modified.Split(',');
-                    Assert.Contains("invalid", parts[2]);
+                    Assert.Contains("invalid", parts[2], StringComparison.Ordinal);
                     break;
                 }
             }
@@ -444,7 +444,7 @@ namespace Zipper
                 if (engine.ShouldIntercept(i))
                 {
                     string modified = engine.Intercept(i, line, "IMG001");
-                    Assert.StartsWith(",VOL001", modified);
+                    Assert.StartsWith(",VOL001", modified, StringComparison.Ordinal);
                     break;
                 }
             }
@@ -516,7 +516,7 @@ namespace Zipper
                 eol: "\r\n",
                 seed: 42));
 
-            Assert.Contains("Chaos Engine requires a positive totalLines count", ex.Message);
+            Assert.Contains("Chaos Engine requires a positive totalLines count", ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -663,7 +663,7 @@ namespace Zipper
             Assert.Equal(10, interceptedCount);
             Assert.True(engine.Anomalies.Count > 0);
 
-            var types = engine.Anomalies.Select(a => a.ErrorType).Distinct().ToList();
+            var types = engine.Anomalies.Select(a => a.ErrorType).Distinct(StringComparer.Ordinal).ToList();
             Assert.True(
                 types.Count >= 2,
                 $"Expected at least 2 distinct anomaly types with all types enabled, got {types.Count}: {string.Join(", ", types)}");
@@ -700,7 +700,7 @@ namespace Zipper
             // Every numeric line number in Anomalies must be an intercepted line
             foreach (var anomaly in engine.Anomalies)
             {
-                if (long.TryParse(anomaly.LineNumber, out var lineNum))
+                if (long.TryParse(anomaly.LineNumber, System.Globalization.CultureInfo.InvariantCulture, out var lineNum))
                 {
                     Assert.Contains(lineNum, interceptedLines);
                 }
@@ -736,7 +736,7 @@ namespace Zipper
             }
 
             var anomalyLines = engine.Anomalies
-                .Select(a => long.TryParse(a.LineNumber, out var n) ? (long?)n : null)
+                .Select(a => long.TryParse(a.LineNumber, System.Globalization.CultureInfo.InvariantCulture, out var n) ? (long?)n : null)
                 .Where(n => n.HasValue)
                 .Select(n => n!.Value)
                 .ToHashSet();

--- a/src/Zipper.Tests/ChaosScenarioTests.cs
+++ b/src/Zipper.Tests/ChaosScenarioTests.cs
@@ -16,7 +16,7 @@ public class ChaosScenarioTests
             using var errWriter = new StringWriter();
             Console.SetOut(outWriter);
             Console.SetError(errWriter);
-            int exitCode = await Program.Main(args);
+            int exitCode = await Program.Main(args).ConfigureAwait(false);
             return (exitCode, outWriter.ToString(), errWriter.ToString());
         }
         finally
@@ -33,7 +33,7 @@ public class ChaosScenarioTests
         var scenario = ChaosScenarios.GetByName("structured-import-failures");
         Assert.NotNull(scenario);
         Assert.Equal("structured-import-failures", scenario.Name);
-        Assert.Contains("mixed-delimiters", scenario.ChaosTypes);
+        Assert.Contains("mixed-delimiters", scenario.ChaosTypes, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -138,9 +138,9 @@ public class ChaosScenarioTests
     {
         var (exitCode, stdout, _) = await RunWithCapture(new[] { "--chaos-list" });
         Assert.Equal(0, exitCode);
-        Assert.Contains("Available Chaos Scenarios", stdout);
-        Assert.Contains("structured-import-failures", stdout);
-        Assert.Contains("full-chaos", stdout);
+        Assert.Contains("Available Chaos Scenarios", stdout, StringComparison.Ordinal);
+        Assert.Contains("structured-import-failures", stdout, StringComparison.Ordinal);
+        Assert.Contains("full-chaos", stdout, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class ChaosScenarioTests
                 "--chaos-scenario", "structured-import-failures",
             });
             Assert.Equal(1, exitCode);
-            Assert.Contains("--chaos-scenario requires --chaos-mode", stderr);
+            Assert.Contains("--chaos-scenario requires --chaos-mode", stderr, StringComparison.Ordinal);
         }
         finally
         {
@@ -179,7 +179,7 @@ public class ChaosScenarioTests
                 "--chaos-types", "quotes",
             });
             Assert.Equal(1, exitCode);
-            Assert.Contains("conflicts with --chaos-types", stderr);
+            Assert.Contains("conflicts with --chaos-types", stderr, StringComparison.Ordinal);
         }
         finally
         {
@@ -202,7 +202,7 @@ public class ChaosScenarioTests
                 "--chaos-mode", "--chaos-scenario", "fake-scenario",
             });
             Assert.Equal(1, exitCode);
-            Assert.Contains("Unknown chaos scenario 'fake-scenario'", stderr);
+            Assert.Contains("Unknown chaos scenario 'fake-scenario'", stderr, StringComparison.Ordinal);
         }
         finally
         {
@@ -226,7 +226,7 @@ public class ChaosScenarioTests
                 "--loadfile-format", "dat",
             });
             Assert.Equal(1, exitCode);
-            Assert.Contains("requires --loadfile-format opt", stderr);
+            Assert.Contains("requires --loadfile-format opt", stderr, StringComparison.Ordinal);
         }
         finally
         {
@@ -249,7 +249,7 @@ public class ChaosScenarioTests
                 "--chaos-mode", "--chaos-scenario", "structured-import-failures", "--seed", "42",
             });
             Assert.Equal(0, exitCode);
-            Assert.Contains("Chaos Scenario: structured-import-failures", stdout);
+            Assert.Contains("Chaos Scenario: structured-import-failures", stdout, StringComparison.Ordinal);
 
             // Verify load file was created
             var datFiles = Directory.GetFiles(tempPath, "*.dat");
@@ -267,7 +267,7 @@ public class ChaosScenarioTests
 
             // Verify anomaly types match scenario (mixed-delimiters, quotes, columns)
             var anomalies = chaosMode.GetProperty("injectedAnomalies");
-            var errorTypes = new HashSet<string>();
+            var errorTypes = new HashSet<string>(StringComparer.Ordinal);
             foreach (var anomaly in anomalies.EnumerateArray())
             {
                 errorTypes.Add(anomaly.GetProperty("errorType").GetString()!);
@@ -276,7 +276,7 @@ public class ChaosScenarioTests
             // Should only contain types from the structured-import-failures scenario
             Assert.Subset(
                 errorTypes,
-                new HashSet<string> { "mixed-delimiters", "quotes", "columns" });
+                new HashSet<string>(StringComparer.Ordinal) { "mixed-delimiters", "quotes", "columns" });
         }
         finally
         {
@@ -366,7 +366,7 @@ public class ChaosScenarioTests
                 "--chaos-mode", "--chaos-scenario", "broken-boundaries", "--seed", "42",
             });
             Assert.Equal(0, exitCode);
-            Assert.Contains("Chaos Scenario: broken-boundaries", stdout);
+            Assert.Contains("Chaos Scenario: broken-boundaries", stdout, StringComparison.Ordinal);
 
             var optFiles = Directory.GetFiles(tempPath, "*.opt");
             Assert.Single(optFiles);

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -95,7 +95,7 @@ namespace Zipper
         public void ValidateAndParseArguments_WithEmptyArgs_ShouldReturnNull()
         {
             // Arrange
-            var args = new string[0];
+            var args = Array.Empty<string>();
 
             // Act
             var result = Cli.Pipeline.Build(args);
@@ -379,7 +379,7 @@ namespace Zipper
                 // Assert
                 Assert.Null(result);
                 var output = errorOutput.ToString();
-                Assert.Contains("Error: Invalid TIFF pages range", output);
+                Assert.Contains("Error: Invalid TIFF pages range", output, StringComparison.Ordinal);
             }
             finally
             {
@@ -425,7 +425,7 @@ namespace Zipper
                 // Assert
                 Assert.Null(result);
                 var output = errorOutput.ToString();
-                Assert.Contains("Error: Invalid load file format", output);
+                Assert.Contains("Error: Invalid load file format", output, StringComparison.Ordinal);
             }
             finally
             {
@@ -493,7 +493,7 @@ namespace Zipper
                 // Assert
                 Assert.NotNull(result); // The valid args should still parse into a valid request
                 var output = errorOutput.ToString();
-                Assert.Contains("Warning: Unknown argument or unconsumed value '--unknown-arg' ignored.", output);
+                Assert.Contains("Warning: Unknown argument or unconsumed value '--unknown-arg' ignored.", output, StringComparison.Ordinal);
             }
             finally
             {
@@ -685,7 +685,7 @@ namespace Zipper
                 // Assert
                 Assert.Null(result);
                 var output = errorOutput.ToString();
-                Assert.Contains("--count must be a positive number", output);
+                Assert.Contains("--count must be a positive number", output, StringComparison.Ordinal);
             }
             finally
             {
@@ -712,7 +712,7 @@ namespace Zipper
                 // Assert
                 Assert.Null(result);
                 var output = errorOutput.ToString();
-                Assert.Contains("--count must be a positive number", output);
+                Assert.Contains("--count must be a positive number", output, StringComparison.Ordinal);
             }
             finally
             {
@@ -739,7 +739,7 @@ namespace Zipper
                 // Assert
                 Assert.Null(result);
                 var output = errorOutput.ToString();
-                Assert.Contains("--count must not exceed", output);
+                Assert.Contains("--count must not exceed", output, StringComparison.Ordinal);
             }
             finally
             {

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -409,7 +409,7 @@ namespace Zipper.Tests
                     var result = CliValidator.Validate(args);
                     Assert.True(result);
                     var output = errWriter.ToString();
-                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
                 }
                 finally
                 {
@@ -436,7 +436,7 @@ namespace Zipper.Tests
                     var result = CliValidator.Validate(args);
                     Assert.True(result);
                     var output = errWriter.ToString();
-                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                    Assert.Contains("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
                 }
                 finally
                 {
@@ -463,7 +463,7 @@ namespace Zipper.Tests
                     var result = CliValidator.Validate(args);
                     Assert.True(result);
                     var output = errWriter.ToString();
-                    Assert.DoesNotContain("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output);
+                    Assert.DoesNotContain("Warning: --with-families is only meaningful when --type eml and --attachment-rate > 0 are specified.", output, StringComparison.Ordinal);
                 }
                 finally
                 {
@@ -489,7 +489,7 @@ namespace Zipper.Tests
                     var result = CliValidator.Validate(args);
                     Assert.True(result);
                     var output = errWriter.ToString();
-                    Assert.Contains("Warning: --with-families has no effect in --loadfile-only mode.", output);
+                    Assert.Contains("Warning: --with-families has no effect in --loadfile-only mode.", output, StringComparison.Ordinal);
                 }
                 finally
                 {

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable RS0030 // Do not use banned APIs
 using System.Text.Json;
 using Xunit;
 using Zipper.Profiles;
@@ -48,7 +49,7 @@ namespace Zipper
                     new ColumnDefinition { Name = "DocID", Type = "identifier" },
                     new ColumnDefinition { Name = "Title", Type = "text" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             var filePath = Path.Combine(this.tempDir, "test-profile.json");
@@ -114,7 +115,7 @@ namespace Zipper
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.LoadFromFile(filePath));
 
-            Assert.Contains("Invalid JSON", exception.Message);
+            Assert.Contains("Invalid JSON", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -129,7 +130,7 @@ namespace Zipper
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.LoadFromFile(filePath));
 
-            Assert.Contains("Failed to parse", exception.Message);
+            Assert.Contains("Failed to parse", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -144,7 +145,7 @@ namespace Zipper
                     new ColumnDefinition { Name = "DocID", Type = "identifier" },
                     new ColumnDefinition { Name = "Text", Type = "text" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert - Should not throw
@@ -162,14 +163,14 @@ namespace Zipper
                 {
                     new ColumnDefinition { Name = "ID", Type = "identifier" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("must have a name", exception.Message);
+            Assert.Contains("must have a name", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -180,14 +181,14 @@ namespace Zipper
             {
                 Name = "NoColumnsProfile",
                 Columns = new List<ColumnDefinition>(),
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("at least one column", exception.Message);
+            Assert.Contains("at least one column", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -198,14 +199,14 @@ namespace Zipper
             {
                 Name = "NullColumnsProfile",
                 Columns = null!,
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("at least one column", exception.Message);
+            Assert.Contains("at least one column", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -226,7 +227,7 @@ namespace Zipper
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("DataSources dictionary", exception.Message);
+            Assert.Contains("DataSources dictionary", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -247,14 +248,14 @@ namespace Zipper
             {
                 Name = "TooManyColumnsProfile",
                 Columns = columns,
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("exceeds maximum of 200", exception.Message);
+            Assert.Contains("exceeds maximum of 200", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -269,14 +270,14 @@ namespace Zipper
                     new ColumnDefinition { Name = "ID", Type = "identifier" },
                     new ColumnDefinition { Name = "ID", Type = "text" }, // Duplicate!
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("Duplicate column name", exception.Message);
+            Assert.Contains("Duplicate column name", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -291,14 +292,14 @@ namespace Zipper
                     new ColumnDefinition { Name = "ID", Type = "identifier" },
                     new ColumnDefinition { Name = string.Empty, Type = "text" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("null or empty name", exception.Message);
+            Assert.Contains("null or empty name", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -313,14 +314,14 @@ namespace Zipper
                     new ColumnDefinition { Name = "Text1", Type = "text" },
                     new ColumnDefinition { Name = "Text2", Type = "text" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("'identifier' type column", exception.Message);
+            Assert.Contains("'identifier' type column", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -340,14 +341,14 @@ namespace Zipper
                         DataSource = "categories", // References undefined data source
                     },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(), // Empty!
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal), // Empty!
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("undefined data source", exception.Message);
+            Assert.Contains("undefined data source", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -362,14 +363,14 @@ namespace Zipper
                     new ColumnDefinition { Name = "ID", Type = "identifier" },
                     new ColumnDefinition { Name = "Invalid", Type = "invalid_type" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("invalid type", exception.Message);
+            Assert.Contains("invalid type", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -389,14 +390,14 @@ namespace Zipper
                         EmptyPercentage = 150, // Invalid: > 100
                     },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("invalid emptyPercentage", exception.Message);
+            Assert.Contains("invalid emptyPercentage", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -416,14 +417,14 @@ namespace Zipper
                         TruePercentage = -10, // Invalid: < 0
                     },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("invalid truePercentage", exception.Message);
+            Assert.Contains("invalid truePercentage", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -454,8 +455,8 @@ namespace Zipper
             });
 
             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
-            Assert.Contains("BadDate", ex.Message);
-            Assert.Contains("DateRange.Min", ex.Message);
+            Assert.Contains("BadDate", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("DateRange.Min", ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -470,8 +471,8 @@ namespace Zipper
             });
 
             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
-            Assert.Contains("BadMax", ex.Message);
-            Assert.Contains("DateRange.Max", ex.Message);
+            Assert.Contains("BadMax", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("DateRange.Max", ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -486,8 +487,8 @@ namespace Zipper
             });
 
             var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
-            Assert.Contains("Inverted", ex.Message);
-            Assert.Contains("greater than", ex.Message);
+            Assert.Contains("Inverted", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("greater than", ex.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -547,8 +548,8 @@ namespace Zipper
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("testDS", exception.Message);
-            Assert.Contains("more weights than values", exception.Message);
+            Assert.Contains("testDS", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("more weights than values", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -567,8 +568,8 @@ namespace Zipper
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 ColumnProfileLoader.Validate(profile));
 
-            Assert.Contains("testDS", exception.Message);
-            Assert.Contains("more weights than values", exception.Message);
+            Assert.Contains("testDS", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("more weights than values", exception.Message, StringComparison.Ordinal);
         }
 
         private static ColumnProfile CreateMinimalProfile()
@@ -580,7 +581,7 @@ namespace Zipper
                 {
                     new() { Name = "DOCID", Type = "identifier" },
                 },
-                DataSources = new Dictionary<string, DataSourceConfig>(),
+                DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             };
         }
     }

--- a/src/Zipper.Tests/ColumnProfileTests.cs
+++ b/src/Zipper.Tests/ColumnProfileTests.cs
@@ -19,9 +19,9 @@ public class ColumnProfileTests
 
         Assert.Equal("minimal", profile.Name);
         Assert.Equal(5, profile.Columns.Count);
-        Assert.Contains(profile.Columns, c => c.Name == "DOCID");
-        Assert.Contains(profile.Columns, c => c.Name == "FILEPATH");
-        Assert.Contains(profile.Columns, c => c.Name == "CUSTODIAN");
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "DOCID", StringComparison.Ordinal));
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "FILEPATH", StringComparison.Ordinal));
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "CUSTODIAN", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -34,9 +34,9 @@ public class ColumnProfileTests
 
         Assert.Equal("standard", profile.Name);
         Assert.Equal(24, profile.Columns.Count);
-        Assert.Contains(profile.Columns, c => c.Name == "BEGBATES");
-        Assert.Contains(profile.Columns, c => c.Name == "EMAILFROM");
-        Assert.Contains(profile.Columns, c => c.Name == "RESPONSIVE");
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "BEGBATES", StringComparison.Ordinal));
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "EMAILFROM", StringComparison.Ordinal));
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "RESPONSIVE", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -49,8 +49,8 @@ public class ColumnProfileTests
 
         Assert.Equal("litigation", profile.Name);
         Assert.Equal(48, profile.Columns.Count);
-        Assert.Contains(profile.Columns, c => c.Name == "MD5HASH");
-        Assert.Contains(profile.Columns, c => c.Name == "PRIVILEGE");
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "MD5HASH", StringComparison.Ordinal));
+        Assert.Contains(profile.Columns, c => string.Equals(c.Name, "PRIVILEGE", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public class ColumnProfileTests
         var profile = BuiltInProfiles.GetProfile(profileName);
 
         Assert.NotNull(profile);
-        Assert.Contains(profile.Columns, c => c.Type == "identifier");
+        Assert.Contains(profile.Columns, c => string.Equals(c.Type, "identifier", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/src/Zipper.Tests/CsvLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/CsvLoadFileWriterTests.cs
@@ -9,10 +9,10 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
     {
         var writer = new CsvComposingWriter();
         using var stream = new MemoryStream();
-        await writer.WriteAsync(stream, request, files);
+        await writer.WriteAsync(stream, request, files).ConfigureAwait(false);
         stream.Position = 0;
         using var reader = new StreamReader(stream);
-        return await reader.ReadToEndAsync();
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
     }
 
     [Fact]
@@ -32,8 +32,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(4, lines.Length);
-        Assert.Contains("CONTROL NUMBER", lines[0]);
-        Assert.Contains("DOC00000001", lines[1]);
+        Assert.Contains("CONTROL NUMBER", lines[0], StringComparison.Ordinal);
+        Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
 
         var content = await File.ReadAllTextAsync(outputPath);
 
-        Assert.Contains("\"\"", content);
+        Assert.Contains("\"\"", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -72,8 +72,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var request = this.CreateTestRequest();
         var files = this.CreateTestFileData(2);
         var content = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("DOC00000001", content);
-        Assert.Contains("DOC00000002", content);
+        Assert.Contains("DOC00000001", content, StringComparison.Ordinal);
+        Assert.Contains("DOC00000002", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var files = this.CreateTestFileData(1);
         files[0] = files[0] with { WorkItem = files[0].WorkItem with { FilePathInZip = "folder_001/file_00000001.pdf" } };
         var content = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("folder_001/file_00000001.txt", content);
+        Assert.Contains("folder_001/file_00000001.txt", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -94,16 +94,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         request.Metadata = request.Metadata with { WithMetadata = true };
         var files = this.CreateTestFileData(1);
         var contentWith = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("CUSTODIAN", contentWith);
+        Assert.Contains("CUSTODIAN", contentWith, StringComparison.Ordinal);
 
         request.Metadata = request.Metadata with { WithMetadata = false };
         var contentWithout = await this.CaptureCsvOutput(request, files);
-        Assert.DoesNotContain("CUSTODIAN", contentWithout);
+        Assert.DoesNotContain("CUSTODIAN", contentWithout, StringComparison.Ordinal);
 
         var emlRequest = this.CreateTestRequest("eml");
         emlRequest.Metadata = emlRequest.Metadata with { WithMetadata = false };
         var emlContent = await this.CaptureCsvOutput(emlRequest, files);
-        Assert.Contains("CUSTODIAN", emlContent);
+        Assert.Contains("CUSTODIAN", emlContent, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -133,16 +133,16 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var files = this.CreateTestFileData(1);
         files[0] = files[0] with { PageCount = 5 };
         var contentWith = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("PAGE COUNT", contentWith);
+        Assert.Contains("PAGE COUNT", contentWith, StringComparison.Ordinal);
 
         request.Tiff = request.Tiff with { PageRange = null };
         var contentWithout = await this.CaptureCsvOutput(request, files);
-        Assert.DoesNotContain("PAGE COUNT", contentWithout);
+        Assert.DoesNotContain("PAGE COUNT", contentWithout, StringComparison.Ordinal);
 
         var pdfRequest = this.CreateTestRequest("pdf");
         pdfRequest.Tiff = pdfRequest.Tiff with { PageRange = (1, 10) };
         var pdfContent = await this.CaptureCsvOutput(pdfRequest, files);
-        Assert.DoesNotContain("PAGE COUNT", pdfContent);
+        Assert.DoesNotContain("PAGE COUNT", pdfContent, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var files = this.CreateTestFileData(1);
         files[0] = files[0] with { WorkItem = files[0].WorkItem with { Index = 10 } };
         var content = await this.CaptureCsvOutput(request, files);
-        Assert.Contains("TEST001009", content);
+        Assert.Contains("TEST001009", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -171,8 +171,8 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         files[0] = files[0] with { DataLength = 1024, WorkItem = files[0].WorkItem with { FolderNumber = 5 } };
         var content = await this.CaptureCsvOutput(request, files);
         var dataLine = content.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1];
-        Assert.Contains("Custodian 5", dataLine);
-        Assert.Contains("1024", dataLine);
+        Assert.Contains("Custodian 5", dataLine, StringComparison.Ordinal);
+        Assert.Contains("1024", dataLine, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         Assert.Equal(0xFE, bytes[1]);
 
         var content = await File.ReadAllTextAsync(outputPath, System.Text.Encoding.Unicode);
-        Assert.Contains("CONTROL NUMBER", content);
+        Assert.Contains("CONTROL NUMBER", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -232,6 +232,6 @@ public class CsvLoadFileWriterTests : TempDirectoryTestBase
         var content = encoding.GetString(bytes);
         var roundTripBytes = encoding.GetBytes(content);
         Assert.Equal(bytes, roundTripBytes);
-        Assert.Contains("CONTROL NUMBER", content);
+        Assert.Contains("CONTROL NUMBER", content, StringComparison.Ordinal);
     }
 }

--- a/src/Zipper.Tests/DatLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/DatLoadFileWriterTests.cs
@@ -34,10 +34,10 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(6, lines.Length);
-        Assert.Contains("Control Number", lines[0]);
-        Assert.Contains("File Path", lines[0]);
-        Assert.Contains("EmailSubject", lines[0]);
-        Assert.Contains("ExtractedText", lines[0]);
+        Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
+        Assert.Contains("File Path", lines[0], StringComparison.Ordinal);
+        Assert.Contains("EmailSubject", lines[0], StringComparison.Ordinal);
+        Assert.Contains("ExtractedText", lines[0], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -113,11 +113,11 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(6, lines.Length);
-        Assert.Contains("DOCID", lines[0]);
-        Assert.Contains("BATES_NUMBER", lines[0]);
-        Assert.Contains("NATIVE_PATH", lines[0]);
-        Assert.Contains("IMAGE_PATH", lines[0]);
-        Assert.Contains("\r\n", content);
+        Assert.Contains("DOCID", lines[0], StringComparison.Ordinal);
+        Assert.Contains("BATES_NUMBER", lines[0], StringComparison.Ordinal);
+        Assert.Contains("NATIVE_PATH", lines[0], StringComparison.Ordinal);
+        Assert.Contains("IMAGE_PATH", lines[0], StringComparison.Ordinal);
+        Assert.Contains("\r\n", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class DatLoadFileWriterTests : TempDirectoryTestBase
         stream.Position = 0;
         var content = Encoding.UTF8.GetString(stream.ToArray());
 
-        Assert.Contains("\r\n", content);
+        Assert.Contains("\r\n", content, StringComparison.Ordinal);
     }
 
 

--- a/src/Zipper.Tests/DatWriterTests.cs
+++ b/src/Zipper.Tests/DatWriterTests.cs
@@ -15,9 +15,9 @@ namespace Zipper
             var (_, lines) = await WriteAndCapture(DefaultRequest(), []);
             var header = lines[0];
 
-            Assert.Contains("Control Number", header);
-            Assert.Contains("File Path", header);
-            Assert.DoesNotContain("Custodian", header);
+            Assert.Contains("Control Number", header, StringComparison.Ordinal);
+            Assert.Contains("File Path", header, StringComparison.Ordinal);
+            Assert.DoesNotContain("Custodian", header, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -26,10 +26,10 @@ namespace Zipper
             var request = DefaultRequest();
             request.Metadata = request.Metadata with { WithMetadata = true };
             var output = await WriteAndCaptureOutput(request, []);
-            Assert.Contains("Custodian", output);
-            Assert.Contains("Date Sent", output);
-            Assert.Contains("Author", output);
-            Assert.Contains("File Size", output);
+            Assert.Contains("Custodian", output, StringComparison.Ordinal);
+            Assert.Contains("Date Sent", output, StringComparison.Ordinal);
+            Assert.Contains("Author", output, StringComparison.Ordinal);
+            Assert.Contains("File Size", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -38,11 +38,11 @@ namespace Zipper
             var request = DefaultRequest();
             request.Output = request.Output with { FileType = "eml" };
             var output = await WriteAndCaptureOutput(request, []);
-            Assert.Contains("To", output);
-            Assert.Contains("From", output);
-            Assert.Contains("Subject", output);
-            Assert.Contains("Sent Date", output);
-            Assert.Contains("Attachment", output);
+            Assert.Contains("To", output, StringComparison.Ordinal);
+            Assert.Contains("From", output, StringComparison.Ordinal);
+            Assert.Contains("Subject", output, StringComparison.Ordinal);
+            Assert.Contains("Sent Date", output, StringComparison.Ordinal);
+            Assert.Contains("Attachment", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Zipper
                 Increment = 1,
             };
             var output = await WriteAndCaptureOutput(request, []);
-            Assert.Contains("Bates Number", output);
+            Assert.Contains("Bates Number", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Zipper
             request.Output = request.Output with { FileType = "tiff" };
             request.Tiff = request.Tiff with { PageRange = (1, 10) };
             var output = await WriteAndCaptureOutput(request, []);
-            Assert.Contains("Page Count", output);
+            Assert.Contains("Page Count", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Zipper
             var request = DefaultRequest();
             request.Output = request.Output with { WithText = true };
             var output = await WriteAndCaptureOutput(request, []);
-            Assert.Contains("Extracted Text", output);
+            Assert.Contains("Extracted Text", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -86,8 +86,8 @@ namespace Zipper
             var files = new List<FileData> { MakeFileData(1), MakeFileData(2) };
             var (_, lines) = await WriteAndCapture(request, files);
             Assert.Equal(3, lines.Length);
-            Assert.Contains("DOC00000001", lines[1]);
-            Assert.Contains("DOC00000002", lines[2]);
+            Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
+            Assert.Contains("DOC00000002", lines[2], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -98,8 +98,8 @@ namespace Zipper
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains("Custodian 1", output);
-            Assert.Contains("File Size", output);
+            Assert.Contains("Custodian 1", output, StringComparison.Ordinal);
+            Assert.Contains("File Size", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -133,10 +133,10 @@ namespace Zipper
             };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains("test@example.com", output);
-            Assert.Contains("sender@example.com", output);
-            Assert.Contains("Test Subject", output);
-            Assert.Contains("2026-01-15", output);
+            Assert.Contains("test@example.com", output, StringComparison.Ordinal);
+            Assert.Contains("sender@example.com", output, StringComparison.Ordinal);
+            Assert.Contains("Test Subject", output, StringComparison.Ordinal);
+            Assert.Contains("2026-01-15", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace Zipper
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains("DOC000100", output);
+            Assert.Contains("DOC000100", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Zipper
 
             var output = await WriteAndCaptureOutput(request, files);
             var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
-            Assert.EndsWith("þ3þ", dataLine);
+            Assert.EndsWith("þ3þ", dataLine, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace Zipper
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains(".txt", output);
+            Assert.Contains(".txt", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -243,8 +243,8 @@ namespace Zipper
             };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains("recipient1@example.com", output);
-            Assert.Contains("sender1@example.com", output);
+            Assert.Contains("recipient1@example.com", output, StringComparison.Ordinal);
+            Assert.Contains("sender1@example.com", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Zipper
             var files = new List<FileData> { MakeFileData(1) };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.Contains("þ", output);
+            Assert.Contains("þ", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -283,8 +283,8 @@ namespace Zipper
             };
 
             var output = await WriteAndCaptureOutput(request, files);
-            Assert.DoesNotContain("line1\r\nline2", output);
-            Assert.Contains("line1®line2", output);
+            Assert.DoesNotContain("line1\r\nline2", output, StringComparison.Ordinal);
+            Assert.Contains("line1®line2", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace Zipper
 
             var output = await WriteAndCaptureOutput(request, files);
             var dataLine = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
-            Assert.Contains("line1®line2", dataLine);
+            Assert.Contains("line1®line2", dataLine, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -334,9 +334,9 @@ namespace Zipper
             var header = lines[0];
 
             // With no quote delimiter, fields must NOT be wrapped in any quote character
-            Assert.DoesNotContain("þ", header);
-            Assert.Contains("Control Number", header);
-            Assert.Contains("File Path", header);
+            Assert.DoesNotContain("þ", header, StringComparison.Ordinal);
+            Assert.Contains("Control Number", header, StringComparison.Ordinal);
+            Assert.Contains("File Path", header, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -350,8 +350,8 @@ namespace Zipper
             var dataRow = lines[1];
 
             // DOC00000001 must appear unquoted — no þ wrapper
-            Assert.DoesNotContain("þ", dataRow);
-            Assert.Contains("DOC00000001", dataRow);
+            Assert.DoesNotContain("þ", dataRow, StringComparison.Ordinal);
+            Assert.Contains("DOC00000001", dataRow, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -365,8 +365,8 @@ namespace Zipper
             var output = await WriteAndCaptureOutput(request, files);
 
             // Metadata columns (Custodian, Date Sent, Author, File Size) must appear unquoted
-            Assert.DoesNotContain("þ", output);
-            Assert.Contains("Custodian", output);
+            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
+            Assert.Contains("Custodian", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -380,8 +380,8 @@ namespace Zipper
             var output = await WriteAndCaptureOutput(request, files);
 
             // Extracted Text column must appear unquoted
-            Assert.DoesNotContain("þ", output);
-            Assert.Contains(".txt", output);
+            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
+            Assert.Contains(".txt", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -395,8 +395,8 @@ namespace Zipper
             var output = await WriteAndCaptureOutput(request, files);
 
             // Bates Number column must appear unquoted
-            Assert.DoesNotContain("þ", output);
-            Assert.Contains("TEST", output);
+            Assert.DoesNotContain("þ", output, StringComparison.Ordinal);
+            Assert.Contains("TEST", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace Zipper
         {
             using var stream = new MemoryStream();
             var writer = new DatComposingWriter();
-            await writer.WriteAsync(stream, request, files);
+            await writer.WriteAsync(stream, request, files).ConfigureAwait(false);
 
             var output = Encoding.UTF8.GetString(stream.ToArray());
             var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -423,7 +423,7 @@ namespace Zipper
 
         private static async Task<string> WriteAndCaptureOutput(FileGenerationRequest request, List<FileData> files)
         {
-            var (output, _) = await WriteAndCapture(request, files);
+            var (output, _) = await WriteAndCapture(request, files).ConfigureAwait(false);
             return output;
         }
 
@@ -493,7 +493,7 @@ namespace Zipper
             Assert.All(chaosEngine.Anomalies, a => Assert.Equal("quotes", a.ErrorType));
 
             var anomaly = chaosEngine.Anomalies.First();
-            Assert.Contains("Omitted the closing", anomaly.Description);
+            Assert.Contains("Omitted the closing", anomaly.Description, StringComparison.Ordinal);
             Assert.NotEqual("N/A", anomaly.Column);
 
             var baseQuoteCount = baseOutput.Count(c => c == '\u00fe');
@@ -532,7 +532,7 @@ namespace Zipper
             Assert.True(chaosOutput.Contains(",") || chaosOutput.Contains("\t") || chaosOutput.Contains("|"), "Should contain alternative delimiters");
 
             var anomaly = chaosEngine.Anomalies.First();
-            Assert.Contains("Replaced delimiter", anomaly.Description);
+            Assert.Contains("Replaced delimiter", anomaly.Description, StringComparison.Ordinal);
             Assert.NotEqual("N/A", anomaly.Column);
 
             var baseDelimCount = baseOutput.Count(c => c == '\u0014');
@@ -714,7 +714,7 @@ namespace Zipper
             Assert.All(chaosEngine.Anomalies, a => Assert.Equal("quotes", a.ErrorType));
 
             var anomaly = chaosEngine.Anomalies.First();
-            Assert.Contains("Omitted the closing", anomaly.Description);
+            Assert.Contains("Omitted the closing", anomaly.Description, StringComparison.Ordinal);
             Assert.NotEqual("N/A", anomaly.Column);
 
             var baseQuoteCount = baseOutput.Count(c => c == '\u00fe');
@@ -772,8 +772,8 @@ namespace Zipper
 
             // The output should have anomalies injected for line 1 and line 4 (among others).
             // This means there should be anomalies in the Audit log specifically for Boundary 1-2 and Boundary 4-5.
-            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
-            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
+            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 1-2", StringComparison.Ordinal));
+            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 4-5", StringComparison.Ordinal));
 
             Assert.NotNull(headerAnomaly);
             Assert.NotNull(lastLineAnomaly);
@@ -796,10 +796,10 @@ namespace Zipper
             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             Assert.Equal(4, lines.Length);
-            Assert.Contains("Control Number", lines[0]);
-            Assert.Contains("DOC00000001", lines[1]);
-            Assert.Contains("DOC00000002", lines[2]);
-            Assert.Contains("DOC00000003", lines[3]);
+            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
+            Assert.Contains("DOC00000001", lines[1], StringComparison.Ordinal);
+            Assert.Contains("DOC00000002", lines[2], StringComparison.Ordinal);
+            Assert.Contains("DOC00000003", lines[3], StringComparison.Ordinal);
         }
 
         [Theory]
@@ -832,7 +832,7 @@ namespace Zipper
             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(lines.Length >= 2);
-            Assert.Contains("Control Number", lines[0]);
+            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -862,7 +862,7 @@ namespace Zipper
 
             var output = await File.ReadAllTextAsync(outputPath);
 
-            Assert.Contains("folderþþX/file.pdf", output);
+            Assert.Contains("folderþþX/file.pdf", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -905,7 +905,7 @@ namespace Zipper
             stream.Position = 0;
             var output = Encoding.UTF8.GetString(stream.ToArray());
 
-            Assert.Contains("fileþþX.pdf", output);
+            Assert.Contains("fileþþX.pdf", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -941,17 +941,17 @@ namespace Zipper
             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             Assert.Equal(3, lines.Length);
-            Assert.Contains("BEGATTACH", lines[0]);
-            Assert.Contains("ENDATTACH", lines[0]);
-            Assert.Contains("PARENTDOCID", lines[0]);
+            Assert.Contains("BEGATTACH", lines[0], StringComparison.Ordinal);
+            Assert.Contains("ENDATTACH", lines[0], StringComparison.Ordinal);
+            Assert.Contains("PARENTDOCID", lines[0], StringComparison.Ordinal);
 
             var parentLine = lines[1];
-            Assert.Contains("DOC00000001", parentLine);
-            Assert.Contains("DOC00000001_A001", parentLine);
+            Assert.Contains("DOC00000001", parentLine, StringComparison.Ordinal);
+            Assert.Contains("DOC00000001_A001", parentLine, StringComparison.Ordinal);
 
             var childLine = lines[2];
-            Assert.Contains("DOC00000001_A001", childLine);
-            Assert.Contains("DOC00000001", childLine);
+            Assert.Contains("DOC00000001_A001", childLine, StringComparison.Ordinal);
+            Assert.Contains("DOC00000001", childLine, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -998,15 +998,15 @@ namespace Zipper
             var lines = content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
 
             Assert.Equal(3, lines.Length);
-            Assert.Contains("BEGATTACH", lines[0]);
-            Assert.Contains("ENDATTACH", lines[0]);
-            Assert.Contains("PARENTDOCID", lines[0]);
+            Assert.Contains("BEGATTACH", lines[0], StringComparison.Ordinal);
+            Assert.Contains("ENDATTACH", lines[0], StringComparison.Ordinal);
+            Assert.Contains("PARENTDOCID", lines[0], StringComparison.Ordinal);
 
-            Assert.Contains("TEST00000001", lines[1]);
-            Assert.Contains("TEST00000001_A001", lines[1]);
+            Assert.Contains("TEST00000001", lines[1], StringComparison.Ordinal);
+            Assert.Contains("TEST00000001_A001", lines[1], StringComparison.Ordinal);
 
-            Assert.Contains("TEST00000001_A001", lines[2]);
-            Assert.Contains("TEST00000001", lines[2]);
+            Assert.Contains("TEST00000001_A001", lines[2], StringComparison.Ordinal);
+            Assert.Contains("TEST00000001", lines[2], StringComparison.Ordinal);
         }
     }
 }

--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -109,7 +109,7 @@ public class DataGeneratorTests
         // ISRESPONSIVE is a boolean column with Format = "YN"
         var responsiveValue = row["ISRESPONSIVE"];
         Assert.True(
-            responsiveValue == "Y" || responsiveValue == "N" || string.IsNullOrEmpty(responsiveValue),
+string.Equals(responsiveValue, "Y", StringComparison.Ordinal) || string.Equals(responsiveValue, "N", StringComparison.Ordinal) || string.IsNullOrEmpty(responsiveValue),
             $"Expected Y, N, or empty but got {responsiveValue}");
     }
 
@@ -151,8 +151,8 @@ public class DataGeneratorTests
         var emailValue = row["EMAILFROM"];
         if (!string.IsNullOrEmpty(emailValue))
         {
-            Assert.Contains("@", emailValue);
-            Assert.Contains(".", emailValue);
+            Assert.Contains("@", emailValue, StringComparison.Ordinal);
+            Assert.Contains(".", emailValue, StringComparison.Ordinal);
         }
     }
 
@@ -199,7 +199,7 @@ public class DataGeneratorTests
             var emailToValue = row["EMAILTO"];
             if (!string.IsNullOrEmpty(emailToValue) && emailToValue.Contains(delimiter))
             {
-                Assert.Contains(delimiter, emailToValue);
+                Assert.Contains(delimiter, emailToValue, StringComparison.Ordinal);
                 var parts = emailToValue.Split(delimiter);
                 Assert.True(parts.Length >= 2);
                 return;
@@ -224,7 +224,7 @@ public class DataGeneratorTests
 
         var fileSizeValue = row["FILESIZE"];
         Assert.True(
-            long.TryParse(fileSizeValue, out var size),
+            long.TryParse(fileSizeValue, System.Globalization.CultureInfo.InvariantCulture, out var size),
             $"Expected valid number but got {fileSizeValue}");
         Assert.True(size >= 0, "File size should be non-negative");
     }
@@ -239,6 +239,7 @@ public class DataGeneratorTests
         {
             Name = "test-every-kind",
             DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
             {
                 ["statusValues"] = new DataSourceConfig { Values = ["Active", "Inactive", "Pending", "Closed", "Archived"] },
                 ["categoryValues"] = new DataSourceConfig { Values = ["CategoryA", "CategoryB", "CategoryC", "CategoryD"], Weights = [40, 30, 20, 10] },
@@ -258,8 +259,8 @@ public class DataGeneratorTests
             },
         };
         var generator = new DataGenerator(profile, seed: 42);
-        var validCoded = new HashSet<string> { "Active", "Inactive", "Pending", "Closed", "Archived" };
-        var validBool = new HashSet<string> { "Y", "N" };
+        var validCoded = new HashSet<string>(StringComparer.Ordinal) { "Active", "Inactive", "Pending", "Closed", "Archived" };
+        var validBool = new HashSet<string>(StringComparer.Ordinal) { "Y", "N" };
 
         for (int i = 1; i <= 200; i++)
         {
@@ -281,13 +282,13 @@ public class DataGeneratorTests
             // datetime: ISO 8601 with time component
             if (!string.IsNullOrEmpty(row["DATETIMEFIELD"]))
             {
-                Assert.Contains("T", row["DATETIMEFIELD"]);
+                Assert.Contains("T", row["DATETIMEFIELD"], StringComparison.Ordinal);
             }
 
             // number: integer in valid range
             if (!string.IsNullOrEmpty(row["NUMBERFIELD"]))
             {
-                Assert.True(int.TryParse(row["NUMBERFIELD"], out var numVal), $"NUMBERFIELD is not an integer: {row["NUMBERFIELD"]}");
+                Assert.True(int.TryParse(row["NUMBERFIELD"], System.Globalization.CultureInfo.InvariantCulture, out var numVal), $"NUMBERFIELD is not an integer: {row["NUMBERFIELD"]}");
                 Assert.InRange(numVal, 0, 10000);
             }
 
@@ -324,7 +325,7 @@ public class DataGeneratorTests
         var profile = new ColumnProfile
         {
             Name = $"test-empty-{emptyPct}",
-            DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>(),
+            DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             Columns = new System.Collections.Generic.List<ColumnDefinition>
             {
                 new() { Name = "DOCID", Type = "identifier", Required = true },
@@ -374,6 +375,7 @@ public class DataGeneratorTests
         {
             Name = "test-weighted-bias",
             DataSources = new System.Collections.Generic.Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
             {
                 ["weightedDS"] = new DataSourceConfig
                 {
@@ -402,11 +404,11 @@ public class DataGeneratorTests
             var row = generator.GenerateRow(workItem, fileData);
 
             var value = row["WEIGHTEDFIELD"];
-            if (value == "A")
+            if (string.Equals(value, "A", StringComparison.Ordinal))
             {
                 aCount++;
             }
-            else if (value == "B")
+            else if (string.Equals(value, "B", StringComparison.Ordinal))
             {
                 bCount++;
             }
@@ -432,9 +434,9 @@ public class DataGeneratorTests
         // Use 500 rows (seeded) to ensure all 3 values appear given pareto distribution.
         var profile = BuiltInProfiles.Standard;
         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 3);
-        var validValues = new HashSet<string> { "Custodian_1", "Custodian_2", "Custodian_3" };
+        var validValues = new HashSet<string>(StringComparer.Ordinal) { "Custodian_1", "Custodian_2", "Custodian_3" };
 
-        var custodianValues = new HashSet<string>();
+        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
 
         for (int i = 1; i <= 500; i++)
         {
@@ -472,7 +474,7 @@ public class DataGeneratorTests
         {
             Name = "no-custodians",
             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-            DataSources = new Dictionary<string, DataSourceConfig>(),
+            DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
             Columns = new List<ColumnDefinition>
             {
                 new() { Name = "DOCID", Type = "identifier", Required = true },
@@ -499,6 +501,7 @@ public class DataGeneratorTests
             Name = "values-custodians",
             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
             DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
             {
                 ["custodians"] = new DataSourceConfig
                 {
@@ -515,7 +518,7 @@ public class DataGeneratorTests
 
         // Override to 2: only "Alice" and "Bob" should ever appear
         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
-        var custodianValues = new HashSet<string>();
+        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
 
         for (int i = 1; i <= 200; i++)
         {
@@ -530,7 +533,7 @@ public class DataGeneratorTests
             $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
         foreach (var v in custodianValues)
         {
-            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value: {v}");
+            Assert.True(string.Equals(v, "Alice", StringComparison.Ordinal) || string.Equals(v, "Bob", StringComparison.Ordinal), $"Unexpected custodian value: {v}");
         }
     }
 
@@ -547,6 +550,7 @@ public class DataGeneratorTests
             Name = "weighted-values-custodians",
             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
             DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
             {
                 ["custodians"] = new DataSourceConfig
                 {
@@ -566,7 +570,7 @@ public class DataGeneratorTests
         // If Weights was NOT truncated, PrecomputeIndices would sum all 5 weights (100)
         // but only 2 values exist, causing index-out-of-range fallback to the last value.
         var generator = new DataGenerator(profile, seed: 42, custodianCountOverride: 2);
-        var custodianValues = new HashSet<string>();
+        var custodianValues = new HashSet<string>(StringComparer.Ordinal);
 
         for (int i = 1; i <= 200; i++)
         {
@@ -581,7 +585,7 @@ public class DataGeneratorTests
             $"Expected at most 2 custodians (Alice, Bob) but got {custodianValues.Count}: {string.Join(", ", custodianValues)}");
         foreach (var v in custodianValues)
         {
-            Assert.True(v == "Alice" || v == "Bob", $"Unexpected custodian value after weight truncation: {v}");
+            Assert.True(string.Equals(v, "Alice", StringComparison.Ordinal) || string.Equals(v, "Bob", StringComparison.Ordinal), $"Unexpected custodian value after weight truncation: {v}");
         }
     }
 
@@ -598,6 +602,7 @@ public class DataGeneratorTests
             Name = "generated-weighted-custodians",
             Settings = new ProfileSettings { EmptyValuePercentage = 0 },
             DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
             {
                 ["custodians"] = new DataSourceConfig
                 {
@@ -628,11 +633,11 @@ public class DataGeneratorTests
             var row = generator.GenerateRow(workItem, fileData);
 
             var value = row["CUSTODIAN"];
-            if (value == "Cust_1")
+            if (string.Equals(value, "Cust_1", StringComparison.Ordinal))
             {
                 cust1Count++;
             }
-            else if (value == "Cust_2")
+            else if (string.Equals(value, "Cust_2", StringComparison.Ordinal))
             {
                 cust2Count++;
             }

--- a/src/Zipper.Tests/Emails/EmailFactoryTests.cs
+++ b/src/Zipper.Tests/Emails/EmailFactoryTests.cs
@@ -51,8 +51,8 @@ namespace Zipper
             // Assert — basic RFC-5321 shape: local@domain
             Assert.Matches(@"^[^@]+@[^@]+\.[^@]+$", template.To);
             Assert.Matches(@"^[^@]+@[^@]+\.[^@]+$", template.From);
-            Assert.Contains($"recipient{recipientIndex:D3}@", template.To);
-            Assert.Contains($"sender{senderIndex:D3}@", template.From);
+            Assert.Contains($"recipient{recipientIndex:D3}@", template.To, StringComparison.Ordinal);
+            Assert.Contains($"sender{senderIndex:D3}@", template.From, StringComparison.Ordinal);
         }
 
         [Theory]
@@ -71,13 +71,13 @@ namespace Zipper
         public void Create_SentDate_WithinCategoryRange(EmailCategory category, int maxDaysAgo)
         {
             // Arrange
-            var now = DateTime.Now;
+            var now = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
             const int iterations = 50;
 
             for (int i = 0; i < iterations; i++)
             {
                 // Act
-                var template = EmailFactory.Create(i, i, category, new Random(i));
+                var template = EmailFactory.Create(i, i, category, new Random(i), now);
 
                 // Assert — date is not absurdly far in the past or future
                 // Allow 2-day buffer for the ±23 hour and ±59 min adjustments
@@ -276,8 +276,8 @@ namespace Zipper
         [Fact]
         public void GenerateEmailAddress_ProducesExpectedFormat()
         {
-            Assert.Contains("recipient042@", EmailFactory.GenerateEmailAddress(42, "recipient"));
-            Assert.Contains("sender001@", EmailFactory.GenerateEmailAddress(1, "sender"));
+            Assert.Contains("recipient042@", EmailFactory.GenerateEmailAddress(42, "recipient"), StringComparison.Ordinal);
+            Assert.Contains("sender001@", EmailFactory.GenerateEmailAddress(1, "sender"), StringComparison.Ordinal);
         }
 
         // Tests redistributed from EmailTemplateSystemTests
@@ -287,14 +287,15 @@ namespace Zipper
             const int recipientIndex = 1;
             const int senderIndex = 2;
 
-            var email = EmailFactory.Create(recipientIndex, senderIndex, null, new Random(42));
+            var now = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var email = EmailFactory.Create(recipientIndex, senderIndex, null, new Random(42), now);
 
             Assert.NotNull(email);
             Assert.False(string.IsNullOrEmpty(email.To));
             Assert.False(string.IsNullOrEmpty(email.From));
             Assert.False(string.IsNullOrEmpty(email.Subject));
             Assert.False(string.IsNullOrEmpty(email.Body));
-            Assert.True(email.SentDate <= DateTime.Now);
+            Assert.True(email.SentDate <= now);
         }
 
         [Theory]
@@ -318,8 +319,8 @@ namespace Zipper
             var email = EmailFactory.Create(recipientIndex, senderIndex, category, new Random(99));
 
             Assert.NotNull(email);
-            Assert.Contains($"recipient{recipientIndex:D3}@", email.To);
-            Assert.Contains($"sender{senderIndex:D3}@", email.From);
+            Assert.Contains($"recipient{recipientIndex:D3}@", email.To, StringComparison.Ordinal);
+            Assert.Contains($"sender{senderIndex:D3}@", email.From, StringComparison.Ordinal);
             this.output.WriteLine($"Category: {category}, Subject: {email.Subject}");
         }
 
@@ -335,7 +336,7 @@ namespace Zipper
                 subjects[i] = email.Subject;
             }
 
-            var uniqueSubjects = subjects.Distinct().Count();
+            var uniqueSubjects = subjects.Distinct(StringComparer.Ordinal).Count();
             Assert.True(uniqueSubjects > 1, "Expected multiple different subjects");
             Assert.True(uniqueSubjects >= iterations * 0.3, $"Expected at least 30% variety, got {uniqueSubjects}/{iterations}");
         }
@@ -352,8 +353,8 @@ namespace Zipper
                 emailAddresses[i] = (email.To, email.From);
             }
 
-            var uniqueToAddresses = emailAddresses.Select(e => e.to).Distinct().Count();
-            var uniqueFromAddresses = emailAddresses.Select(e => e.from).Distinct().Count();
+            var uniqueToAddresses = emailAddresses.Select(e => e.to).Distinct(StringComparer.Ordinal).Count();
+            var uniqueFromAddresses = emailAddresses.Select(e => e.from).Distinct(StringComparer.Ordinal).Count();
 
             Assert.Equal(iterations, uniqueToAddresses);
             Assert.Equal(iterations, uniqueFromAddresses);
@@ -376,8 +377,8 @@ namespace Zipper
             var email = EmailFactory.CreateContextual(context, new Random(42));
 
             Assert.NotNull(email);
-            Assert.Contains("recipient005@", email.To);
-            Assert.Contains("sender010@", email.From);
+            Assert.Contains("recipient005@", email.To, StringComparison.Ordinal);
+            Assert.Contains("sender010@", email.From, StringComparison.Ordinal);
             Assert.Equal(new DateTime(2023, 6, 15), email.SentDate);
             Assert.True(email.IsHighPriority);
             Assert.True(email.RequestReadReceipt);
@@ -438,7 +439,7 @@ namespace Zipper
                 var email = EmailFactory.Create(i + 1, i + 2, category, new Random(i));
                 foreach (var placeholder in bodyPlaceholders)
                 {
-                    Assert.DoesNotContain(placeholder, email.Body);
+                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
                 }
             }
         }
@@ -452,8 +453,8 @@ namespace Zipper
             var email = EmailFactory.Create(largeRecipientIndex, largeSenderIndex, null, new Random(1));
 
             Assert.NotNull(email);
-            Assert.Contains($"recipient{largeRecipientIndex:D6}@", email.To);
-            Assert.Contains($"sender{largeSenderIndex:D6}@", email.From);
+            Assert.Contains($"recipient{largeRecipientIndex:D6}@", email.To, StringComparison.Ordinal);
+            Assert.Contains($"sender{largeSenderIndex:D6}@", email.From, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -467,13 +468,13 @@ namespace Zipper
                 var email = EmailFactory.Create(i + 1, i + 2, null, new Random(i));
                 foreach (var placeholder in commonPlaceholders)
                 {
-                    Assert.DoesNotContain(placeholder, email.Subject);
-                    Assert.DoesNotContain(placeholder, email.Body);
+                    Assert.DoesNotContain(placeholder, email.Subject, StringComparison.Ordinal);
+                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
                 }
 
                 foreach (var placeholder in bodyOnlyPlaceholders)
                 {
-                    Assert.DoesNotContain(placeholder, email.Body);
+                    Assert.DoesNotContain(placeholder, email.Body, StringComparison.Ordinal);
                 }
             }
         }

--- a/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
@@ -21,13 +21,13 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("From: sender@example.com", content);
-            Assert.Contains("To: recipient@example.com", content);
-            Assert.Contains("Subject: RFC 2822 Test", content);
-            Assert.Contains("Date: Fri, 15 Mar 2024 10:30:00", content);
-            Assert.Contains("MIME-Version: 1.0", content);
-            Assert.Contains("Content-Type: text/plain; charset=utf-8", content);
-            Assert.Contains("Content-Transfer-Encoding: 8bit", content);
+            Assert.Contains("From: sender@example.com", content, StringComparison.Ordinal);
+            Assert.Contains("To: recipient@example.com", content, StringComparison.Ordinal);
+            Assert.Contains("Subject: RFC 2822 Test", content, StringComparison.Ordinal);
+            Assert.Contains("Date: Fri, 15 Mar 2024 10:30:00", content, StringComparison.Ordinal);
+            Assert.Contains("MIME-Version: 1.0", content, StringComparison.Ordinal);
+            Assert.Contains("Content-Type: text/plain; charset=utf-8", content, StringComparison.Ordinal);
+            Assert.Contains("Content-Transfer-Encoding: 8bit", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Zipper
                 var content = Encoding.UTF8.GetString(result);
 
                 // Must use English abbreviations per RFC 2822
-                Assert.Contains("Date: Mon, 15 Jan 2024 14:00:00", content);
+                Assert.Contains("Date: Mon, 15 Jan 2024 14:00:00", content, StringComparison.Ordinal);
             }
             finally
             {
@@ -75,8 +75,8 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains(unicodeBody, content);
-            Assert.Contains("Unicode Subject: ñoño", content);
+            Assert.Contains(unicodeBody, content, StringComparison.Ordinal);
+            Assert.Contains("Unicode Subject: ñoño", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -99,10 +99,10 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, attachment);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("multipart/mixed", content);
-            Assert.Contains("Content-Transfer-Encoding: base64", content);
-            Assert.Contains("Content-Disposition: attachment; filename=\"data.pdf\"", content);
-            Assert.Contains("application/pdf", content);
+            Assert.Contains("multipart/mixed", content, StringComparison.Ordinal);
+            Assert.Contains("Content-Transfer-Encoding: base64", content, StringComparison.Ordinal);
+            Assert.Contains("Content-Disposition: attachment; filename=\"data.pdf\"", content, StringComparison.Ordinal);
+            Assert.Contains("application/pdf", content, StringComparison.Ordinal);
             Assert.True(result.Length > 0);
         }
 
@@ -122,8 +122,8 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("X-Priority: 1", content);
-            Assert.Contains("Priority: Urgent", content);
+            Assert.Contains("X-Priority: 1", content, StringComparison.Ordinal);
+            Assert.Contains("Priority: Urgent", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Disposition-Notification-To: sender@example.com", content);
+            Assert.Contains("Disposition-Notification-To: sender@example.com", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Cc: cc@example.com", content);
+            Assert.Contains("Cc: cc@example.com", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Reply-To: reply@example.com", content);
+            Assert.Contains("Reply-To: reply@example.com", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -205,8 +205,8 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.DoesNotContain("X-Priority:", content);
-            Assert.DoesNotContain("Priority: Urgent", content);
+            Assert.DoesNotContain("X-Priority:", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("Priority: Urgent", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -231,8 +231,8 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, attachment);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Content-ID: <img-001>", content);
-            Assert.Contains("Content-Disposition: inline; filename=\"image.png\"", content);
+            Assert.Contains("Content-ID: <img-001>", content, StringComparison.Ordinal);
+            Assert.Contains("Content-Disposition: inline; filename=\"image.png\"", content, StringComparison.Ordinal);
         }
 
         // Tests redistributed from EmailBuilderTests
@@ -253,8 +253,8 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, null);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Cc: cc@example.com", content);
-            Assert.Contains("Bcc: bcc@example.com", content);
+            Assert.Contains("Cc: cc@example.com", content, StringComparison.Ordinal);
+            Assert.Contains("Bcc: bcc@example.com", content, StringComparison.Ordinal);
         }
 
         [Theory]
@@ -284,7 +284,7 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, attachment);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains(expectedContentType, content);
+            Assert.Contains(expectedContentType, content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace Zipper
             var result = EmailSerializer.ToEml(email, attachment);
 
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("application/custom-type", content);
+            Assert.Contains("application/custom-type", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -334,7 +334,7 @@ namespace Zipper
 
             Assert.True(result.Length > largeContent.Length);
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("base64", content.ToLowerInvariant());
+            Assert.Contains("base64", content.ToLowerInvariant(), StringComparison.Ordinal);
         }
 
         [Fact]
@@ -354,7 +354,7 @@ namespace Zipper
             Assert.NotNull(result);
             Assert.True(result.Length > 0);
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Subject:", content);
+            Assert.Contains("Subject:", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -373,7 +373,7 @@ namespace Zipper
 
             Assert.NotNull(result);
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("Date:", content);
+            Assert.Contains("Date:", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -397,7 +397,7 @@ namespace Zipper
 
             Assert.NotNull(result);
             var content = Encoding.UTF8.GetString(result);
-            Assert.Contains("multipart/mixed", content);
+            Assert.Contains("multipart/mixed", content, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs
+++ b/src/Zipper.Tests/Emails/EmlFileGeneratorDeterminismTests.cs
@@ -31,12 +31,12 @@ public class EmlFileGeneratorDeterminismTests
 
         // Correctness assertions (M3)
         var emlText = System.Text.Encoding.UTF8.GetString(result1.Content);
-        Assert.Contains("To: recipient005@", emlText);
-        Assert.Contains("From: sender005@", emlText);
-        Assert.Contains("Subject: ", emlText);
-        Assert.Contains("MIME-Version: 1.0", emlText);
-        Assert.Contains("Date: ", emlText);
-        Assert.Contains("Content-Type: text/plain", emlText);
+        Assert.Contains("To: recipient005@", emlText, StringComparison.Ordinal);
+        Assert.Contains("From: sender005@", emlText, StringComparison.Ordinal);
+        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
+        Assert.Contains("MIME-Version: 1.0", emlText, StringComparison.Ordinal);
+        Assert.Contains("Date: ", emlText, StringComparison.Ordinal);
+        Assert.Contains("Content-Type: text/plain", emlText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -66,11 +66,11 @@ public class EmlFileGeneratorDeterminismTests
 
         // Correctness assertions (M3)
         var emlText = System.Text.Encoding.UTF8.GetString(result1.Content);
-        Assert.Contains("To: recipient003@", emlText);
-        Assert.Contains("From: sender003@", emlText);
-        Assert.Contains("Subject: ", emlText);
-        Assert.Contains("MIME-Version: 1.0", emlText);
-        Assert.Contains("Content-Type: multipart/mixed", emlText);
+        Assert.Contains("To: recipient003@", emlText, StringComparison.Ordinal);
+        Assert.Contains("From: sender003@", emlText, StringComparison.Ordinal);
+        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
+        Assert.Contains("MIME-Version: 1.0", emlText, StringComparison.Ordinal);
+        Assert.Contains("Content-Type: multipart/mixed", emlText, StringComparison.Ordinal);
         Assert.NotNull(result1.Attachment);
         Assert.NotEmpty(result1.Attachment.Value.filename);
         Assert.NotEmpty(result1.Attachment.Value.content);
@@ -89,9 +89,9 @@ public class EmlFileGeneratorDeterminismTests
         var emlText = System.Text.Encoding.UTF8.GetString(result.Content);
 
         // Headers presence check
-        Assert.Contains("From: ", emlText);
-        Assert.Contains("To: ", emlText);
-        Assert.Contains("Subject: ", emlText);
+        Assert.Contains("From: ", emlText, StringComparison.Ordinal);
+        Assert.Contains("To: ", emlText, StringComparison.Ordinal);
+        Assert.Contains("Subject: ", emlText, StringComparison.Ordinal);
 
         // Date should be RFC 2822 formatted with InvariantCulture
         Assert.Matches(@"Date: (Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} [+-]\d{2}:\d{2}", emlText);

--- a/src/Zipper.Tests/EncodingDataTests.cs
+++ b/src/Zipper.Tests/EncodingDataTests.cs
@@ -6,7 +6,7 @@ namespace Zipper.Tests;
 public class EncodingDataTests
 {
     private static readonly System.Collections.Generic.HashSet<string> ValidEncodings =
-        new() { "UTF-8", "ASCII", "UTF-16", "ISO-8859-1", "Windows-1252" };
+        new(StringComparer.Ordinal) { "UTF-8", "ASCII", "UTF-16", "ISO-8859-1", "Windows-1252" };
 
     [Fact]
     public void GetRandom_ReturnsNonEmptyString()

--- a/src/Zipper.Tests/FieldNamingTests.cs
+++ b/src/Zipper.Tests/FieldNamingTests.cs
@@ -151,7 +151,7 @@ public class FieldNamingTests : IDisposable
         };
 
         var ex = Assert.Throws<InvalidOperationException>(() => ColumnProfileLoader.Validate(profile));
-        Assert.Contains("has an invalid fieldNamingConvention", ex.Message);
+        Assert.Contains("has an invalid fieldNamingConvention", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -33,14 +33,14 @@ namespace Zipper
         public async Task RunAsync_ThrowingMode_PrintsLegacyErrorFormatToStderr()
         {
             var (_, _, err) = await RunWithCapture(new ThrowingMode("disk full"), DefaultRequest());
-            Assert.Contains("\nAn error occurred: disk full", err);
+            Assert.Contains("\nAn error occurred: disk full", err, StringComparison.Ordinal);
         }
 
         [Fact]
         public async Task RunAsync_ThrowingMode_DoesNotWriteErrorToStdout()
         {
             var (_, output, _) = await RunWithCapture(new ThrowingMode("boom"), DefaultRequest());
-            Assert.DoesNotContain("An error occurred", output);
+            Assert.DoesNotContain("An error occurred", output, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Zipper
                 using var errWriter = new StringWriter();
                 Console.SetOut(outWriter);
                 Console.SetError(errWriter);
-                int exit = await GenerationRunner.RunAsync(mode, request);
+                int exit = await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
                 return (exit, outWriter.ToString(), errWriter.ToString());
             }
             finally

--- a/src/Zipper.Tests/HelpTextGeneratorTests.cs
+++ b/src/Zipper.Tests/HelpTextGeneratorTests.cs
@@ -18,21 +18,21 @@ namespace Zipper.Tests
                 HelpTextGenerator.Show();
 
                 var output = errorOutput.ToString();
-                Assert.Contains("Error: Missing required arguments.", output);
-                Assert.Contains("Usage:", output);
-                Assert.Contains("--type <pdf|jpg|tiff|eml|docx|xlsx>", output);
-                Assert.Contains("--count <number>", output);
-                Assert.Contains("--output-path <path>", output);
-                Assert.Contains("Optional Arguments:", output);
-                Assert.Contains("Required Arguments:", output);
-                Assert.Contains("Load File Options:", output);
-                Assert.Contains("Loadfile-Only Options:", output);
-                Assert.Contains("Chaos Engine Options:", output);
-                Assert.Contains("Production Set Options:", output);
-                Assert.Contains("Bates Numbering:", output);
-                Assert.Contains("TIFF Options:", output);
-                Assert.Contains("Column Profile Options:", output);
-                Assert.Contains("Utility Options:", output);
+                Assert.Contains("Error: Missing required arguments.", output, StringComparison.Ordinal);
+                Assert.Contains("Usage:", output, StringComparison.Ordinal);
+                Assert.Contains("--type <pdf|jpg|tiff|eml|docx|xlsx>", output, StringComparison.Ordinal);
+                Assert.Contains("--count <number>", output, StringComparison.Ordinal);
+                Assert.Contains("--output-path <path>", output, StringComparison.Ordinal);
+                Assert.Contains("Optional Arguments:", output, StringComparison.Ordinal);
+                Assert.Contains("Required Arguments:", output, StringComparison.Ordinal);
+                Assert.Contains("Load File Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Loadfile-Only Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Chaos Engine Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Production Set Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Bates Numbering:", output, StringComparison.Ordinal);
+                Assert.Contains("TIFF Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Column Profile Options:", output, StringComparison.Ordinal);
+                Assert.Contains("Utility Options:", output, StringComparison.Ordinal);
             }
             finally
             {

--- a/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
@@ -41,10 +41,10 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
 
         Assert.Equal(2, lines.Length);
 
-        Assert.Contains("\u00feCONTROLNUMBER\u00fe", lines[0]);
-        Assert.Contains("\u00fePATH\u00fe", lines[0]);
-        Assert.Contains("\u00feDOC00000001\u00fe", lines[1]);
-        Assert.Contains("\u00fefolder/doc1.pdf\u00fe", lines[1]);
+        Assert.Contains("\u00feCONTROLNUMBER\u00fe", lines[0], StringComparison.Ordinal);
+        Assert.Contains("\u00fePATH\u00fe", lines[0], StringComparison.Ordinal);
+        Assert.Contains("\u00feDOC00000001\u00fe", lines[1], StringComparison.Ordinal);
+        Assert.Contains("\u00fefolder/doc1.pdf\u00fe", lines[1], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
         var dataLine = content.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1];
         var fields = dataLine.Split('\u0014');
 
-        Assert.Contains("\u00fe\u00fe", fields[3]);
+        Assert.Contains("\u00fe\u00fe", fields[3], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -95,11 +95,11 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
         var content = await File.ReadAllTextAsync(outputPath);
         var colDelim = '\u0014';
         Assert.Contains(colDelim, content);
-        Assert.Contains("CONTROLNUMBER", content);
+        Assert.Contains("CONTROLNUMBER", content, StringComparison.Ordinal);
 
         var lines_split = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.Contains("BEGATTY", lines_split[0]);
-        Assert.Contains("CONTROLNUMBER", lines_split[0]);
-        Assert.Contains("PATH", lines_split[0]);
+        Assert.Contains("BEGATTY", lines_split[0], StringComparison.Ordinal);
+        Assert.Contains("CONTROLNUMBER", lines_split[0], StringComparison.Ordinal);
+        Assert.Contains("PATH", lines_split[0], StringComparison.Ordinal);
     }
 }

--- a/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
+++ b/src/Zipper.Tests/LoadFiles/DatSerializerTests.cs
@@ -14,10 +14,10 @@ public class DatSerializerTests
 
         var content = serializer.RenderHeader(columns);
 
-        Assert.Contains("DOCID", content);
-        Assert.Contains("FILEPATH", content);
-        Assert.Contains("CUSTODIAN", content);
-        Assert.Contains("\x14", content); // column delimiter
+        Assert.Contains("DOCID", content, StringComparison.Ordinal);
+        Assert.Contains("FILEPATH", content, StringComparison.Ordinal);
+        Assert.Contains("CUSTODIAN", content, StringComparison.Ordinal);
+        Assert.Contains("\x14", content, StringComparison.Ordinal); // column delimiter
     }
 
     [Fact]
@@ -29,6 +29,7 @@ public class DatSerializerTests
         {
             Columns = columns,
             Values = new Dictionary<string, string>
+(StringComparer.Ordinal)
             {
                 ["DOCID"] = "DOC001",
                 ["FILEPATH"] = "folder/file.pdf",
@@ -37,9 +38,9 @@ public class DatSerializerTests
 
         var content = serializer.RenderRecord(record);
 
-        Assert.Contains("DOC001", content);
-        Assert.Contains("folder/file.pdf", content);
-        Assert.Contains("\x14", content); // column delimiter
+        Assert.Contains("DOC001", content, StringComparison.Ordinal);
+        Assert.Contains("folder/file.pdf", content, StringComparison.Ordinal);
+        Assert.Contains("\x14", content, StringComparison.Ordinal); // column delimiter
     }
 
     [Fact]
@@ -50,6 +51,7 @@ public class DatSerializerTests
         {
             Columns = new List<string> { "VALUE" },
             Values = new Dictionary<string, string>
+(StringComparer.Ordinal)
             {
                 ["VALUE"] = "has\xfequote",
             },
@@ -58,7 +60,7 @@ public class DatSerializerTests
         var content = serializer.RenderRecord(record);
 
         // Quote delimiter should be doubled
-        Assert.Contains("\xfe\xfe", content);
+        Assert.Contains("\xfe\xfe", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -69,6 +71,7 @@ public class DatSerializerTests
         {
             Columns = new List<string> { "TEXT" },
             Values = new Dictionary<string, string>
+(StringComparer.Ordinal)
             {
                 ["TEXT"] = "line1\nline2",
             },
@@ -76,8 +79,8 @@ public class DatSerializerTests
 
         var content = serializer.RenderRecord(record);
 
-        Assert.DoesNotContain("\n", content);
-        Assert.Contains("\xae", content);
+        Assert.DoesNotContain("\n", content, StringComparison.Ordinal);
+        Assert.Contains("\xae", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -87,7 +90,7 @@ public class DatSerializerTests
         var record = new LoadFileRecord
         {
             Columns = new List<string> { "A", "B" },
-            Values = new Dictionary<string, string> { ["A"] = "x", ["B"] = "y" },
+            Values = new Dictionary<string, string>(StringComparer.Ordinal) { ["A"] = "x", ["B"] = "y" },
         };
 
         var content = serializer.RenderRecord(record);
@@ -102,7 +105,7 @@ public class DatSerializerTests
         var record = new LoadFileRecord
         {
             Columns = new List<string> { "A", "MISSING", "B" },
-            Values = new Dictionary<string, string> { ["A"] = "x", ["B"] = "y" },
+            Values = new Dictionary<string, string>(StringComparer.Ordinal) { ["A"] = "x", ["B"] = "y" },
         };
 
         var content = serializer.RenderRecord(record);

--- a/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/LoadFileEmitterTests.cs
@@ -28,7 +28,7 @@ public class LoadFileEmitterTests
     private static LoadFileRecord Rec(string id, params (string Col, string Val)[] cells) => new()
     {
         Columns = cells.Select(c => c.Col).ToList(),
-        Values = cells.ToDictionary(c => c.Col, c => c.Val),
+        Values = cells.ToDictionary(c => c.Col, c => c.Val, StringComparer.Ordinal),
         RecordId = id,
     };
 
@@ -75,7 +75,7 @@ public class LoadFileEmitterTests
     public async Task NoChaos_StreamsLargeInputWithoutLoss()
     {
         using var ms = new MemoryStream();
-        var records = Enumerable.Range(0, 5000).Select(i => Rec(i.ToString(), ("A", $"v{i}")));
+        var records = Enumerable.Range(0, 5000).Select(i => Rec(i.ToString(System.Globalization.CultureInfo.InvariantCulture), ("A", $"v{i}")));
 
         await LoadFileEmitter.EmitAsync(ms, new FakeSerializer(), Array.Empty<string>(), records, NoBom, "\n", chaosEngine: null);
 

--- a/src/Zipper.Tests/LoadFiles/OptWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/OptWriterTests.cs
@@ -54,8 +54,8 @@ public class OptWriterTests : TempDirectoryTestBase
         var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(2, lines.Length);
-        Assert.StartsWith("DOC00000001_001,VOL001,IMAGES\\DOC00000001_001.tif,Y", lines[0]);
-        Assert.StartsWith("DOC00000001_002,VOL001,IMAGES\\DOC00000001_002.tif,", lines[1]);
+        Assert.StartsWith("DOC00000001_001,VOL001,IMAGES\\DOC00000001_001.tif,Y", lines[0], StringComparison.Ordinal);
+        Assert.StartsWith("DOC00000001_002,VOL001,IMAGES\\DOC00000001_002.tif,", lines[1], StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -72,24 +72,24 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
 
         var content = await File.ReadAllTextAsync(outputPath);
 
-        Assert.Contains("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>", content.ToLowerInvariant());
-        Assert.Contains("<Root DataInterchangeType=\"Export\" MajorVersion=\"1\" MinorVersion=\"2\">", content);
-        Assert.Contains("<Batch>", content);
-        Assert.DoesNotContain("<Documents>", content);
-        Assert.DoesNotContain("</Documents>", content);
-        Assert.Contains("<Document DocID=\"DOC00000001\">", content);
-        Assert.Contains("<Files>", content);
-        Assert.Contains("<File FileType=\"Native\">", content);
-        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.pdf\" FileName=\"file_00000001.pdf\" FileSize=\"14\" Hash=\"", content);
-        Assert.Contains("<File FileType=\"Text\">", content);
-        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content);
-        Assert.Contains("<Tags>", content);
-        Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content);
-        Assert.DoesNotContain("<Fields>", content);
-        Assert.DoesNotContain("<Field ", content);
-        Assert.Contains("</Document>", content);
-        Assert.Contains("</Batch>", content);
-        Assert.Contains("</Root>", content);
+        Assert.Contains("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>", content.ToLowerInvariant(), StringComparison.Ordinal);
+        Assert.Contains("<Root DataInterchangeType=\"Export\" MajorVersion=\"1\" MinorVersion=\"2\">", content, StringComparison.Ordinal);
+        Assert.Contains("<Batch>", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("<Documents>", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("</Documents>", content, StringComparison.Ordinal);
+        Assert.Contains("<Document DocID=\"DOC00000001\">", content, StringComparison.Ordinal);
+        Assert.Contains("<Files>", content, StringComparison.Ordinal);
+        Assert.Contains("<File FileType=\"Native\">", content, StringComparison.Ordinal);
+        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.pdf\" FileName=\"file_00000001.pdf\" FileSize=\"14\" Hash=\"", content, StringComparison.Ordinal);
+        Assert.Contains("<File FileType=\"Text\">", content, StringComparison.Ordinal);
+        Assert.Contains("<ExternalFile FilePath=\"folder_001/file_00000001.txt\" FileName=\"file_00000001.txt\" FileSize=\"41\" Hash=\"", content, StringComparison.Ordinal);
+        Assert.Contains("<Tags>", content, StringComparison.Ordinal);
+        Assert.Contains("<Tag TagName=\"Custodian\" TagValue=\"Custodian 1\" />", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("<Fields>", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("<Field ", content, StringComparison.Ordinal);
+        Assert.Contains("</Document>", content, StringComparison.Ordinal);
+        Assert.Contains("</Batch>", content, StringComparison.Ordinal);
+        Assert.Contains("</Root>", content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -69,11 +69,11 @@ namespace Zipper
             var result = await LoadfileOnlyGenerator.GenerateAsync(request);
 
             var firstLine = (await File.ReadAllLinesAsync(result.LoadFilePath))[0];
-            Assert.Contains("Control Number", firstLine);
-            Assert.Contains("File Path", firstLine);
-            Assert.Contains("Custodian", firstLine);
-            Assert.Contains("EmailSubject", firstLine);
-            Assert.Contains("ExtractedText", firstLine);
+            Assert.Contains("Control Number", firstLine, StringComparison.Ordinal);
+            Assert.Contains("File Path", firstLine, StringComparison.Ordinal);
+            Assert.Contains("Custodian", firstLine, StringComparison.Ordinal);
+            Assert.Contains("EmailSubject", firstLine, StringComparison.Ordinal);
+            Assert.Contains("ExtractedText", firstLine, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -134,9 +134,9 @@ namespace Zipper
             var parts = firstLine.Split(',');
 
             Assert.Equal(7, parts.Length);
-            Assert.StartsWith("IMG", parts[0]); // Bates Number
+            Assert.StartsWith("IMG", parts[0], StringComparison.Ordinal); // Bates Number
             Assert.Equal("VOL001", parts[1]); // Volume
-            Assert.Contains("IMAGES", parts[2]); // ImagePath
+            Assert.Contains("IMAGES", parts[2], StringComparison.Ordinal); // ImagePath
             Assert.Equal("Y", parts[3]); // DocBreak
         }
 
@@ -183,8 +183,8 @@ namespace Zipper
             var content = Encoding.UTF8.GetString(bytes);
 
             // Should contain LF but not CRLF
-            Assert.Contains("\n", content);
-            Assert.DoesNotContain("\r\n", content);
+            Assert.Contains("\n", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("\r\n", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -236,7 +236,7 @@ namespace Zipper
             var lines = await File.ReadAllLinesAsync(result.LoadFilePath);
 
             Assert.Equal(2, lines.Length);
-            Assert.Contains("Control Number", lines[0]);
+            Assert.Contains("Control Number", lines[0], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -252,13 +252,13 @@ namespace Zipper
 
             var parts1 = lines[0].Split(',');
             Assert.Equal(7, parts1.Length);
-            Assert.StartsWith("IMG", parts1[0]);
+            Assert.StartsWith("IMG", parts1[0], StringComparison.Ordinal);
             Assert.Equal("VOL001", parts1[1]);
             Assert.Equal("Y", parts1[3]); // First page is doc break
 
             var parts2 = lines[1].Split(',');
             Assert.Equal(7, parts2.Length);
-            Assert.StartsWith("IMG", parts2[0]);
+            Assert.StartsWith("IMG", parts2[0], StringComparison.Ordinal);
             Assert.Equal("VOL001", parts2[1]);
             Assert.Equal(string.Empty, parts2[3]); // Subsequent pages are not doc break
         }
@@ -273,8 +273,8 @@ namespace Zipper
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
             var content = System.Text.Encoding.UTF8.GetString(bytes);
 
-            Assert.Contains("\r", content);
-            Assert.DoesNotContain("\n", content);
+            Assert.Contains("\r", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("\n", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -287,7 +287,7 @@ namespace Zipper
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
             var content = System.Text.Encoding.UTF8.GetString(bytes);
 
-            Assert.Contains("\r\n", content);
+            Assert.Contains("\r\n", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -300,8 +300,8 @@ namespace Zipper
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
             var content = System.Text.Encoding.UTF8.GetString(bytes);
 
-            Assert.Contains("\n", content);
-            Assert.DoesNotContain("\r\n", content);
+            Assert.Contains("\n", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("\r\n", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ namespace Zipper
             var bytes = await File.ReadAllBytesAsync(result.LoadFilePath);
             var content = System.Text.Encoding.UTF8.GetString(bytes);
 
-            Assert.Contains("\r\n", content);
+            Assert.Contains("\r\n", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -362,8 +362,8 @@ namespace Zipper
             var content2 = await File.ReadAllTextAsync(result2.LoadFilePath);
 
             // DAT should have header, OPT should not
-            Assert.Contains("Control Number", content1);
-            Assert.DoesNotContain("Control Number", content2);
+            Assert.Contains("Control Number", content1, StringComparison.Ordinal);
+            Assert.DoesNotContain("Control Number", content2, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -556,7 +556,7 @@ namespace Zipper
 
             // Verify first page of first document
             var parts1 = lines[0].Split(',');
-            Assert.StartsWith("ABC001_00001", parts1[0]);
+            Assert.StartsWith("ABC001_00001", parts1[0], StringComparison.Ordinal);
             if (parts1[0].Contains("_"))
             {
                 Assert.Equal("ABC001_00001_001", parts1[0]);
@@ -565,7 +565,7 @@ namespace Zipper
             Assert.Equal("Y", parts1[3]); // doc break
 
             // If there's a second page for first document, verify no doc break
-            if (lines.Length > 1 && lines[1].StartsWith("ABC001_00001"))
+            if (lines.Length > 1 && lines[1].StartsWith("ABC001_00001", StringComparison.Ordinal))
             {
                 var parts2 = lines[1].Split(',');
                 Assert.Equal("ABC001_00001_002", parts2[0]);
@@ -635,7 +635,7 @@ namespace Zipper
                 }
 
                 this.TrackMemory();
-                await this.inner.WriteAsync(buffer, offset, count, cancellationToken);
+                await inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
 
             public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -648,7 +648,7 @@ namespace Zipper
                 }
 
                 this.TrackMemory();
-                await this.inner.WriteAsync(buffer, cancellationToken);
+                await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
 
             private void TrackMemory()

--- a/src/Zipper.Tests/LoremIpsumDataTests.cs
+++ b/src/Zipper.Tests/LoremIpsumDataTests.cs
@@ -23,7 +23,7 @@ public class LoremIpsumDataTests
     public void GetSentence_EndsWithPeriod()
     {
         var result = LoremIpsum.GetSentence(new Random(42));
-        Assert.EndsWith(".", result);
+        Assert.EndsWith(".", result, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Zipper.Tests/MetadataRowBuilderTests.cs
+++ b/src/Zipper.Tests/MetadataRowBuilderTests.cs
@@ -104,7 +104,7 @@ namespace Zipper
         {
             var gen = new LegacyRandomFileSizeGenerator();
             var result = gen.Generate(MakeContext(seed: 42));
-            var parsed = int.Parse(result);
+            var parsed = int.Parse(result, System.Globalization.CultureInfo.InvariantCulture);
             Assert.InRange(parsed, 1024, 10485760);
         }
 

--- a/src/Zipper.Tests/OfficeFileGeneratorTests.cs
+++ b/src/Zipper.Tests/OfficeFileGeneratorTests.cs
@@ -126,7 +126,7 @@ namespace Zipper
             var content = reader.ReadToEnd();
 
             // O(1): pre-computed content is identical for all files
-            Assert.Contains("eDiscovery testing", content);
+            Assert.Contains("eDiscovery testing", content, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace Zipper
             Assert.NotNull(archive);
 
             // XLSX files should contain workbook entries
-            var xlEntry = archive.Entries.FirstOrDefault(e => e.FullName.StartsWith("xl/"));
+            var xlEntry = archive.Entries.FirstOrDefault(e => e.FullName.StartsWith("xl/", StringComparison.Ordinal));
             Assert.NotNull(xlEntry);
         }
 

--- a/src/Zipper.Tests/OptLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/OptLoadFileWriterTests.cs
@@ -98,7 +98,7 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         Assert.Equal(3, lines.Length);
         Assert.Contains(',', lines[0]);
         Assert.DoesNotContain('\t', lines[0]);
-        Assert.DoesNotContain("Control Number", lines[0]);
+        Assert.DoesNotContain("Control Number", lines[0], StringComparison.Ordinal);
         Assert.Equal(6, lines[0].Count(c => c == ','));
     }
 
@@ -165,16 +165,16 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var optContentWithAnsi = await File.ReadAllTextAsync(optOutputPath, optTargetEncoding);
 
         Assert.NotEmpty(optContentWithAnsi);
-        Assert.Contains(",", optContentWithAnsi);
+        Assert.Contains(",", optContentWithAnsi, StringComparison.Ordinal);
 
         var datContentWithUtf8 = await File.ReadAllTextAsync(datOutputPath, Encoding.UTF8);
         Assert.NotEmpty(datContentWithUtf8);
 
         var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optOutputPath, request, fileData.Count, null, LoadFileFormat.Opt);
-        Assert.Contains("\"encoding\": \"ANSI\"", optAuditJson);
+        Assert.Contains("\"encoding\": \"ANSI\"", optAuditJson, StringComparison.Ordinal);
 
         var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datOutputPath, request, fileData.Count, null, LoadFileFormat.Dat);
-        Assert.Contains("\"encoding\": \"UTF-8\"", datAuditJson);
+        Assert.Contains("\"encoding\": \"UTF-8\"", datAuditJson, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -204,8 +204,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         {
             int commaCount = line.Count(c => c == ',');
             Assert.Equal(6, commaCount);
-            Assert.StartsWith("IMG", line);
-            Assert.Contains("VOL001", line);
+            Assert.StartsWith("IMG", line, StringComparison.Ordinal);
+            Assert.Contains("VOL001", line, StringComparison.Ordinal);
         }
     }
 
@@ -254,12 +254,12 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         Assert.Equal(3, lines.Length);
         foreach (var line in lines)
         {
-            Assert.StartsWith("PROD", line);
-            Assert.Contains(".tif", line);
-            Assert.Contains("VOL001", line);
+            Assert.StartsWith("PROD", line, StringComparison.Ordinal);
+            Assert.Contains(".tif", line, StringComparison.Ordinal);
+            Assert.Contains("VOL001", line, StringComparison.Ordinal);
         }
 
-        Assert.Contains("\r\n", content);
+        Assert.Contains("\r\n", content, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -296,8 +296,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var decodedWithAnsi = Encoding.GetEncoding(1252).GetString(bytes);
         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
 
-        Assert.Contains("TEST_ü", decodedWithAnsi);
-        Assert.DoesNotContain("TEST_ü", decodedWithUtf8);
+        Assert.Contains("TEST_ü", decodedWithAnsi, StringComparison.Ordinal);
+        Assert.DoesNotContain("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -331,7 +331,7 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var bytes = stream.ToArray();
         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
 
-        Assert.Contains("TEST_ü", decodedWithUtf8);
+        Assert.Contains("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -368,8 +368,8 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var decodedWithAnsi = Encoding.GetEncoding(1252).GetString(bytes);
         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
 
-        Assert.Contains("TEST_ü", decodedWithAnsi);
-        Assert.DoesNotContain("TEST_ü", decodedWithUtf8);
+        Assert.Contains("TEST_ü", decodedWithAnsi, StringComparison.Ordinal);
+        Assert.DoesNotContain("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -403,6 +403,6 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var bytes = stream.ToArray();
         var decodedWithUtf8 = Encoding.UTF8.GetString(bytes);
 
-        Assert.Contains("TEST_ü", decodedWithUtf8);
+        Assert.Contains("TEST_ü", decodedWithUtf8, StringComparison.Ordinal);
     }
 }

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -128,7 +128,7 @@ namespace Zipper
                         },
                     }));
 
-                Assert.Contains("target ZIP size", ex.Message);
+                Assert.Contains("target ZIP size", ex.Message, StringComparison.Ordinal);
             }
             finally
             {
@@ -324,7 +324,7 @@ namespace Zipper
                         },
                     }));
 
-                Assert.Contains("File count must be positive", ex.Message);
+                Assert.Contains("File count must be positive", ex.Message, StringComparison.Ordinal);
             }
             finally
             {
@@ -392,7 +392,7 @@ namespace Zipper
                         },
                     }));
 
-                Assert.Contains("Unknown file type", ex.Message);
+                Assert.Contains("Unknown file type", ex.Message, StringComparison.Ordinal);
             }
             finally
             {
@@ -531,7 +531,7 @@ namespace Zipper
                             Folders = 2,
                             Concurrency = 4,
                         },
-                    });
+                    }).ConfigureAwait(false);
                 });
             }
             finally

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+
 using Xunit;
 
 namespace Zipper

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -205,7 +205,7 @@ namespace Zipper
                 $"..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}windows{Path.DirectorySeparatorChar}system32",
                 "test/../../sensitive/../../../data",
                 "/folder/../../etc/shadow",
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:\\folder\\..\\..\\sensitive" : "/folder/../../sensitive",
+                OperatingSystem.IsWindows() ? "C:\\folder\\..\\..\\sensitive" : "/folder/../../sensitive",
             };
 
             // Act & Assert

--- a/src/Zipper.Tests/PlaceholderFilesTests.cs
+++ b/src/Zipper.Tests/PlaceholderFilesTests.cs
@@ -104,8 +104,8 @@ public class PlaceholderFilesTests
         var nullableAttachment = PlaceholderFiles.GetRandomAttachment();
         Assert.NotNull(nullableAttachment);
         var attachment = nullableAttachment.Value;
-        Assert.StartsWith("attachment.", attachment.filename);
-        Assert.True(attachment.filename.EndsWith(".jpg") || attachment.filename.EndsWith(".pdf") || attachment.filename.EndsWith(".tiff"));
+        Assert.StartsWith("attachment.", attachment.filename, StringComparison.Ordinal);
+        Assert.True(attachment.filename.EndsWith(".jpg", StringComparison.Ordinal) || attachment.filename.EndsWith(".pdf", StringComparison.Ordinal) || attachment.filename.EndsWith(".tiff", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -141,7 +141,7 @@ public class ProductionSetTests : IDisposable
 
         var nativeFiles = Directory.GetFiles(Path.Combine(result.ProductionPath, "NATIVES"), "*.*", SearchOption.AllDirectories)
             .Select(Path.GetFileNameWithoutExtension)
-            .OrderBy(f => f)
+            .OrderBy(f => f, StringComparer.Ordinal)
             .ToArray();
 
         Assert.Equal("DOC000001", nativeFiles[0]);
@@ -160,7 +160,7 @@ public class ProductionSetTests : IDisposable
 
         var volDirs = Directory.GetDirectories(Path.Combine(result.ProductionPath, "NATIVES"));
         Assert.Equal(4, volDirs.Length);
-        Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL001");
+        Assert.Contains(volDirs, d => string.Equals(Path.GetFileName(d), "VOL001", StringComparison.Ordinal));
         Assert.Contains(volDirs, d => Path.GetFileName(d) == "VOL004");
     }
 
@@ -177,10 +177,10 @@ public class ProductionSetTests : IDisposable
 
         // Header should contain expected columns
         var header = datContent[0];
-        Assert.Contains("DOCID", header);
-        Assert.Contains("BATES_NUMBER", header);
-        Assert.Contains("NATIVE_PATH", header);
-        Assert.Contains("IMAGE_PATH", header);
+        Assert.Contains("DOCID", header, StringComparison.Ordinal);
+        Assert.Contains("BATES_NUMBER", header, StringComparison.Ordinal);
+        Assert.Contains("NATIVE_PATH", header, StringComparison.Ordinal);
+        Assert.Contains("IMAGE_PATH", header, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -195,8 +195,8 @@ public class ProductionSetTests : IDisposable
         Assert.Equal(5, optContent.Length);
 
         // Each line should contain the Bates number
-        Assert.StartsWith("TEST", optContent[0]);
-        Assert.Contains(".tif", optContent[0]);
+        Assert.StartsWith("TEST", optContent[0], StringComparison.Ordinal);
+        Assert.Contains(".tif", optContent[0], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -325,10 +325,10 @@ public class ProductionSetTests : IDisposable
         foreach (var file in nativeFiles)
         {
             var content = await File.ReadAllTextAsync(file);
-            Assert.Contains("From:", content);
-            Assert.Contains("To:", content);
-            Assert.Contains("Subject:", content);
-            Assert.Contains("Date:", content);
+            Assert.Contains("From:", content, StringComparison.Ordinal);
+            Assert.Contains("To:", content, StringComparison.Ordinal);
+            Assert.Contains("Subject:", content, StringComparison.Ordinal);
+            Assert.Contains("Date:", content, StringComparison.Ordinal);
         }
     }
 
@@ -444,7 +444,7 @@ public class ProductionSetTests : IDisposable
         var result = await ProductionSetGenerator.GenerateAsync(request);
 
         var datContent = await File.ReadAllTextAsync(result.DatFilePath, System.Text.Encoding.Unicode);
-        Assert.Contains("DOCID", datContent);
+        Assert.Contains("DOCID", datContent, StringComparison.Ordinal);
         Assert.Equal(4, datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
     }
 
@@ -518,7 +518,7 @@ public class ProductionSetTests : IDisposable
             Assert.True(vol2Deleted, "Test did not induce the intended VOL002 deletion failure.");
 
             // The generation task should now fail mid-write (when it tries to write to VOL002)
-            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(async () => await generateTask);
+            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(async () => await generateTask.ConfigureAwait(false));
 
             // Verify: no PRODUCTION_* directory should remain
             var productionDirs = Directory.GetDirectories(outputPath, "PRODUCTION_*");

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -518,7 +518,7 @@ public class ProductionSetTests : IDisposable
             Assert.True(vol2Deleted, "Test did not induce the intended VOL002 deletion failure.");
 
             // The generation task should now fail mid-write (when it tries to write to VOL002)
-            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(async () => await generateTask.ConfigureAwait(false));
+            await Assert.ThrowsAnyAsync<System.IO.DirectoryNotFoundException>(() => generateTask);
 
             // Verify: no PRODUCTION_* directory should remain
             var productionDirs = Directory.GetDirectories(outputPath, "PRODUCTION_*");

--- a/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
+++ b/src/Zipper.Tests/ProfileDrivenDatWriterTests.cs
@@ -37,7 +37,7 @@ namespace Zipper
         {
             var writer = new DatComposingWriter(Zipper.LoadFiles.WriterMode.LoadfileOnly);
             using var stream = new MemoryStream();
-            await writer.WriteAsync(stream, request, new List<FileData>());
+            await writer.WriteAsync(stream, request, new List<FileData>()).ConfigureAwait(false);
             stream.Position = 0;
             return Encoding.UTF8.GetString(stream.ToArray());
         }
@@ -52,8 +52,8 @@ namespace Zipper
 
             // Header + 3 data rows
             Assert.Equal(4, lines.Length);
-            Assert.Contains("DOCID", lines[0]);
-            Assert.Contains("FILEPATH", lines[0]);
+            Assert.Contains("DOCID", lines[0], StringComparison.Ordinal);
+            Assert.Contains("FILEPATH", lines[0], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Zipper
             var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             // Each data field should be wrapped in the quote delimiter (\u00fe)
-            Assert.Contains("\u00fe", lines[1]);
+            Assert.Contains("\u00fe", lines[1], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -76,6 +76,7 @@ namespace Zipper
                 Name = "escape-test",
                 Settings = new ProfileSettings { EmptyValuePercentage = 0 },
                 DataSources = new Dictionary<string, DataSourceConfig>
+(StringComparer.Ordinal)
                 {
                     ["quoteValues"] = new DataSourceConfig
                     {
@@ -93,7 +94,7 @@ namespace Zipper
             var content = await CaptureOutputAsync(request);
 
             // \u00fe inside the field value must be doubled to \u00fe\u00fe per Concordance escaping
-            Assert.Contains("val\u00fe\u00feSpecial", content);
+            Assert.Contains("val\u00fe\u00feSpecial", content, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace Zipper
             var custodianIdx = headers.IndexOf("CUSTODIAN");
             Assert.True(custodianIdx >= 0, "CUSTODIAN column not found in profile output");
 
-            var custodianValues = new HashSet<string>();
+            var custodianValues = new HashSet<string>(StringComparer.Ordinal);
             foreach (var line in lines.Skip(1))
             {
                 var fields = line.Split(colDelim);
@@ -172,8 +173,8 @@ namespace Zipper
             await new DatComposingWriter(Zipper.LoadFiles.WriterMode.LoadfileOnly).WriteAsync(chaosStream, request, [], chaosEngine);
             var chaosBytes = chaosStream.ToArray();
 
-            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 1-2");
-            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => a.LineNumber == "Boundary 4-5");
+            var headerAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 1-2", StringComparison.Ordinal));
+            var lastLineAnomaly = chaosEngine.Anomalies.FirstOrDefault(a => string.Equals(a.LineNumber, "Boundary 4-5", StringComparison.Ordinal));
 
             Assert.NotNull(headerAnomaly);
             Assert.NotNull(lastLineAnomaly);

--- a/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
@@ -75,7 +75,7 @@ public class AdditionalGeneratorTests
             Range = new RangeConfig { Min = 100, Max = 200 }
         };
         var genRange = new NumberGenerator(colRange);
-        var val = int.Parse(genRange.Generate(context));
+        var val = int.Parse(genRange.Generate(context), System.Globalization.CultureInfo.InvariantCulture);
         Assert.InRange(val, 100, 200);
 
         // Exponential distribution
@@ -86,7 +86,7 @@ public class AdditionalGeneratorTests
             Range = new RangeConfig { Min = 50, Max = 150 }
         };
         var genExp = new NumberGenerator(colExp);
-        var expVal = int.Parse(genExp.Generate(context));
+        var expVal = int.Parse(genExp.Generate(context), System.Globalization.CultureInfo.InvariantCulture);
         Assert.InRange(expVal, 50, 150);
     }
 
@@ -100,7 +100,7 @@ public class AdditionalGeneratorTests
         var colSingle = new ColumnDefinition { MultiValue = false };
         var genSingle = new EmailAddressGenerator(colSingle, settings);
         var email = genSingle.Generate(context);
-        Assert.Contains("@", email);
+        Assert.Contains("@", email, StringComparison.Ordinal);
 
         // Multi value
         var colMulti = new ColumnDefinition
@@ -112,8 +112,8 @@ public class AdditionalGeneratorTests
         var emails = genMulti.Generate(context);
         var parts = emails.Split(';');
         Assert.Equal(2, parts.Length);
-        Assert.Contains("@", parts[0]);
-        Assert.Contains("@", parts[1]);
+        Assert.Contains("@", parts[0], StringComparison.Ordinal);
+        Assert.Contains("@", parts[1], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class AdditionalGeneratorTests
         var dateCreated = new LegacyDateCreatedGenerator().Generate(context);
         Assert.NotNull(dateCreated);
 
-        Assert.StartsWith("Author ", new LegacyAuthorGenerator().Generate(context));
+        Assert.StartsWith("Author ", new LegacyAuthorGenerator().Generate(context), StringComparison.Ordinal);
         Assert.Equal("2048", new LegacyFileSizeFromDataGenerator().Generate(context));
         Assert.NotEmpty(new LegacyRandomFileSizeGenerator().Generate(context));
 
@@ -168,7 +168,7 @@ public class AdditionalGeneratorTests
         // Paragraphs generator
         var colPara = new ColumnDefinition
         {
-            GeneratorParams = new Dictionary<string, object> { { "min", 2 }, { "max", 2 } }
+            GeneratorParams = new Dictionary<string, object>(StringComparer.Ordinal) { { "min", 2 }, { "max", 2 } }
         };
         var genPara = new LongTextGenerator(colPara);
         var text = genPara.Generate(context);

--- a/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/BooleanGeneratorTests.cs
@@ -30,7 +30,7 @@ public class BooleanGeneratorTests
         var col = new ColumnDefinition { Name = "Test", Format = "yn", TruePercentage = 50 };
         var generator = new BooleanGenerator(col);
 
-        var results = new HashSet<string>();
+        var results = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < 50; i++)
         {
             results.Add(generator.Generate(MakeContext(i)));
@@ -38,7 +38,7 @@ public class BooleanGeneratorTests
 
         Assert.Contains("Y", results);
         Assert.Contains("N", results);
-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
+        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class BooleanGeneratorTests
         var col = new ColumnDefinition { Name = "Test", Format = "truefalse", TruePercentage = 50 };
         var generator = new BooleanGenerator(col);
 
-        var results = new HashSet<string>();
+        var results = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < 50; i++)
         {
             results.Add(generator.Generate(MakeContext(i)));
@@ -58,7 +58,7 @@ public class BooleanGeneratorTests
 
         Assert.Contains("True", results);
         Assert.Contains("False", results);
-        Assert.Subset(new HashSet<string> { "True", "False" }, results);
+        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "True", "False" }, results);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class BooleanGeneratorTests
         var col = new ColumnDefinition { Name = "Test", Format = "10", TruePercentage = 50 };
         var generator = new BooleanGenerator(col);
 
-        var results = new HashSet<string>();
+        var results = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < 50; i++)
         {
             results.Add(generator.Generate(MakeContext(i)));
@@ -78,7 +78,7 @@ public class BooleanGeneratorTests
 
         Assert.Contains("1", results);
         Assert.Contains("0", results);
-        Assert.Subset(new HashSet<string> { "1", "0" }, results);
+        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "1", "0" }, results);
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public class BooleanGeneratorTests
         var col = new ColumnDefinition { Name = "Test", Format = null, TruePercentage = 50 };
         var generator = new BooleanGenerator(col);
 
-        var results = new HashSet<string>();
+        var results = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < 50; i++)
         {
             results.Add(generator.Generate(MakeContext(i)));
@@ -98,7 +98,7 @@ public class BooleanGeneratorTests
 
         Assert.Contains("Y", results);
         Assert.Contains("N", results);
-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
+        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ public class BooleanGeneratorTests
         var col = new ColumnDefinition { Name = "Test", Format = "unknown", TruePercentage = 50 };
         var generator = new BooleanGenerator(col);
 
-        var results = new HashSet<string>();
+        var results = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < 50; i++)
         {
             results.Add(generator.Generate(MakeContext(i)));
@@ -118,7 +118,7 @@ public class BooleanGeneratorTests
 
         Assert.Contains("Y", results);
         Assert.Contains("N", results);
-        Assert.Subset(new HashSet<string> { "Y", "N" }, results);
+        Assert.Subset(new HashSet<string>(StringComparer.Ordinal) { "Y", "N" }, results);
     }
 
     /// <summary>

--- a/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/CodedGeneratorTests.cs
@@ -45,7 +45,7 @@ public class CodedGeneratorTests
 
         var parts = result.Split(';');
         Assert.InRange(parts.Length, 2, 3);
-        Assert.Equal(parts.Length, parts.Distinct().Count());
+        Assert.Equal(parts.Length, parts.Distinct(StringComparer.Ordinal).Count());
     }
 
     [Fact(Timeout = 2000)]
@@ -62,7 +62,7 @@ public class CodedGeneratorTests
 
         var parts = result.Split(';');
         Assert.InRange(parts.Length, 2, 3);
-        Assert.Equal(parts.Length, parts.Distinct().Count());
+        Assert.Equal(parts.Length, parts.Distinct(StringComparer.Ordinal).Count());
     }
 
     [Fact]

--- a/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/ColumnValueGeneratorRegistryTests.cs
@@ -59,6 +59,6 @@ public class ColumnValueGeneratorRegistryTests
     public void KnownTypes_HasNoUnknownDuplicates()
     {
         // Each entry should be distinct (HashSet enforces uniqueness)
-        Assert.Equal(ColumnValueGeneratorRegistry.KnownTypes.Count, ColumnValueGeneratorRegistry.KnownTypes.ToHashSet().Count);
+        Assert.Equal(ColumnValueGeneratorRegistry.KnownTypes.Count, ColumnValueGeneratorRegistry.KnownTypes.ToHashSet(StringComparer.Ordinal).Count);
     }
 }

--- a/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/DateGeneratorTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable RS0030 // Do not use banned APIs
 using System.Globalization;
 using Xunit;
 using Zipper.Profiles;

--- a/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/DateTimeColumnGeneratorTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable RS0030 // Do not use banned APIs
 using System.Globalization;
 using Xunit;
 using Zipper.Profiles;
@@ -105,7 +106,7 @@ public class DateTimeColumnGeneratorTests
         var settings = new ProfileSettings { DateTimeFormat = "yyyy-MM-dd HH:mm" };
         var generator = new DateTimeColumnGenerator(col, settings);
 
-        var generatedTimes = new HashSet<string>();
+        var generatedTimes = new HashSet<string>(StringComparer.Ordinal);
         var context = MakeContext();
         for (int i = 0; i < 50; i++)
         {

--- a/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/NumberGeneratorTests.cs
@@ -36,7 +36,7 @@ public class NumberGeneratorTests
 
         for (int i = 0; i < 50; i++)
         {
-            var result = int.Parse(generator.Generate(MakeContext(i)));
+            var result = int.Parse(generator.Generate(MakeContext(i)), System.Globalization.CultureInfo.InvariantCulture);
             Assert.InRange(result, 10, 20);
         }
     }
@@ -55,7 +55,7 @@ public class NumberGeneratorTests
         var generator = new NumberGenerator(col);
 
         var context = MakeContext();
-        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context))).ToList();
+        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context), System.Globalization.CultureInfo.InvariantCulture)).ToList();
 
         Assert.Contains(results, x => x == 1);
         Assert.Contains(results, x => x == 10);
@@ -77,7 +77,7 @@ public class NumberGeneratorTests
         var generator = new NumberGenerator(col);
 
         var context = MakeContext();
-        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context))).ToList();
+        var results = Enumerable.Range(0, 1000).Select(_ => int.Parse(generator.Generate(context), System.Globalization.CultureInfo.InvariantCulture)).ToList();
 
         Assert.All(results, x => Assert.InRange(x, 0, 100));
         var average = results.Average();

--- a/src/Zipper.Tests/ProgramTests.cs
+++ b/src/Zipper.Tests/ProgramTests.cs
@@ -15,7 +15,7 @@ namespace Zipper
                 using var errWriter = new StringWriter();
                 Console.SetOut(outWriter);
                 Console.SetError(errWriter);
-                return await action();
+                return await action().ConfigureAwait(false);
             }
             finally
             {
@@ -41,7 +41,7 @@ namespace Zipper
         public async Task Main_WithInvalidArguments_ReturnsErrorCode()
         {
             // Arrange - Missing required arguments
-            string[] args = { };
+            string[] args = Array.Empty<string>();
 
             // Act
             int exitCode = await RunWithRedirectedConsole(() => Program.Main(args));
@@ -197,13 +197,13 @@ namespace Zipper
                                       .Where(f => !f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
                                                   !f.EndsWith(".dat", StringComparison.OrdinalIgnoreCase) &&
                                                   !f.Contains("_properties.json", StringComparison.OrdinalIgnoreCase))
-                                      .OrderBy(n => n).ToList();
+                                      .OrderBy(n => n, StringComparer.Ordinal).ToList();
                 var files2 = Directory.GetFiles(tempPath2, "*.*", SearchOption.AllDirectories)
                                       .Select(f => Path.GetRelativePath(tempPath2, f))
                                       .Where(f => !f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
                                                   !f.EndsWith(".dat", StringComparison.OrdinalIgnoreCase) &&
                                                   !f.Contains("_properties.json", StringComparison.OrdinalIgnoreCase))
-                                      .OrderBy(n => n).ToList();
+                                      .OrderBy(n => n, StringComparer.Ordinal).ToList();
 
                 Assert.Equal(files1, files2);
 
@@ -313,8 +313,8 @@ namespace Zipper
                 using (var archive1 = System.IO.Compression.ZipFile.OpenRead(zipFile1))
                 using (var archive2 = System.IO.Compression.ZipFile.OpenRead(zipFile2))
                 {
-                    var entries1 = archive1.Entries.OrderBy(e => e.FullName).ToList();
-                    var entries2 = archive2.Entries.OrderBy(e => e.FullName).ToList();
+                    var entries1 = archive1.Entries.OrderBy(e => e.FullName, StringComparer.Ordinal).ToList();
+                    var entries2 = archive2.Entries.OrderBy(e => e.FullName, StringComparer.Ordinal).ToList();
 
                     Assert.Equal(entries1.Count, entries2.Count);
                     for (int i = 0; i < entries1.Count; i++)

--- a/src/Zipper.Tests/ReviewNoteDataTests.cs
+++ b/src/Zipper.Tests/ReviewNoteDataTests.cs
@@ -24,6 +24,6 @@ public class ReviewNoteDataTests
     public void GetRandomNote_EndsWithPeriod()
     {
         var result = ReviewNotes.GetRandomNote(new Random(42));
-        Assert.EndsWith(".", result);
+        Assert.EndsWith(".", result, StringComparison.Ordinal);
     }
 }

--- a/src/Zipper.Tests/SmokeTests.cs
+++ b/src/Zipper.Tests/SmokeTests.cs
@@ -28,7 +28,7 @@ public class SmokeTests
             var datContent = await File.ReadAllTextAsync(datFiles[0]);
             var datLines = datContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(101, datLines.Length); // 100 records + 1 header
-            Assert.Contains("DOC00000001", datContent);
+            Assert.Contains("DOC00000001", datContent, StringComparison.Ordinal);
         }
         finally
         {
@@ -61,8 +61,8 @@ public class SmokeTests
             var datFiles = Directory.GetFiles(tempDir, "*.dat");
             Assert.Single(datFiles);
             var datContent = await File.ReadAllTextAsync(datFiles[0]);
-            Assert.Contains("Attachment", datContent);
-            Assert.Contains("Subject", datContent);
+            Assert.Contains("Attachment", datContent, StringComparison.Ordinal);
+            Assert.Contains("Subject", datContent, StringComparison.Ordinal);
         }
         finally
         {
@@ -95,7 +95,7 @@ public class SmokeTests
             var datFiles = Directory.GetFiles(tempDir, "*.dat");
             Assert.Single(datFiles);
             var datContent = await File.ReadAllTextAsync(datFiles[0]);
-            Assert.Contains("Page Count", datContent);
+            Assert.Contains("Page Count", datContent, StringComparison.Ordinal);
         }
         finally
         {
@@ -126,17 +126,17 @@ public class SmokeTests
             var datContent = await File.ReadAllTextAsync(datFiles[0]);
             var datLines = datContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(11, datLines.Length); // 10 records + 1 header
-            Assert.Contains("DOC00000001", datContent);
+            Assert.Contains("DOC00000001", datContent, StringComparison.Ordinal);
 
             // Verify load file column structure
             var header = datLines[0];
-            Assert.Contains("\x14", header);
-            Assert.Contains("\xFE", header);
+            Assert.Contains("\x14", header, StringComparison.Ordinal);
+            Assert.Contains("\xFE", header, StringComparison.Ordinal);
 
             var propFiles = Directory.GetFiles(tempDir, "*_properties.json");
             Assert.Single(propFiles);
             var propContent = await File.ReadAllTextAsync(propFiles[0]);
-            Assert.Contains("DAT (Metadata)", propContent);
+            Assert.Contains("DAT (Metadata)", propContent, StringComparison.Ordinal);
         }
         finally
         {
@@ -170,7 +170,7 @@ public class SmokeTests
             var propFiles = Directory.GetFiles(tempDir, "*_properties.json");
             Assert.Single(propFiles);
             var propContent = await File.ReadAllTextAsync(propFiles[0]);
-            Assert.Contains("\"enabled\": true", propContent);
+            Assert.Contains("\"enabled\": true", propContent, StringComparison.Ordinal);
         }
         finally
         {
@@ -275,8 +275,8 @@ public class SmokeTests
             Assert.Single(optFiles);
 
             var optContent = await File.ReadAllTextAsync(optFiles[0]);
-            Assert.Contains("DOC00000001", optContent);
-            Assert.Contains("VOL001", optContent);
+            Assert.Contains("DOC00000001", optContent, StringComparison.Ordinal);
+            Assert.Contains("VOL001", optContent, StringComparison.Ordinal);
 
             // Clean up files in tempDir
             foreach (var file in Directory.GetFiles(tempDir))
@@ -296,7 +296,7 @@ public class SmokeTests
             Assert.Single(optFiles);
 
             var optContentJpg = await File.ReadAllTextAsync(optFiles[0]);
-            Assert.Contains("DOC00000001", optContentJpg);
+            Assert.Contains("DOC00000001", optContentJpg, StringComparison.Ordinal);
         }
         finally
         {
@@ -329,9 +329,9 @@ public class SmokeTests
             var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             Assert.True(lines.Length > 0);
             var header = lines[0];
-            Assert.Contains("BEGATTACH", header);
-            Assert.Contains("ENDATTACH", header);
-            Assert.Contains("PARENTDOCID", header);
+            Assert.Contains("BEGATTACH", header, StringComparison.Ordinal);
+            Assert.Contains("ENDATTACH", header, StringComparison.Ordinal);
+            Assert.Contains("PARENTDOCID", header, StringComparison.Ordinal);
 
             // Assert there are more rows than emails since there are child attachment rows
             Assert.True(lines.Length > 6);

--- a/src/Zipper.Tests/TimeZoneDataTests.cs
+++ b/src/Zipper.Tests/TimeZoneDataTests.cs
@@ -6,7 +6,7 @@ namespace Zipper.Tests;
 public class TimeZoneDataTests
 {
     private static readonly System.Collections.Generic.HashSet<string> ValidTimeZones =
-        new() { "UTC", "America/New_York", "America/Los_Angeles", "America/Chicago", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Shanghai" };
+        new(StringComparer.Ordinal) { "UTC", "America/New_York", "America/Los_Angeles", "America/Chicago", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Shanghai" };
 
     [Fact]
     public void GetRandom_ReturnsNonEmptyString()

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -179,7 +179,7 @@ namespace Zipper.Tests
 
             // Should have 2 EML files and 2 attachments
             var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
-            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment")).ToList();
+            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment", StringComparison.Ordinal)).ToList();
 
             Assert.Equal(2, emlEntries.Count);
             Assert.Equal(2, attachmentEntries.Count);
@@ -315,9 +315,9 @@ namespace Zipper.Tests
             Assert.Equal(8, archive.Entries.Count);
 
             var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
-            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal) && !e.FullName.Contains("attachment")).ToList();
-            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && !e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
-            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal) && !e.FullName.Contains("attachment", StringComparison.Ordinal)).ToList();
+            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment", StringComparison.Ordinal) && !e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment", StringComparison.Ordinal) && e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
 
             Assert.Equal(2, emlEntries.Count);
             Assert.Equal(2, emlTextEntries.Count);

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -46,7 +46,7 @@ namespace Zipper.Tests
             // Assert
             Assert.True(File.Exists(zipPath));
             using var archive = ZipFile.OpenRead(zipPath);
-            Assert.Equal(5, archive.Entries.Count(e => e.FullName.EndsWith(".pdf")));
+            Assert.Equal(5, archive.Entries.Count(e => e.FullName.EndsWith(".pdf", StringComparison.Ordinal)));
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace Zipper.Tests
             Assert.Equal(6, archive.Entries.Count); // 3 PDF files + 3 text files
 
             // Verify text files exist
-            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt")).ToList();
+            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
             Assert.Equal(3, textEntries.Count);
         }
 
@@ -178,7 +178,7 @@ namespace Zipper.Tests
             using var archive = ZipFile.OpenRead(zipPath);
 
             // Should have 2 EML files and 2 attachments
-            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml")).ToList();
+            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
             var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment")).ToList();
 
             Assert.Equal(2, emlEntries.Count);
@@ -228,8 +228,8 @@ namespace Zipper.Tests
             // Should have: 2 PDF files + 2 text files + 1 load file + 1 properties file = 6 total files
             Assert.Equal(6, archive.Entries.Count);
 
-            var pdfEntries = archive.Entries.Where(e => e.FullName.EndsWith(".pdf")).ToList();
-            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt")).ToList();
+            var pdfEntries = archive.Entries.Where(e => e.FullName.EndsWith(".pdf", StringComparison.Ordinal)).ToList();
+            var textEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
             var loadEntry = archive.GetEntry("load.dat");
 
             Assert.Equal(2, pdfEntries.Count);
@@ -314,10 +314,10 @@ namespace Zipper.Tests
             // Should have: 2 EML files + 2 EML text files + 2 attachments + 2 attachment text files = 8 total
             Assert.Equal(8, archive.Entries.Count);
 
-            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml")).ToList();
-            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt") && !e.FullName.Contains("attachment")).ToList();
-            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && !e.FullName.EndsWith(".txt")).ToList();
-            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && e.FullName.EndsWith(".txt")).ToList();
+            var emlEntries = archive.Entries.Where(e => e.FullName.EndsWith(".eml", StringComparison.Ordinal)).ToList();
+            var emlTextEntries = archive.Entries.Where(e => e.FullName.EndsWith(".txt", StringComparison.Ordinal) && !e.FullName.Contains("attachment")).ToList();
+            var attachmentEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && !e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
+            var attachmentTextEntries = archive.Entries.Where(e => e.FullName.Contains("attachment") && e.FullName.EndsWith(".txt", StringComparison.Ordinal)).ToList();
 
             Assert.Equal(2, emlEntries.Count);
             Assert.Equal(2, emlTextEntries.Count);

--- a/src/Zipper.Tests/packages.lock.json
+++ b/src/Zipper.Tests/packages.lock.json
@@ -14,6 +14,18 @@
         "resolved": "4.1.0",
         "contentHash": "DsED7jD2lJK8K3Chpex38yNH2UmuKck1ML4QtSeBVk+eH7uVJL95peTmg6sxEje93IOu9bn1dMfXPqtsfAWcBg=="
       },
+      "Meziantou.Analyzer": {
+        "type": "Direct",
+        "requested": "[3.0.102, )",
+        "resolved": "3.0.102",
+        "contentHash": "WhGaJ3QsULOtDUXqZIDMZqTnZ68wvl6UMvPjkdxcZVIe/n3sfJyd2rDRVO3Ea7KitP0xUn3M85L/t7+JGkt63w=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.6.0, )",

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -15,6 +15,18 @@
           "SixLabors.Fonts": "1.0.0"
         }
       },
+      "Meziantou.Analyzer": {
+        "type": "Direct",
+        "requested": "[3.0.102, )",
+        "resolved": "3.0.102",
+        "contentHash": "WhGaJ3QsULOtDUXqZIDMZqTnZ68wvl6UMvPjkdxcZVIe/n3sfJyd2rDRVO3Ea7KitP0xUn3M85L/t7+JGkt63w=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
         "requested": "[10.0.8, )",


### PR DESCRIPTION
Closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed datetime handling to use UTC timestamps instead of local time for consistency across time zones.

* **Chores**
  * Integrated code analyzer (Meziantou.Analyzer) to enhance code quality checks and enforce API usage standards.
  * Updated configuration for banned API detection to guide developers toward safer alternatives (e.g., UtcNow, InvariantCulture, IFormatProvider overloads).
  * Improved async operations throughout the codebase with context-free continuations and optimized synchronization primitives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->