### PR TITLE
feat: cooperative cancellation (Ctrl-C / CancellationToken) in CLI

### DIFF
--- a/src/GenerationRunner.cs
+++ b/src/GenerationRunner.cs
@@ -11,12 +11,17 @@ namespace Zipper
         /// Exception messages are written to standard error in the legacy format
         /// (<c>"\nAn error occurred: {message}"</c>).
         /// </summary>
-        public static async Task<int> RunAsync(IGenerationMode mode, FileGenerationRequest request)
+        public static async Task<int> RunAsync(IGenerationMode mode, FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             try
             {
-                await mode.RunAsync(request).ConfigureAwait(false);
+                await mode.RunAsync(request, cancellationToken).ConfigureAwait(false);
                 return 0;
+            }
+            catch (OperationCanceledException)
+            {
+                Console.Error.WriteLine("\nOperation cancelled.");
+                return 130;
             }
             catch (Exception ex)
             {

--- a/src/GenerationRunner.cs
+++ b/src/GenerationRunner.cs
@@ -18,14 +18,14 @@ namespace Zipper
                 await mode.RunAsync(request, cancellationToken).ConfigureAwait(false);
                 return 0;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested || ex.CancellationToken == cancellationToken)
             {
-                Console.Error.WriteLine("\nOperation cancelled.");
+                await Console.Error.WriteLineAsync("\nOperation cancelled.").ConfigureAwait(false);
                 return 130;
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\nAn error occurred: {0}", ex.Message));
+                await Console.Error.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\nAn error occurred: {0}", ex.Message)).ConfigureAwait(false);
                 return 1;
             }
         }

--- a/src/IGenerationMode.cs
+++ b/src/IGenerationMode.cs
@@ -10,6 +10,6 @@ namespace Zipper
         /// <summary>
         /// Runs the mode end-to-end. Throws on failure; the runner translates exceptions into exit code 1.
         /// </summary>
-        Task RunAsync(FileGenerationRequest request);
+        Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/LoadFiles/ConcordanceComposingWriter.cs
+++ b/src/LoadFiles/ConcordanceComposingWriter.cs
@@ -16,13 +16,14 @@ internal sealed class ConcordanceComposingWriter : ILoadFileWriter
         Stream stream,
         FileGenerationRequest request,
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
-        ChaosEngine? chaosEngine = null)
+        ChaosEngine? chaosEngine = null,
+        CancellationToken cancellationToken = default)
     {
         var composer = new ConcordanceComposer(request);
         var serializer = new ConcordanceSerializer(request);
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         await LoadFileEmitter.EmitAsync(
-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
+            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/CsvComposingWriter.cs
+++ b/src/LoadFiles/CsvComposingWriter.cs
@@ -15,13 +15,14 @@ internal sealed class CsvComposingWriter : ILoadFileWriter
         Stream stream,
         FileGenerationRequest request,
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
-        ChaosEngine? chaosEngine = null)
+        ChaosEngine? chaosEngine = null,
+        CancellationToken cancellationToken = default)
     {
         var composer = new CsvComposer(request);
         var serializer = new CsvSerializer();
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
 
         await LoadFileEmitter.EmitAsync(
-            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null).ConfigureAwait(false);
+            stream, serializer, composer.HeaderColumns, composer.Compose(processedFiles), encoding, Environment.NewLine, chaosEngine: null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/DatComposingWriter.cs
+++ b/src/LoadFiles/DatComposingWriter.cs
@@ -28,7 +28,8 @@ internal sealed class DatComposingWriter : ILoadFileWriter
         Stream stream,
         FileGenerationRequest request,
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
-        ChaosEngine? chaosEngine = null)
+        ChaosEngine? chaosEngine = null,
+        CancellationToken cancellationToken = default)
     {
         var composer = new DatComposer(request, this.mode);
         var serializer = new DatSerializer(request);
@@ -41,6 +42,6 @@ internal sealed class DatComposingWriter : ILoadFileWriter
             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
 
         var records = composer.Compose(processedFiles);
-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
+        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, chaosEngine, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/LoadFiles/ILoadFileWriter.cs
+++ b/src/LoadFiles/ILoadFileWriter.cs
@@ -22,6 +22,7 @@ internal interface ILoadFileWriter
     /// <param name="request">File generation request parameters.</param>
     /// <param name="processedFiles">List of processed file data.</param>
     /// <param name="chaosEngine">Optional chaos engine for anomaly injection.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task representing the write operation.</returns>
-    Task WriteAsync(Stream stream, FileGenerationRequest request, System.Collections.Generic.IReadOnlyList<FileData> processedFiles, ChaosEngine? chaosEngine = null);
+    Task WriteAsync(Stream stream, FileGenerationRequest request, System.Collections.Generic.IReadOnlyList<FileData> processedFiles, ChaosEngine? chaosEngine = null, CancellationToken cancellationToken = default);
 }

