### PR TITLE
feat: add review-wait gate for robot reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,13 +129,15 @@ Verify behavior changes against Requirements.md before committing. Run `grep -n 
 8. Commit and create PR — include `## Release Notes` per the [Release Notes Mandate](#release-notes-mandate) below
 9. Monitor CI until all checks pass; fix failures before requesting review. Reproduce each gate locally first — see the [docs/cicd.md](docs/cicd.md#quick-reference-for-agents) gate-to-command table so you fail fast instead of waiting on CI minutes. If a CI failure appears flaky (same test passes locally, or failure is in an unrelated component), re-run once. If it fails again, document the flake in the PR and proceed to request review. Push fixes via `git commit --amend --no-edit && git push --force-with-lease`.
 10. Check SonarCloud on the PR after CI completes (see [CI.md](CI.md#sonarcloud)). Fix all BLOCKER and MAJOR issues before merge. The quality **gate** can also fail on new-code *conditions* (duplication ≥3%, coverage) with **zero** BLOCKER/MAJOR issues — query the gate conditions, not just the issue list. When adding parallel per-format modules (e.g. a composer/serializer per format), extract a shared base/builder to stay under the duplication threshold.
-11. Address review comments from **all** bots/reviewers (CodeRabbit, Gemini Code Assist, Codex, SonarCloud, human). Blocking/major issues required, nitpicks optional. Bots post to three *separate* endpoints — you must query all three to discover every comment (the PR web view and `gh pr view` alone miss inline threads):
+11. **Run `bash tests/wait-for-reviews.sh <PR-number>` after creating the PR and again after every push.** The script blocks until every robot reviewer (Gemini Code Assist, CodeRabbit, Codex) has reviewed or declared a rate-limit skip, then exits non-zero while any review thread is unresolved. A "pass" or "skipped" check status from a review bot is **not** an approval — only the script's exit 0 is.
+
+    For each finding it reports: verify it against current code, fix if still valid, or reply on the thread with a brief skip reason (e.g. conflicts with an explicit design decision), then resolve the thread and re-run the script. Blocking/major issues must be fixed; nitpicks may be skipped-with-reason but never silently ignored. **A review-driven fix that changes behavior can stale the architecture diagram, ADRs, glossary, or code comments — re-verify those (Critical Rules 1, 4, and 5) before pushing the fix.**
+
+    Fallback if the script is unavailable — bots post to three *separate* endpoints; query all three (the PR web view and `gh pr view` alone miss inline threads):
     - **Inline review comments** (code-anchored): `gh api repos/<owner>/<repo>/pulls/<N>/comments --paginate`
     - **Review summary bodies** (verdict + overview): `gh api repos/<owner>/<repo>/pulls/<N>/reviews --paginate`
     - **Issue-level PR comments** (CodeRabbit walkthrough, SonarCloud gate, perf guard): `gh api repos/<owner>/<repo>/issues/<N>/comments --paginate`
-
-    For each finding: verify it against current code, fix if still valid, or skip with a brief reason (e.g. conflicts with an explicit design decision). If a suggestion contradicts a deliberate choice, reply on the thread explaining why rather than silently ignoring it. **A review-driven fix that changes behavior can stale the architecture diagram, ADRs, glossary, or code comments — re-verify those (Critical Rules 1, 4, and 5) before pushing the fix.**
-12. Merge after all checks pass and reviews are addressed
+12. Merge after all checks pass, `tests/wait-for-reviews.sh` exits 0, and reviews are addressed. Branch protection on `main` enforces this server-side: GitHub refuses the merge while any review thread is unresolved (see [CI.md](CI.md#robot-reviews)).
 
 **Test location:** `src/Zipper.Tests/`.
 

--- a/CI.md
+++ b/CI.md
@@ -39,6 +39,35 @@ curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=dwojta
 2. Amend the last commit and force-push **your PR branch** (not `main`): `git commit --amend --no-edit && git push --force-with-lease`
 3. Re-check after CI re-runs
 
+## Robot Reviews
+
+After creating a PR — and after every subsequent push — run the review-wait gate:
+
+```bash
+bash tests/wait-for-reviews.sh <PR-number> [timeout-minutes]   # default timeout: 20
+```
+
+The script blocks until each expected bot (Gemini Code Assist, CodeRabbit, Codex) has posted a review or declared a rate-limit skip, then lists every unresolved review thread and exits non-zero while any remain. Fix or reply-with-reason on each thread, resolve it, and re-run until exit 0. A bot that stays silent past the timeout produces a warning, not a failure.
+
+Caveats:
+- A "pass" check status from a review bot can mean "review skipped" (rate limit) — never treat check status as approval.
+- Resolving a thread without a reply is prohibited; the thread must carry a fix reference or a skip reason.
+
+Server-side enforcement: `main` has branch protection with **required conversation resolution** — GitHub refuses the merge while any review thread is unresolved. One-time setup (admin):
+
+```bash
+gh api -X PUT "repos/dwojtaszek/zipper/branches/main/protection" \
+  --input - <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_conversation_resolution": true
+}
+JSON
+```
+
 ## CodeRabbit
 
 Address blocking issues (required). Nitpicks are optional.

--- a/docs/superpowers/specs/2026-06-10-review-wait-gate-design.md
+++ b/docs/superpowers/specs/2026-06-10-review-wait-gate-design.md
@@ -1,0 +1,48 @@
+# Review-Wait Gate — Design
+
+**Date:** 2026-06-10
+**Status:** Approved
+**Motivation:** PR #479 was merged on green CI before robot reviewers (Gemini Code Assist, CodeRabbit, Codex) had been read. Gemini findings only surfaced post-merge. AGENTS.md step 11 already mandated the review sweep, but nothing made the wait mechanical or the merge conditional.
+
+## Goals
+
+1. Make "wait for robot reviews, then address them" a single mechanical command an agent cannot misinterpret.
+2. Make merging with unaddressed review threads impossible server-side, independent of agent discipline.
+
+## Non-goals
+
+- Blocking PRs until every bot reviews (bots rate-limit and outage; timeout warns instead of failing).
+- Required human approvals or other branch-protection tightening.
+
+## Components
+
+### 1. `tests/wait-for-reviews.sh <PR#> [timeout-minutes]`
+
+- Expected reviewers (array at top of script): `gemini-code-assist[bot]`, `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`.
+- Polls every 30 s, default timeout 20 minutes. A bot is **accounted for** when:
+  - it has posted a review (`GET pulls/<N>/reviews`), or
+  - it has posted an issue comment matching a skip pattern (`usage limit | rate limit | review limit | Review skipped | Walkthrough` — the last covers CodeRabbit's walkthrough-only responses, which carry no formal review object), or
+  - the timeout expires (prints a warning; does not fail the gate).
+- After all bots are accounted for, queries GraphQL `reviewThreads` for resolution state and prints every unresolved inline thread (author, path:line, first lines of body) plus non-empty review summary bodies.
+- **Exit codes:** `1` if any unresolved review thread exists (agent must fix or reply-and-resolve, then re-run); `0` when clean. Transient API failures are retried, not fatal.
+
+### 2. Branch protection on `main`
+
+- `required_conversation_resolution: true` — GitHub refuses the merge while any review thread is unresolved.
+- No other settings enabled (no required reviewers, no admin enforcement). Side effect: force-pushes to `main` are blocked.
+- Applied once via API; the exact command is documented in CI.md for reproducibility.
+
+### 3. Documentation
+
+- AGENTS.md step 11 rewritten to mandate the script after PR creation and after every push, with the manual three-endpoint queries kept as fallback. Step 12 notes the server-side block.
+- CI.md gains a "Robot reviews" section: script usage, skip-pattern caveat, protection setup command.
+
+## Testing
+
+- Dry-run against merged PRs with known states: #479 (had findings; threads now replied) and #482 (clean reviews, Codex skipped).
+- Shellcheck-clean like the other `tests/*.sh` scripts.
+
+## Accepted gaps
+
+- A bot that never posts anything and never declares a skip → script warns at timeout and proceeds; branch protection still blocks if its threads appear later.
+- Thread "resolved" state is GitHub's, not semantic — an agent could resolve without addressing. Mitigated by AGENTS.md requiring a reply (fix or reason) before resolving.

--- a/tests/wait-for-reviews.sh
+++ b/tests/wait-for-reviews.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Review-wait gate — blocks until all expected robot reviewers have either
+# reviewed the PR or declared a skip (rate limit), then reports every
+# unresolved review thread.
+#
+# Usage:   bash tests/wait-for-reviews.sh <PR-number> [timeout-minutes]
+# Exit:    0 = all bots accounted for, no unresolved review threads
+#          1 = unresolved review threads exist (fix or reply + resolve, re-run)
+#          2 = usage error / missing prerequisites
+#
+# A bot that stays silent past the timeout produces a warning, not a failure:
+# branch protection (required conversation resolution) still blocks the merge
+# if its threads appear later.
+#
+# Spec: docs/superpowers/specs/2026-06-10-review-wait-gate-design.md
+
+set -euo pipefail
+
+# --- Configuration ---
+
+EXPECTED_BOTS=(
+    "gemini-code-assist[bot]"
+    "coderabbitai[bot]"
+    "chatgpt-codex-connector[bot]"
+)
+# Matches both explicit skip declarations (rate limits) and CodeRabbit's
+# walkthrough-only responses, which carry no formal review object.
+SKIP_PATTERN='usage limit|rate limit|review limit|Review skipped|Walkthrough'
+POLL_SECONDS=30
+
+# --- Prerequisites ---
+
+for tool in gh jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Error: required tool '$tool' is not installed." >&2
+        exit 2
+    fi
+done
+
+# --- Arguments ---
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: bash tests/wait-for-reviews.sh <PR-number> [timeout-minutes]" >&2
+    exit 2
+fi
+PR="$1"
+TIMEOUT_MINUTES="${2:-20}"
+if ! [[ "$PR" =~ ^[0-9]+$ ]] || ! [[ "$TIMEOUT_MINUTES" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number and timeout-minutes must be positive integers." >&2
+    exit 2
+fi
+DEADLINE=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+print_info()  { printf '\033[44m[ INFO ]\033[0m %s\n' "$1"; }
+print_warn()  { printf '\033[43m[ WARN ]\033[0m %s\n' "$1"; }
+print_error() { printf '\033[41m[ FAIL ]\033[0m %s\n' "$1"; }
+print_ok()    { printf '\033[42m[ OK ]\033[0m %s\n' "$1"; }
+
+# --- Phase 1: wait until every expected bot is accounted for ---
+
+# Fetches reviews and issue comments once per polling cycle; individual bots
+# are then checked against the local JSON to keep API usage flat.
+reviews_json=""
+comments_json=""
+fetch_review_state() {
+    reviews_json=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate --slurp 2>/dev/null \
+        | jq '[.[][]]' 2>/dev/null) || reviews_json="[]"
+    comments_json=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --slurp 2>/dev/null \
+        | jq '[.[][]]' 2>/dev/null) || comments_json="[]"
+}
+
+bot_accounted_for() {
+    local bot="$1"
+    # Posted a review?
+    if jq -e --arg bot "$bot" '.[] | select(.user.login == $bot)' <<<"$reviews_json" >/dev/null 2>&1; then
+        return 0
+    fi
+    # Declared a skip / rate limit / walkthrough in an issue comment?
+    if jq -r --arg bot "$bot" '.[] | select(.user.login == $bot) | .body' <<<"$comments_json" 2>/dev/null \
+        | grep -qiE "$SKIP_PATTERN"; then
+        return 0
+    fi
+    return 1
+}
+
+print_info "Waiting for robot reviews on PR #$PR (timeout: ${TIMEOUT_MINUTES}m)..."
+pending=("${EXPECTED_BOTS[@]}")
+while [[ ${#pending[@]} -gt 0 ]]; do
+    fetch_review_state
+    still_pending=()
+    for bot in "${pending[@]}"; do
+        if bot_accounted_for "$bot"; then
+            print_ok "$bot has reviewed or declared a skip."
+        else
+            still_pending+=("$bot")
+        fi
+    done
+    pending=("${still_pending[@]+"${still_pending[@]}"}")
+    [[ ${#pending[@]} -eq 0 ]] && break
+    if [[ $(date +%s) -ge $DEADLINE ]]; then
+        for bot in "${pending[@]}"; do
+            print_warn "$bot did not respond within ${TIMEOUT_MINUTES}m — proceeding without it."
+        done
+        break
+    fi
+    sleep "$POLL_SECONDS"
+done
+
+# --- Phase 2: report unresolved review threads ---
+
+# shellcheck disable=SC2016  # $vars below are GraphQL variables, not shell
+threads_json=$(gh api graphql \
+    -f owner="$OWNER" -f name="$NAME" -F pr="$PR" -f query='
+    query($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              comments(first: 1) {
+                nodes { author { login } path line body }
+              }
+            }
+          }
+        }
+      }
+    }')
+
+unresolved=$(jq '[.data?.repository?.pullRequest?.reviewThreads?.nodes? // [] | .[] | select(.isResolved | not)]' <<<"$threads_json")
+unresolved_count=$(jq 'length' <<<"$unresolved")
+
+# Non-empty review summary bodies (verdicts, overviews) — informational.
+print_info "Review summaries:"
+jq -r '.[] | select(.body != null and .body != "") | "  \(.user.login) [\(.state)]: \(.body | split("\n")[0])"' <<<"$reviews_json" || true
+
+if [[ "$unresolved_count" -eq 0 ]]; then
+    print_ok "No unresolved review threads on PR #$PR."
+    exit 0
+fi
+
+print_error "$unresolved_count unresolved review thread(s) on PR #$PR:"
+jq -r '.[] | (.comments.nodes[0] // {}) | "  \(.author.login // "unknown") \(.path // "?"):\(.line // "?")\n    \([(.body // "") | split("\n")[] | select((. != "") and (startswith("![") | not))][0] // "")"' <<<"$unresolved"
+print_info "Fix each finding, or reply with a skip reason and resolve the thread, then re-run."
+exit 1


### PR DESCRIPTION
## Summary

PR #479 was merged on green CI before its robot reviews had been read — the findings only surfaced post-merge (#482). This PR makes that impossible to repeat:

- **`tests/wait-for-reviews.sh <PR#> [timeout-min]`** — blocks until every expected bot (Gemini Code Assist, CodeRabbit, Codex) has posted a review or declared a rate-limit skip (CodeRabbit's walkthrough-only responses count), then lists every unresolved review thread and **exits 1 while any remain**. Silent bot past timeout = warning, not failure.
- **AGENTS.md steps 11–12** — running the script after PR creation and after every push is now mandatory; the three-endpoint manual sweep stays as fallback; explicit note that a bot's "pass" check status can mean "review skipped".
- **CI.md** — new *Robot Reviews* section: usage, caveats, and the one-time branch-protection command (`required_conversation_resolution` on `main`) that enforces the same rule server-side. Protection will be enabled right after this PR merges.

Design spec: `docs/superpowers/specs/2026-06-10-review-wait-gate-design.md`.

## Release Notes

None — tooling/docs only, no product change.

## Verification

- Dry-run against #479 (known findings): correctly reported 7 unresolved threads, exit 1; after resolving, exit 0
- Dry-run against #482 (clean reviews, Codex rate-limited): all bots accounted for, exit 0
- `bash -n` clean; shellcheck clean (one intentional SC2016 suppressed)
- This PR will dogfood the gate before its own merge