### PR TITLE
test: close coverage gaps in PathValidator, composers, generators, and modes

### DIFF
--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -649,4 +649,178 @@ string.Equals(responsiveValue, "Y", StringComparison.Ordinal) || string.Equals(r
         Assert.InRange(cust1Percent, 45.0, 55.0);
         Assert.InRange(cust2Percent, 45.0, 55.0);
     }
+
+    /// <summary>
+    /// Test that the date format override is applied to date columns without an explicit format.
+    /// </summary>
+    [Fact]
+    public void Constructor_DateFormatOverride_AppliesToDateColumns()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "date-format-override",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DATECREATED", Type = "date", Required = true },
+            },
+        };
+
+        var generator = new DataGenerator(profile, seed: 42, dateFormatOverride: "dd/MM/yyyy");
+        var workItem = new FileWorkItem { Index = 1, FilePathInZip = "Folder001/file001.pdf" };
+        var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+
+        var row = generator.GenerateRow(workItem, fileData);
+
+        Assert.Matches(@"^\d{2}/\d{2}/\d{4}$", row["DATECREATED"]);
+    }
+
+    /// <summary>
+    /// Test that an empty percentage override of zero suppresses empty values and bumps
+    /// zero-minimum multi-value counts so every value is populated.
+    /// </summary>
+    [Fact]
+    public void Constructor_EmptyPercentageOverrideZero_ProducesNoEmptyValues()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "empty-override-zero",
+            Settings = new ProfileSettings { EmptyValuePercentage = 90 },
+            DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal)
+            {
+                ["tags"] = new DataSourceConfig { Count = 3, Prefix = "Tag_" },
+            },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "NOTE", Type = "text", EmptyPercentage = 90 },
+                new()
+                {
+                    Name = "TAGS",
+                    Type = "coded",
+                    DataSource = "tags",
+                    MultiValue = true,
+                    MultiValueCount = new RangeConfig { Min = 0, Max = 2 },
+                },
+            },
+        };
+
+        var generator = new DataGenerator(profile, seed: 42, emptyPercentageOverride: 0);
+
+        for (int i = 1; i <= 50; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"Folder/doc{i}.pdf" };
+            var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            Assert.NotEqual(string.Empty, row["NOTE"]);
+            Assert.NotEqual(string.Empty, row["TAGS"]);
+        }
+    }
+
+    /// <summary>
+    /// Test that an empty percentage override of 100 forces all non-required columns empty
+    /// while required columns keep their values.
+    /// </summary>
+    [Fact]
+    public void Constructor_EmptyPercentageOverrideFull_EmptiesNonRequiredColumnsOnly()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "empty-override-full",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "DOCID", Type = "identifier", Required = true },
+                new() { Name = "NOTE", Type = "text", EmptyPercentage = 0 },
+            },
+        };
+
+        var generator = new DataGenerator(profile, seed: 42, emptyPercentageOverride: 100);
+
+        for (int i = 1; i <= 20; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"Folder/doc{i}.pdf" };
+            var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            Assert.NotEqual(string.Empty, row["DOCID"]);
+            Assert.Equal(string.Empty, row["NOTE"]);
+        }
+    }
+
+    /// <summary>
+    /// Test that legacy and synthetic-email column types resolve to their dedicated generators.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_LegacyAndSyntheticEmailColumnTypes_ProduceExpectedShapes()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "legacy-types",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "CUSTODIAN", Type = "indexcustodian", Required = true },
+                new() { Name = "DATECREATED", Type = "legacydatecreated", Required = true },
+                new() { Name = "FILESIZE", Type = "randomfilesize", Required = true },
+                new() { Name = "TO", Type = "syntheticemailto", Required = true },
+                new() { Name = "FROM", Type = "syntheticemailfrom", Required = true },
+                new() { Name = "SUBJECT", Type = "syntheticemailsubject", Required = true },
+                new() { Name = "SENTDATE", Type = "syntheticemailsentdate", Required = true },
+            },
+        };
+
+        var generator = new DataGenerator(profile, seed: 42);
+        var workItem = new FileWorkItem { Index = 7, FolderNumber = 3, FilePathInZip = "Folder003/doc7.pdf" };
+        var fileData = new FileData { Data = new byte[256], WorkItem = workItem };
+
+        var row = generator.GenerateRow(workItem, fileData);
+
+        Assert.Equal("Custodian 8", row["CUSTODIAN"]); // (7 % 10) + 1
+        Assert.NotEmpty(row["DATECREATED"]);
+        Assert.True(long.Parse(row["FILESIZE"], System.Globalization.CultureInfo.InvariantCulture) > 0);
+        Assert.Contains("@", row["TO"], StringComparison.Ordinal);
+        Assert.Contains("@", row["FROM"], StringComparison.Ordinal);
+        Assert.NotEmpty(row["SUBJECT"]);
+        Assert.NotEmpty(row["SENTDATE"]);
+    }
+
+    /// <summary>
+    /// Test that a weighted data source whose weights sum to zero falls back to a uniform draw
+    /// instead of failing.
+    /// </summary>
+    [Fact]
+    public void GenerateRow_WeightedSourceWithZeroTotalWeight_FallsBackToUniformDraw()
+    {
+        var profile = new ColumnProfile
+        {
+            Name = "zero-weights",
+            Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+            DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal)
+            {
+                ["tags"] = new DataSourceConfig
+                {
+                    Values = new List<string> { "alpha", "beta", "gamma" },
+                    Weights = new List<int> { 0, 0, 0 },
+                    Distribution = "weighted",
+                },
+            },
+            Columns = new List<ColumnDefinition>
+            {
+                new() { Name = "TAG", Type = "coded", DataSource = "tags", Required = true },
+            },
+        };
+
+        var generator = new DataGenerator(profile, seed: 42);
+        var validValues = new HashSet<string>(StringComparer.Ordinal) { "alpha", "beta", "gamma" };
+
+        for (int i = 1; i <= 20; i++)
+        {
+            var workItem = new FileWorkItem { Index = i, FilePathInZip = $"Folder/doc{i}.pdf" };
+            var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
+            var row = generator.GenerateRow(workItem, fileData);
+
+            Assert.Contains(row["TAG"], validValues);
+        }
+    }
 }