--- a/src/LoadFiles/LoadFileEmitter.cs
+++ b/src/LoadFiles/LoadFileEmitter.cs
@@ -77,13 +77,9 @@ internal static class LoadFileEmitter
                 await writer.WriteAsync(eol).ConfigureAwait(false);
             }
 
-            long lineCount = 0;
             foreach (var record in records)
             {
-                if (++lineCount % 1000 == 0)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
                 await writer.WriteAsync(serializer.RenderRecord(record)).ConfigureAwait(false);
                 await writer.WriteAsync(eol).ConfigureAwait(false);
@@ -122,10 +118,7 @@ internal static class LoadFileEmitter
 
         foreach (var record in records)
         {
-            if (lineNumber % 1000 == 0)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol, cancellationToken).ConfigureAwait(false);
             lineNumber++;

--- a/src/LoadFiles/LoadFileEmitter.cs
+++ b/src/LoadFiles/LoadFileEmitter.cs
@@ -40,17 +40,18 @@ internal static class LoadFileEmitter
         IEnumerable<LoadFileRecord> records,
         Encoding encoding,
         string eol,
-        ChaosEngine? chaosEngine)
+        ChaosEngine? chaosEngine,
+        CancellationToken cancellationToken = default)
     {
         bool hasHeader = headerColumns is { Count: > 0 };
 
         if (chaosEngine == null)
         {
-            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol).ConfigureAwait(false);
+            await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine).ConfigureAwait(false);
+            await EmitWithChaosAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, chaosEngine, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -61,7 +62,8 @@ internal static class LoadFileEmitter
         IReadOnlyList<string> headerColumns,
         IEnumerable<LoadFileRecord> records,
         Encoding encoding,
-        string eol)
+        string eol,
+        CancellationToken cancellationToken)
     {
         // A StreamWriter owns the encoding preamble (written once) and chunks output to the
         // underlying stream by its internal buffer, so records stream out without the whole
@@ -75,8 +77,14 @@ internal static class LoadFileEmitter
                 await writer.WriteAsync(eol).ConfigureAwait(false);
             }
 
+            long lineCount = 0;
             foreach (var record in records)
             {
+                if (++lineCount % 1000 == 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 await writer.WriteAsync(serializer.RenderRecord(record)).ConfigureAwait(false);
                 await writer.WriteAsync(eol).ConfigureAwait(false);
             }
@@ -93,7 +101,8 @@ internal static class LoadFileEmitter
         IEnumerable<LoadFileRecord> records,
         Encoding encoding,
         string eol,
-        ChaosEngine chaosEngine)
+        ChaosEngine chaosEngine,
+        CancellationToken cancellationToken)
     {
         // Records stream lazily: raw encoding-anomaly bytes are written straight to the stream
         // after each line's encoded text, so byte ordering is correct without materializing the
@@ -107,13 +116,18 @@ internal static class LoadFileEmitter
         long lineNumber = 1;
         if (hasHeader)
         {
-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol).ConfigureAwait(false);
+            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderHeader(headerColumns), "HEADER", encoding, eol, cancellationToken).ConfigureAwait(false);
             lineNumber++;
         }
 
         foreach (var record in records)
         {
-            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol).ConfigureAwait(false);
+            if (lineNumber % 1000 == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            await EmitChaosLineAsync(stream, chaosEngine, lineNumber, serializer.RenderRecord(record), record.RecordId, encoding, eol, cancellationToken).ConfigureAwait(false);
             lineNumber++;
         }
     }
