### PR TITLE
test: address Gemini review findings from PR #479

### DIFF
--- a/src/Zipper.Tests/DataGeneratorTests.cs
+++ b/src/Zipper.Tests/DataGeneratorTests.cs
@@ -712,8 +712,8 @@ string.Equals(responsiveValue, "Y", StringComparison.Ordinal) || string.Equals(r
             var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
             var row = generator.GenerateRow(workItem, fileData);
 
-            Assert.NotEqual(string.Empty, row["NOTE"]);
-            Assert.NotEqual(string.Empty, row["TAGS"]);
+            Assert.NotEmpty(row["NOTE"]);
+            Assert.NotEmpty(row["TAGS"]);
         }
     }
 
@@ -743,7 +743,7 @@ string.Equals(responsiveValue, "Y", StringComparison.Ordinal) || string.Equals(r
             var fileData = new FileData { Data = new byte[128], WorkItem = workItem };
             var row = generator.GenerateRow(workItem, fileData);
 
-            Assert.NotEqual(string.Empty, row["DOCID"]);
+            Assert.NotEmpty(row["DOCID"]);
             Assert.Equal(string.Empty, row["NOTE"]);
         }
     }

--- a/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/ConcordanceWriterTests.cs
@@ -153,7 +153,7 @@ public class ConcordanceWriterTests : TempDirectoryTestBase
         await writer.WriteAsync(stream, request, files);
 
         var content = System.Text.Encoding.UTF8.GetString(stream.ToArray());
-        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(3, lines.Length);
 

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -413,7 +413,7 @@ namespace Zipper
                 {
                     return;
                 }
-                catch (System.IO.IOException ex) when (ex.Message.Contains("privilege") || ex.HResult == -2147024564)
+                catch (System.IO.IOException)
                 {
                     return;
                 }
@@ -459,7 +459,7 @@ namespace Zipper
                 {
                     return;
                 }
-                catch (System.IO.IOException ex) when (ex.Message.Contains("privilege") || ex.HResult == -2147024564)
+                catch (System.IO.IOException)
                 {
                     return;
                 }
@@ -468,7 +468,10 @@ namespace Zipper
                 var result = PathValidator.ValidateAndCreateDirectory(insidePath, baseDir);
 
                 Assert.NotNull(result);
-                Assert.StartsWith(baseDir, result.FullName, StringComparison.Ordinal);
+                var comparison = OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+                Assert.StartsWith(baseDir, result.FullName, comparison);
             }
             finally
             {


### PR DESCRIPTION
## Summary

Post-merge follow-up addressing all 9 inline findings from Gemini Code Assist and CodeRabbit on #479 (merged before the review sweep — process gap, enforcement mechanism being designed separately).

**Applied (5):**
- Broad `IOException` skip-guard in the two new symlink-suffix PathValidator tests (replaces the narrow `when (privilege)` filter) so environments without symlink support skip instead of fail (Gemini ×2)
- Concordance EML test splits on `\r\n` and `\n`, consistent with the first test in the file (Gemini)
- `Assert.NotEmpty` instead of `Assert.NotEqual(string.Empty, ...)` in DataGenerator override tests so `null` also fails (CodeRabbit)
- OS-aware `StringComparison` in the inside-base symlink assertion to survive Windows path-casing (CodeRabbit)

**Skipped with reason (4):**
- `Path.GetTempPath()` suggestions in `GenerationModeTests` (Gemini ×4) — tests intentionally follow the existing `SmokeTests` convention; `Directory.GetCurrentDirectory()` is `bin/Debug`, not the repo root, so no workspace pollution. Replied on threads.

## Release Notes

None — test-only change.

## Verification

- `dotnet test` PathValidator + Concordance + DataGenerator classes: 73 passed
- `dotnet format --verify-no-changes src/` clean
- Pre-push E2E smoke: passed