--- a/src/Zipper.Tests/GenerationModeTests.cs
+++ b/src/Zipper.Tests/GenerationModeTests.cs
@@ -1,0 +1,122 @@
+using Xunit;
+
+namespace Zipper;
+
+/// <summary>
+/// End-to-end tests for the generation mode orchestration branches
+/// (StandardMode, ProductionSetMode, LoadfileOnlyMode) driven through Program.Main.
+/// </summary>
+public class GenerationModeTests
+{
+    [Fact]
+    public async Task Main_StandardModeWithIncludeLoadFile_EmbedsLoadFileInArchive()
+    {
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var args = new[] { "--type", "pdf", "--count", "5", "--output-path", tempDir, "--include-load-file", "--seed", "42" };
+            var result = await Program.Main(args);
+
+            Assert.Equal(0, result);
+
+            var zipFile = Directory.GetFiles(tempDir, "*.zip").FirstOrDefault();
+            Assert.NotNull(zipFile);
+
+            using var archive = System.IO.Compression.ZipFile.OpenRead(zipFile!);
+            Assert.Contains(archive.Entries, e => e.Name.EndsWith(".dat", StringComparison.OrdinalIgnoreCase));
+
+            // The load file lives inside the archive, so no loose load file is emitted.
+            Assert.Empty(Directory.GetFiles(tempDir, "*.dat"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Main_StandardModeWithTargetZipSizeFarFromActual_WarnsButSucceeds()
+    {
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // 10KB target with 10 placeholder PDFs lands well outside the +/-10% tolerance,
+            // exercising the deviation warning branch while still completing successfully.
+            var args = new[] { "--type", "pdf", "--count", "10", "--output-path", tempDir, "--target-zip-size", "10KB", "--seed", "42" };
+            var result = await Program.Main(args);
+
+            Assert.Equal(0, result);
+            Assert.NotNull(Directory.GetFiles(tempDir, "*.zip").FirstOrDefault());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Main_ProductionSetModeWithProductionZip_CreatesZipArchive()
+    {
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var args = new[]
+            {
+                "--production-set", "--count", "3", "--output-path", tempDir,
+                "--bates-prefix", "TST", "--type", "pdf", "--production-zip", "--seed", "42",
+            };
+            var result = await Program.Main(args);
+
+            Assert.Equal(0, result);
+
+            var zipFile = Directory.GetFiles(tempDir, "*.zip", SearchOption.AllDirectories).FirstOrDefault();
+            Assert.NotNull(zipFile);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Main_LoadfileOnlyModeWithChaosTypes_GeneratesLoadFile()
+    {
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var args = new[]
+            {
+                "--loadfile-only", "--count", "5", "--output-path", tempDir,
+                "--chaos-mode", "--chaos-types", "quotes", "--seed", "42",
+            };
+            var result = await Program.Main(args);
+
+            Assert.Equal(0, result);
+            Assert.NotEmpty(Directory.GetFiles(tempDir, "*.dat"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
@@ -102,4 +102,83 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
         Assert.Contains("CONTROLNUMBER", lines_split[0], StringComparison.Ordinal);
         Assert.Contains("PATH", lines_split[0], StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task WriteAsync_EmlWithTextAndBates_EmitsEmailTextPathAndBatesColumns()
+    {
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig { OutputPath = this.TempDir, FileCount = 2, FileType = "eml", WithText = true },
+            LoadFile = new LoadFileConfig { Encoding = "UTF-8" },
+            Metadata = new MetadataConfig { WithMetadata = true, Seed = 42 },
+            Bates = new BatesNumberConfig { Prefix = "TST", Start = 1, Digits = 6 },
+        };
+
+        var files = new List<FileData>
+        {
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderNumber = 1,
+                    FileName = "doc1.eml",
+                    FilePathInZip = "folder/doc1.eml",
+                },
+                DataLength = 100,
+                Email = new Zipper.Emails.Email
+                {
+                    To = "alice@example.com",
+                    From = "bob@example.com",
+                    Subject = "Quarterly Report",
+                    SentDate = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+                },
+                Attachment = ("invoice.pdf", new byte[] { 1, 2, 3 }),
+            },
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 2,
+                    FolderNumber = 1,
+                    FileName = "doc2.eml",
+                    FilePathInZip = "folder/doc2.eml",
+                },
+                DataLength = 50,
+            },
+        };
+
+        var writer = new ConcordanceComposingWriter();
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, request, files);
+
+        var content = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(3, lines.Length);
+
+        // Header must use Concordance names for the email, text, and Bates columns.
+        Assert.Contains("þTOþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þFROMþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þSUBJECTþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þSENTDATEþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þATTACHMENTþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þTEXT_PATHþ", lines[0], StringComparison.Ordinal);
+        Assert.Contains("þBATESþ", lines[0], StringComparison.Ordinal);
+
+        // First record carries the explicit email template and attachment values.
+        Assert.Contains("þalice@example.comþ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þbob@example.comþ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þQuarterly Reportþ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þ2024-01-15 10:30:00þ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þinvoice.pdfþ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þfolder/doc1.txtþ", lines[1], StringComparison.Ordinal);
+        Assert.Contains("þTST000001þ", lines[1], StringComparison.Ordinal);
+
+        // Second record has no email template, so synthetic fallbacks are used.
+        Assert.Contains("þrecipient2@example.comþ", lines[2], StringComparison.Ordinal);
+        Assert.Contains("þsender2@example.comþ", lines[2], StringComparison.Ordinal);
+        Assert.Contains("þEmail Subject 2þ", lines[2], StringComparison.Ordinal);
+        Assert.Contains("þfolder/doc2.txtþ", lines[2], StringComparison.Ordinal);
+    }
 }

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -375,5 +375,105 @@ namespace Zipper
                 if (Directory.Exists(targetDir)) Directory.Delete(targetDir, true);
             }
         }
+
+        [Fact]
+        public void IsPathSafe_PathWithEmbeddedNull_ReturnsFalse()
+        {
+            var result = PathValidator.IsPathSafe("folder\0name", Directory.GetCurrentDirectory());
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_SymlinkWithChildSuffix_EscapingBase_ReturnsNull()
+        {
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseSuffixTest_" + Guid.NewGuid().ToString());
+            string targetDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperTargetSuffixTest_" + Guid.NewGuid().ToString());
+
+            Directory.CreateDirectory(baseDir);
+            Directory.CreateDirectory(targetDir);
+
+            string linkPath = Path.Combine(baseDir, "symlink");
+            try
+            {
+                try
+                {
+                    Directory.CreateSymbolicLink(linkPath, targetDir);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Symlink creation is not permitted (e.g. Windows non-admin); skip.
+                    return;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    return;
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    return;
+                }
+                catch (System.IO.IOException ex) when (ex.Message.Contains("privilege") || ex.HResult == -2147024564)
+                {
+                    return;
+                }
+
+                // The child segment does not exist on disk, so resolution must walk up to the
+                // symlink and rebuild the path from the resolved target plus the child suffix.
+                var escapePath = Path.Combine(linkPath, "child");
+                var result = PathValidator.ValidateAndCreateDirectory(escapePath, baseDir);
+                Assert.Null(result);
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
+                if (Directory.Exists(targetDir)) Directory.Delete(targetDir, true);
+            }
+        }
+
+        [Fact]
+        public void ValidateAndCreateDirectory_SymlinkWithChildSuffix_InsideBase_ReturnsDirectoryInfo()
+        {
+            string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseInsideTest_" + Guid.NewGuid().ToString());
+            string targetDir = Path.Combine(baseDir, "real");
+
+            Directory.CreateDirectory(baseDir);
+            Directory.CreateDirectory(targetDir);
+
+            string linkPath = Path.Combine(baseDir, "symlink");
+            try
+            {
+                try
+                {
+                    Directory.CreateSymbolicLink(linkPath, targetDir);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    return;
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    return;
+                }
+                catch (System.IO.IOException ex) when (ex.Message.Contains("privilege") || ex.HResult == -2147024564)
+                {
+                    return;
+                }
+
+                var insidePath = Path.Combine(linkPath, "child");
+                var result = PathValidator.ValidateAndCreateDirectory(insidePath, baseDir);
+
+                Assert.NotNull(result);
+                Assert.StartsWith(baseDir, result.FullName, StringComparison.Ordinal);
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true);
+            }
+        }
     }
 }