@@ -125,18 +139,19 @@ internal static class LoadFileEmitter
         string originalLine,
         string recordId,
         Encoding encoding,
-        string eol)
+        string eol,
+        CancellationToken cancellationToken)
     {
         var text = chaosEngine.ShouldIntercept(lineNumber)
             ? chaosEngine.Intercept(lineNumber, originalLine, recordId)
             : originalLine;
 
-        await stream.WriteAsync(encoding.GetBytes(text + eol)).ConfigureAwait(false);
+        await stream.WriteAsync(encoding.GetBytes(text + eol), cancellationToken).ConfigureAwait(false);
 
         var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
         if (anomaly != null)
         {
-            await stream.WriteAsync(anomaly).ConfigureAwait(false);
+            await stream.WriteAsync(anomaly, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/LoadFiles/OptComposingWriter.cs
+++ b/src/LoadFiles/OptComposingWriter.cs
@@ -30,7 +30,8 @@ internal sealed class OptComposingWriter : ILoadFileWriter
         Stream stream,
         FileGenerationRequest request,
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
-        ChaosEngine? chaosEngine = null)
+        ChaosEngine? chaosEngine = null,
+        CancellationToken cancellationToken = default)
     {
         if (this.mode == WriterMode.Standard)
         {
@@ -49,7 +50,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
             : LoadFileEmitter.GetEolString(request.Delimiters.EndOfLine);
 
         var records = composer.Compose(processedFiles);
-        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos).ConfigureAwait(false);
+        await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, encoding, eol, effectiveChaos, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -52,13 +52,9 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
 #pragma warning restore S2245
                 var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
-                long lineCount = 0;
                 foreach (var fileData in processedFiles)
                 {
-                    if (++lineCount % 1000 == 0)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
                     await element.WriteToAsync(writer, cancellationToken);

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -20,7 +20,8 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
         Stream stream,
         FileGenerationRequest request,
         System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
-        ChaosEngine? chaosEngine = null)
+        ChaosEngine? chaosEngine = null,
+        CancellationToken cancellationToken = default)
     {
         var settings = new XmlWriterSettings
         {
@@ -51,10 +52,16 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
 #pragma warning restore S2245
                 var now = request.Metadata.Seed.HasValue ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) : DateTime.UtcNow;
 
+                long lineCount = 0;
                 foreach (var fileData in processedFiles)
                 {
+                    if (++lineCount % 1000 == 0)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     var element = CreateDocumentElement(fileData.WorkItem, fileData, request, random, now);
-                    await element.WriteToAsync(writer, CancellationToken.None);
+                    await element.WriteToAsync(writer, cancellationToken);
                 }
 
                 await writer.WriteEndElementAsync(); // </Batch>

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -14,7 +14,7 @@ internal static class LoadfileOnlyGenerator
     /// </summary>
     /// <param name="request">File generation request with loadfile-only settings.</param>
     /// <returns>Result containing generated file paths and performance metrics.</returns>
-    public static async Task<LoadfileOnlyResult> GenerateAsync(FileGenerationRequest request)
+    public static async Task<LoadfileOnlyResult> GenerateAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
     {
         request = request.Clone();
 
@@ -31,88 +31,109 @@ internal static class LoadfileOnlyGenerator
         string primaryLoadFilePath = string.Empty;
         string primaryPropertiesPath = string.Empty;
 
-        foreach (var format in formatsToGenerate)
+        var generatedFiles = new List<string>();
+
+        try
         {
-            var extension = format == LoadFileFormat.Opt ? ".opt" : ".dat";
-            var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
-
-            long totalLines = format == LoadFileFormat.Opt
-                ? request.Output.FileCount
-                : request.Output.FileCount + 1;
-
-            // Resolve a named chaos scenario for display and audit, then let ChaosEngineBuilder
-            // own engine construction (including the format-keyed delimiter defaults). This
-            // removes the previous per-caller delimiter leak.
-            if (request.Chaos.ChaosMode && !string.IsNullOrEmpty(request.Chaos.ChaosScenario))
+            foreach (var format in formatsToGenerate)
             {
-                var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
-                if (scenario != null)
+                var extension = format == LoadFileFormat.Opt ? ".opt" : ".dat";
+                var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
+                generatedFiles.Add(loadFilePath);
+
+                long totalLines = format == LoadFileFormat.Opt
+                    ? request.Output.FileCount
+                    : request.Output.FileCount + 1;
+
+                if (request.Chaos.ChaosMode && !string.IsNullOrEmpty(request.Chaos.ChaosScenario))
                 {
-                    if (string.IsNullOrEmpty(request.Chaos.ChaosAmount))
+                    var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
+                    if (scenario != null)
                     {
-                        request.Chaos = request.Chaos with { ChaosAmount = scenario.DefaultAmount };
+                        if (string.IsNullOrEmpty(request.Chaos.ChaosAmount))
+                        {
+                            request.Chaos = request.Chaos with { ChaosAmount = scenario.DefaultAmount };
+                        }
+
+                        request.Chaos = request.Chaos with { ChaosTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes };
+
+                        Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"  Warning: Chaos scenario '{request.Chaos.ChaosScenario}' not found; falling back to the supplied --chaos-types/--chaos-amount (if any).");
+                    }
+                }
+
+                ChaosEngine? chaosEngine = ChaosEngineBuilder.Build(request, totalLines, format);
+
+                ILoadFileWriter writer = LoadFileWriterFactory.CreateWriter(
+                    format == LoadFileFormat.Opt ? LoadFileFormat.Opt : LoadFileFormat.Dat,
+                    WriterMode.LoadfileOnly);
+
+                var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
+                await using (fileStream.ConfigureAwait(false))
+                {
+                    await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine, cancellationToken).ConfigureAwait(false);
+                }
+
+                string propertiesPath;
+                try
+                {
+                    propertiesPath = await LoadfileAuditWriter.WriteAsync(
+                        loadFilePath,
+                        request,
+                        request.Output.FileCount,
+                        chaosEngine?.Anomalies,
+                        format).ConfigureAwait(false);
+                    generatedFiles.Add(propertiesPath);
+                }
+                catch
+                {
+                    if (File.Exists(loadFilePath))
+                    {
+                        File.Delete(loadFilePath);
                     }
 
-                    request.Chaos = request.Chaos with { ChaosTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes };
-
-                    Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
+                    throw;
                 }
-                else
+
+                if (format == request.LoadFile.LoadFileFormat || string.IsNullOrEmpty(primaryLoadFilePath))
                 {
-                    Console.Error.WriteLine($"  Warning: Chaos scenario '{request.Chaos.ChaosScenario}' not found; falling back to the supplied --chaos-types/--chaos-amount (if any).");
+                    primaryLoadFilePath = loadFilePath;
+                    primaryPropertiesPath = propertiesPath;
                 }
             }
 
-            ChaosEngine? chaosEngine = ChaosEngineBuilder.Build(request, totalLines, format);
+            stopwatch.Stop();
 
-            // DatComposingWriter handles the column-profile path internally, so loadfile-only
-            // DAT generation no longer needs a separate profile writer branch here.
-            ILoadFileWriter writer = LoadFileWriterFactory.CreateWriter(
-                format == LoadFileFormat.Opt ? LoadFileFormat.Opt : LoadFileFormat.Dat,
-                WriterMode.LoadfileOnly);
-
-            var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
-            await using (fileStream.ConfigureAwait(false))
+            return new LoadfileOnlyResult
             {
-                await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine).ConfigureAwait(false);
-            }
-
-            string propertiesPath;
-            try
-            {
-                propertiesPath = await LoadfileAuditWriter.WriteAsync(
-                    loadFilePath,
-                    request,
-                    request.Output.FileCount,
-                    chaosEngine?.Anomalies,
-                    format).ConfigureAwait(false);
-            }
-            catch
-            {
-                if (File.Exists(loadFilePath))
-                {
-                    File.Delete(loadFilePath);
-                }
-
-                throw;
-            }
-
-            if (format == request.LoadFile.LoadFileFormat || string.IsNullOrEmpty(primaryLoadFilePath))
-            {
-                primaryLoadFilePath = loadFilePath;
-                primaryPropertiesPath = propertiesPath;
-            }
+                LoadFilePath = primaryLoadFilePath,
+                PropertiesFilePath = primaryPropertiesPath,
+                TotalRecords = request.Output.FileCount,
+                GenerationTime = stopwatch.Elapsed,
+            };
         }
