### PR TITLE
docs: make issue comments first-class spec in agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Do not silently skip blocked work or switch to adjacent tasks. A stuck report is
 ## How To Use This File
 
 - This file is the agent workflow guide. Product behavior → [Requirements.md](Requirements.md). User-facing usage → [README.md](README.md). Domain terms → [UBIQUITOUS_LANGUAGE.md](UBIQUITOUS_LANGUAGE.md). CI/CD pipeline map (local hooks → PR checks → release) → [docs/cicd.md](docs/cicd.md); external-check operations → [CI.md](CI.md).
-- If an issue body, README.md, Requirements.md, and implementation disagree, stop and identify the conflict explicitly before coding. Do not silently choose one source.
+- If an issue body, its comments, README.md, Requirements.md, and implementation disagree, stop and identify the conflict explicitly before coding. Do not silently choose one source. (Exception: a newer issue comment superseding the issue body is not a conflict — see the issue workflow, step 4.)
 
 ---
 
@@ -74,6 +74,7 @@ dotnet run --project src/Zipper.csproj -- [args]  # Run
 # Tests
 dotnet test src/Zipper.Tests/Zipper.Tests.csproj                              # Unit tests (must pass before commit)
 dotnet test src/Zipper.Tests/Zipper.Tests.csproj --filter "FullyQualifiedName~ClassName"  # Single test class
+dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj          # Analyzer tests (must pass when touching src/Zipper.Analyzers/)
 
 # Lint
 dotnet format --verify-no-changes src/   # Format check (run after every code change)
@@ -122,7 +123,10 @@ Verify behavior changes against Requirements.md before committing. Run `grep -n 
 1. `git checkout main && git pull`
 2. `git checkout -b fix/ISSUE-NNN-short-desc` (prefix: `fix/` for bugs, `feat/` for features, `refactor/`, `test/`, `docs/` per issue type)
 3. Use Conventional Commits for commit messages (`fix:`, `feat:`, `refactor:`, `test:`, `docs:`, `chore:`, `deps:`)
-4. Read the issue body; refresh labels, comments, and linked blockers before coding
+4. Read the issue body **and all comments** (`gh issue view NNN --comments`); refresh labels and linked blockers before coding:
+   - Comments are part of the spec: design decisions, implementation guides, and staleness notes posted after the body supersede it.
+   - If the newest substantive comment contradicts the body, follow the comment and say so in the PR.
+   - If the issue itself is stale (the code it describes no longer exists, or another change already resolved it), do not implement it as written — comment on the issue with evidence and a recommendation (close or retarget), then stop.
 5. Write a failing test first (TDD), then implement the fix
 6. Run `dotnet format --verify-no-changes src/` and `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` after every change
 7. Run autoreview before creating PR (see Adversarial Review section below). *Required for any change touching logic, error handling, or public contracts. For docs-only, version-bump, or single-line fixes, a self-review suffices — note the exemption in the PR.*


### PR DESCRIPTION
## Release Notes
Agent workflow documentation now requires reading all GitHub issue comments as part of the spec, treats newer substantive comments as superseding the issue body, and adds the analyzer test suite to the documented test commands.

## Description

The 2026-06-11 backlog audit showed that several open issues carry their real spec in comments, not bodies: #435's body describes a class retired by ADR-0007, and #449/#442/#428 have design decisions resolved only in comments. AGENTS.md step 4 mentioned comments but gave no rule for what they mean, so an agent following body-first would implement against retired code.

Three changes:
1. **Workflow step 4** — read all comments (`gh issue view NNN --comments`); comments are part of the spec; newest substantive comment supersedes the body; a stale issue gets an evidence comment + close/retarget recommendation instead of implementation as written.
2. **Conflict rule** ("How To Use This File") — issue comments added to the disagreement source list, with an explicit exception so comment-supersedes-body doesn't trigger a false stop-and-ask.
3. **Commands** — added `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`; the documented build+lint+test combo never ran analyzer tests.

**Adversarial review exemption:** docs-only change; self-review per AGENTS.md step 7.

## Type of Change

- [x] Documentation

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`) — 1070 passed (pre-push hook)
- [x] E2E tests pass — basic smoke 6/6 + golden suite 13/13 (pre-push hook)
- [x] Lint clean (`dotnet format --verify-no-changes src/`) — pre-commit hook

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None — agent workflow documentation only; no CLI behavior, Load File, Audit File, Production Set, or Email domain changes.