--- a/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/AdditionalGeneratorTests.cs
@@ -206,4 +206,107 @@ public class AdditionalGeneratorTests
         var genNamed = new TextGenerator(colGen, null, null);
         Assert.NotEmpty(genNamed.Generate(context));
     }
+
+    [Theory]
+    [InlineData("sha1hash", 40)]
+    [InlineData("md5hash", 32)]
+    [InlineData("sha256hash", 64)]
+    public void Generate_Text_HashGenerators_ProduceLowercaseHexOfExpectedLength(string generatorName, int expectedLength)
+    {
+        var col = new ColumnDefinition { Name = "HASH", Generator = generatorName };
+        var gen = new TextGenerator(col, null, null);
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.Equal(expectedLength, value.Length);
+        Assert.Matches("^[0-9a-f]+$", value);
+    }
+
+    [Fact]
+    public void Generate_Text_ReviewNoteGenerator_ProducesNonEmptyNote()
+    {
+        var col = new ColumnDefinition { Name = "NOTE", Generator = "reviewnote" };
+        var gen = new TextGenerator(col, null, null);
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.NotEmpty(value);
+    }
+
+    [Fact]
+    public void Generate_Text_TimezoneGenerator_ProducesNonEmptyTimezone()
+    {
+        var col = new ColumnDefinition { Name = "TZ", Generator = "timezone" };
+        var gen = new TextGenerator(col, null, null);
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.NotEmpty(value);
+    }
+
+    [Fact]
+    public void Generate_Text_UnknownNamedGenerator_FallsBackToGeneratedValue()
+    {
+        var col = new ColumnDefinition { Name = "CUSTOM", Generator = "doesnotexist" };
+        var gen = new TextGenerator(col, null, null);
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.Equal("Generated_doesnotexist_12", value);
+    }
+
+    [Theory]
+    [InlineData("FILEPATH")]
+    [InlineData("FILENAME")]
+    [InlineData("FILEEXT")]
+    public void Generate_Text_FileColumnsWithoutFileData_ReturnEmpty(string columnName)
+    {
+        var col = new ColumnDefinition { Name = columnName };
+        var gen = new TextGenerator(col, null, null);
+        var context = new ColumnGenerationContext
+        {
+            NativeFileIndex = 1,
+            FolderNumber = 1,
+            DocumentIndex = 1,
+            Seeded = new Random(7),
+            Now = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc),
+            FileData = null,
+        };
+
+        var value = gen.Generate(context);
+
+        Assert.Equal(string.Empty, value);
+    }
+
+    [Fact]
+    public void Generate_Date_ExplicitDateRangeWithEqualBounds_ReturnsThatDate()
+    {
+        var col = new ColumnDefinition
+        {
+            Name = "DATESENT",
+            Format = "yyyy-MM-dd",
+            DateRange = new DateRangeConfig { Min = "2023-05-17", Max = "2023-05-17" },
+        };
+        var gen = new DateGenerator(col, new ProfileSettings());
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.Equal("2023-05-17", value);
+    }
+
+    [Fact]
+    public void Generate_DateTime_ExplicitDateRangeWithEqualBounds_StaysOnThatDay()
+    {
+        var col = new ColumnDefinition
+        {
+            Name = "SENTSTAMP",
+            Format = "yyyy-MM-dd HH:mm",
+            DateRange = new DateRangeConfig { Min = "2023-05-17", Max = "2023-05-17" },
+        };
+        var gen = new DateTimeColumnGenerator(col, new ProfileSettings());
+
+        var value = gen.Generate(this.CreateContext());
+
+        Assert.StartsWith("2023-05-17 ", value, StringComparison.Ordinal);
+    }
 }

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
## Summary