-
-        stopwatch.Stop();
-
-        return new LoadfileOnlyResult
+        catch
         {
-            LoadFilePath = primaryLoadFilePath,
-            PropertiesFilePath = primaryPropertiesPath,
-            TotalRecords = request.Output.FileCount,
-            GenerationTime = stopwatch.Elapsed,
-        };
+            foreach (var file in generatedFiles)
+            {
+                if (File.Exists(file))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch
+                    {
+                        // Best effort cleanup
+                    }
+                }
+            }
+
+            throw;
+        }
     }
 }
 

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -77,26 +77,13 @@ internal static class LoadfileOnlyGenerator
                     await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine, cancellationToken).ConfigureAwait(false);
                 }
 
-                string propertiesPath;
-                try
-                {
-                    propertiesPath = await LoadfileAuditWriter.WriteAsync(
-                        loadFilePath,
-                        request,
-                        request.Output.FileCount,
-                        chaosEngine?.Anomalies,
-                        format).ConfigureAwait(false);
-                    generatedFiles.Add(propertiesPath);
-                }
-                catch
-                {
-                    if (File.Exists(loadFilePath))
-                    {
-                        File.Delete(loadFilePath);
-                    }
-
-                    throw;
-                }
+                string propertiesPath = await LoadfileAuditWriter.WriteAsync(
+                    loadFilePath,
+                    request,
+                    request.Output.FileCount,
+                    chaosEngine?.Anomalies,
+                    format).ConfigureAwait(false);
+                generatedFiles.Add(propertiesPath);
 
                 if (format == request.LoadFile.LoadFileFormat || string.IsNullOrEmpty(primaryLoadFilePath))
                 {

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -5,7 +5,7 @@ namespace Zipper
     /// </summary>
     internal class LoadfileOnlyMode : IGenerationMode
     {
-        public async Task RunAsync(FileGenerationRequest request)
+        public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("Starting loadfile-only generation...");
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Format: {0}", request.LoadFile.LoadFileFormat));
@@ -23,7 +23,7 @@ namespace Zipper
                 }
             }
 
-            var result = await LoadfileOnlyGenerator.GenerateAsync(request).ConfigureAwait(false);
+            var result = await LoadfileOnlyGenerator.GenerateAsync(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Load file: {0}", result.LoadFilePath));

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -13,7 +13,7 @@ namespace Zipper
     {
         private readonly PerformanceMonitor performanceMonitor = new PerformanceMonitor();
 
-        public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request)
+        public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             string? zipFilePath = null;
             string? loadFilePath = null;
@@ -65,18 +65,18 @@ namespace Zipper
                 }
 
                 // Create channels for work distribution
-                var workChannelReader = CreateWorkChannel(request.Output.FileCount, request.Output.Folders, request.LoadFile.Distribution, request.Output.FileType, request.Output.Concurrency);
+                var workChannelReader = CreateWorkChannel(request.Output.FileCount, request.Output.Folders, request.LoadFile.Distribution, request.Output.FileType, request.Output.Concurrency, cancellationToken);
                 var resultChannel = Channel.CreateBounded<FileData>(new BoundedChannelOptions(request.Output.Concurrency * 2)
                 {
                     FullMode = BoundedChannelFullMode.Wait,
                 });
 
                 // Start the consumer task to write the archive concurrently
-                var consumerTask = ZipArchiveService.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader);
+                var consumerTask = ZipArchiveService.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader, cancellationToken);
 
                 // Generate files in parallel (producers)
                 var producerTasks = Enumerable.Range(0, request.Output.Concurrency)