Coverage audit found the suite at 94.1% line / 83.0% branch with concentrated gaps in defensive paths and rarely-exercised switch arms. This PR adds behavioral tests only (no production changes), raising coverage to **95.1% line / 86.3% branch**. Suite grows 1045 → 1069 tests, all green.

## Per-class impact

| Class | Line | Branch |
|---|---|---|
| PathValidator | 74/96 → 83/96 | 22/28 → 25/28 |
| ConcordanceComposer | 17/24 → 23/24 | 38/78 → 54/78 |
| SyntheticRowValues | — | 9/18 → **18/18** |
| TextGenerator | 44/48 → **48/48** | 33/58 → **58/58** |
| DataGenerator | 155/186 → 182/186 | 131/200 → 159/200 |
| StandardMode | 46/54 → **54/54** | 17/20 → 19/20 |
| ProductionSetMode | 22/28 → **28/28** | 6/12 → 8/12 |
| LoadfileOnlyMode | 18/21 → **21/21** | 5/6 → **6/6** |
| DateGenerator | — | 8/12 → **12/12** |

## What's covered now

- **PathValidator** (security-relevant): `IsPathSafe` catch-all fallback, symlink resolution through a non-existent child suffix (escape detection + inside-base acceptance) covering `RebuildPathFromParts`
- **ConcordanceComposer**: EML + text + Bates request exercises TO/FROM/SUBJECT/SENTDATE/ATTACHMENT/TEXT_PATH header arms and both `SyntheticRowValues.Eml` fallback sides
- **TextGenerator**: all named generators (hashes, reviewnote, timezone, unknown fallback) and null-FileData file columns
- **DataGenerator**: ctor overrides (date format, empty percentage incl. multi-value min bump), legacy/synthetic-email column types, zero-total-weight uniform fallback
- **Modes via `Program.Main`**: `--include-load-file` embedding, `--target-zip-size` deviation warning, `--production-zip`, loadfile-only chaos with `--chaos-types`

## Not covered (intentionally)

`PathValidator` PathTooLong/NotSupported/generic catch blocks are untriggerable on Linux (`Path.GetFullPath` performs no syscalls there); covering them would require production refactoring, which conflicts with the surgical-changes rule.

## Verification

- `dotnet build zipper.sln` clean
- `dotnet format --verify-no-changes src/` clean
- `dotnet test` — 1069 passed, 0 failed, 0 skipped
- `tests/run-e2e-basic.sh` — 6/6 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for data generation with override options, ensuring consistent behavior across date formatting, empty value handling, and weighted data sources.
  * Added end-to-end tests validating generation modes, zip archive creation, and load file embedding.
  * Expanded test suite for output file formatting, path validation scenarios, and text/date generator functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->