-                    .Select(i => this.ProcessFileWorkAsync(workChannelReader, paddingPerFile, resultChannel.Writer, request, fileGenerator))
+                    .Select(i => this.ProcessFileWorkAsync(workChannelReader, paddingPerFile, resultChannel.Writer, request, fileGenerator, cancellationToken))
                     .ToList();
 
                 // Wait for all producers to complete, wrapped in a task that ensures completion
@@ -168,7 +168,7 @@ namespace Zipper
             }
         }
 
-        private static ChannelReader<FileWorkItem> CreateWorkChannel(long fileCount, int folders, DistributionType distribution, string fileType, int concurrency)
+        private static ChannelReader<FileWorkItem> CreateWorkChannel(long fileCount, int folders, DistributionType distribution, string fileType, int concurrency, CancellationToken cancellationToken)
         {
             var channel = Channel.CreateBounded<FileWorkItem>(new BoundedChannelOptions(concurrency * 2)
             {
@@ -194,7 +194,7 @@ namespace Zipper
                             FolderName = folderName,
                             FileName = fileName,
                             FilePathInZip = filePathInZip,
-                        }).ConfigureAwait(false);
+                        }, cancellationToken).ConfigureAwait(false);
                     }
 
                     writer.Complete();
@@ -203,21 +203,21 @@ namespace Zipper
                 {
                     writer.Complete(ex);
                 }
-            });
+            }, cancellationToken);
 
             return channel.Reader;
         }
 
-        private async Task ProcessFileWorkAsync(ChannelReader<FileWorkItem> reader, long paddingPerFile, ChannelWriter<FileData> writer, FileGenerationRequest request, IFileGenerator fileGenerator)
+        private async Task ProcessFileWorkAsync(ChannelReader<FileWorkItem> reader, long paddingPerFile, ChannelWriter<FileData> writer, FileGenerationRequest request, IFileGenerator fileGenerator, CancellationToken cancellationToken)
         {
             long filesProcessed = 0;
 
-            await foreach (var workItem in reader.ReadAllAsync().ConfigureAwait(false))
+            await foreach (var workItem in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 var fileData = this.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
                 try
                 {
-                    await writer.WriteAsync(fileData).ConfigureAwait(false);
+                    await writer.WriteAsync(fileData, cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -14,7 +14,7 @@ internal static class ProductionSetGenerator
     /// </summary>
     /// <param name="request">File generation request with production set settings.</param>
     /// <returns>Result containing paths and performance metrics.</returns>
-    public static async Task<ProductionSetResult> GenerateAsync(FileGenerationRequest request)
+    public static async Task<ProductionSetResult> GenerateAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -30,7 +30,7 @@ internal static class ProductionSetGenerator
 
         try
         {
-            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch).ConfigureAwait(false);
+            return await GenerateCoreAsync(request, productionPath, productionName, stopwatch, cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -52,7 +52,7 @@ internal static class ProductionSetGenerator
     }
 
     private static async Task<ProductionSetResult> GenerateCoreAsync(
-        FileGenerationRequest request, string productionPath, string productionName, Stopwatch stopwatch)
+        FileGenerationRequest request, string productionPath, string productionName, Stopwatch stopwatch, CancellationToken cancellationToken)
     {
         // Create directory structure
         var dataDir = Path.Combine(productionPath, "DATA");
@@ -92,6 +92,8 @@ internal static class ProductionSetGenerator
 
         foreach (var plan in plans)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var workItem = new FileWorkItem
             {
                 Index = plan.Index + 1,
@@ -178,7 +180,7 @@ internal static class ProductionSetGenerator
         var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (datStream.ConfigureAwait(false))
         {
-            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine).ConfigureAwait(false);
+            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine, cancellationToken).ConfigureAwait(false);
         }
 
         var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, totalRecords, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
@@ -194,7 +196,7 @@ internal static class ProductionSetGenerator
         var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (optStream.ConfigureAwait(false))
         {
-            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine).ConfigureAwait(false);
+            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine, cancellationToken).ConfigureAwait(false);
         }
 
         var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, optTotalLines, optChaosEngine?.Anomalies, LoadFileFormat.Opt);

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -5,7 +5,7 @@ namespace Zipper
     /// </summary>
     internal class ProductionSetMode : IGenerationMode
     {
-        public async Task RunAsync(FileGenerationRequest request)
+        public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("Starting production set generation...");
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  File Type: {0}", request.Output.FileType));
@@ -21,7 +21,7 @@ namespace Zipper
                 Console.WriteLine("  ZIP Output: Enabled");
             }
 
-            var result = await ProductionSetGenerator.GenerateAsync(request).ConfigureAwait(false);
+            var result = await ProductionSetGenerator.GenerateAsync(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Production: {0}", result.ProductionPath));

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -38,8 +38,24 @@ namespace Zipper
                 return 1;
             }
 
+            using var cts = new CancellationTokenSource();
+            using var sigInt = System.Runtime.InteropServices.PosixSignalRegistration.Create(
+                System.Runtime.InteropServices.PosixSignal.SIGINT,
+                context =>
+                {
+                    context.Cancel = true;
+                    cts.Cancel();
+                });
+            using var sigTerm = System.Runtime.InteropServices.PosixSignalRegistration.Create(
+                System.Runtime.InteropServices.PosixSignal.SIGTERM,
+                context =>
+                {
+                    context.Cancel = true;
+                    cts.Cancel();
+                });
+
             IGenerationMode mode = SelectMode(request);
-            return await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
+            return await GenerationRunner.RunAsync(mode, request, cts.Token).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -5,7 +5,7 @@ namespace Zipper
     /// </summary>
     internal class StandardMode : IGenerationMode
     {
-        public async Task RunAsync(FileGenerationRequest request)
+        public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Chaos.ChaosMode)
             {
@@ -42,7 +42,7 @@ namespace Zipper
             // Use parallel file generator for improved performance
             var generator = new ParallelFileGenerator();
 
-            var result = await generator.GenerateFilesAsync(request).ConfigureAwait(false);
+            var result = await generator.GenerateFilesAsync(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Archive created: {0}", result.ZipFilePath));

--- a/src/ZipArchiveService.cs
+++ b/src/ZipArchiveService.cs
@@ -24,7 +24,8 @@ namespace Zipper
             string loadFileName,
             string loadFilePath,
             FileGenerationRequest request,
-            ChannelReader<FileData> fileDataReader)
+            ChannelReader<FileData> fileDataReader,
+            CancellationToken cancellationToken = default)
         {
             using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
             using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, true);
@@ -45,7 +46,7 @@ namespace Zipper
 
             try
             {
-                await foreach (var incomingFileData in fileDataReader.ReadAllAsync().ConfigureAwait(false))
+                await foreach (var incomingFileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (incomingFileData.WorkItem.Index == nextExpectedIndex)
                     {

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -169,14 +169,18 @@ namespace Zipper
         {
             public Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
             {
-                throw new OperationCanceledException("Cancelled by test");
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.CompletedTask;
             }
         }
 
         [Fact]
         public async Task RunAsync_OperationCanceledException_Returns130AndPrintsMessage()
         {
-            var (exit, _, err) = await RunWithCapture(new CancellingMode(), DefaultRequest());
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exit, _, err) = await RunWithCapture(new CancellingMode(), DefaultRequest(), cts.Token);
             Assert.Equal(130, exit);
             Assert.Contains("\nOperation cancelled.", err, StringComparison.Ordinal);
         }

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -96,7 +96,7 @@ namespace Zipper
             await Assert.ThrowsAsync<InvalidOperationException>(() => mode.RunAsync(request));
         }
 
-        private static async Task<(int exitCode, string stdout, string stderr)> RunWithCapture(IGenerationMode mode, FileGenerationRequest request)
+        private static async Task<(int exitCode, string stdout, string stderr)> RunWithCapture(IGenerationMode mode, FileGenerationRequest request, CancellationToken token = default)
         {
             var originalOut = Console.Out;
             var originalError = Console.Error;
@@ -106,7 +106,7 @@ namespace Zipper
                 using var errWriter = new StringWriter();
                 Console.SetOut(outWriter);
                 Console.SetError(errWriter);
-                int exit = await GenerationRunner.RunAsync(mode, request).ConfigureAwait(false);
+                int exit = await GenerationRunner.RunAsync(mode, request, token).ConfigureAwait(false);
                 return (exit, outWriter.ToString(), errWriter.ToString());
             }
             finally
@@ -134,7 +134,7 @@ namespace Zipper
         {
             public int RunCount { get; private set; }
 
-            public Task RunAsync(FileGenerationRequest request)
+            public Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
             {
                 this.RunCount++;
                 return Task.CompletedTask;
@@ -150,7 +150,7 @@ namespace Zipper
                 this.message = message;
             }
 
-            public Task RunAsync(FileGenerationRequest request) =>
+            public Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default) =>
                 throw new InvalidOperationException(this.message);
         }
 
@@ -158,11 +158,27 @@ namespace Zipper
         {
             public FileGenerationRequest? LastRequest { get; private set; }
 
-            public Task RunAsync(FileGenerationRequest request)
+            public Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
             {
                 this.LastRequest = request;
                 return Task.CompletedTask;
             }
+        }
+
+        private sealed class CancellingMode : IGenerationMode
+        {
+            public Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
+            {
+                throw new OperationCanceledException("Cancelled by test");
+            }
+        }
+
+        [Fact]
+        public async Task RunAsync_OperationCanceledException_Returns130AndPrintsMessage()
+        {
+            var (exit, _, err) = await RunWithCapture(new CancellingMode(), DefaultRequest());
+            Assert.Equal(130, exit);
+            Assert.Contains("\nOperation cancelled.", err, StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Wired `CancellationToken` from a POSIX signal handler into `GenerationRunner` and down through generators.
- Cleaned up partial archive/loadfile output on cancellation.
- Returned exit code 130 on cancellation.

## Test Plan
- [x] Tested Ctrl-C during long generations cleans up partial state and exits 130
- [x] Passed all unit tests
- [x] E2E smoke tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Long-running operations can now be cancelled gracefully at any point using Ctrl+C or system signals
  * Proper cleanup of temporary files and resources is performed when operations are interrupted
  * Cancelled operations return exit code 130, clearly distinguishing them from other error conditions
  * Cancellation support across file generation, archive creation, and output writing stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->