### PR TITLE
feat: implement line validator for autoreview pipeline

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -156,7 +156,7 @@ The review runs entirely in the current coding agent. Both Claude Code and Curso
 
    **Cache discipline (cost):** assemble the prompt as a stable prefix + volatile suffix — the agent file, effort, insights, and repo context come first (identical across runs of the same repo), and the `<diff>` block comes **last**. Across the fix→re-review cycles (up to 3 per the Contract) keep that prefix **byte-identical** so the host prompt cache hits and only the changed diff is re-billed. Do not reorder or reword the prefix between cycles. See `references/improvements.md` (C1).
 
-4. **Collect responses.** Tag each finding with its specialist. Merge and dedup per `references/review-policy.md` (Finding Merging & Fingerprinting).
+4. **Collect responses.** Tag each finding with its specialist. Pass the structured JSON findings through `validators/line-validator.sh` to deterministically verify that the referenced files and lines exist. Merge and dedup per `references/review-policy.md` (Finding Merging & Fingerprinting).
 
 5. **Merge + synthesize** once all subagents (specialists + adversarial) return. Emit the required **merge table** (fingerprint dedup + multi-source confidence boost) and the **SYNTHESIS** block, both per `references/review-policy.md`. These are mandatory output, not optional — multi-source agreement must be made visible, not left implicit.
 

--- a/.agents/skills/autoreview/validators/line-validator.sh
+++ b/.agents/skills/autoreview/validators/line-validator.sh
@@ -18,8 +18,7 @@ if [[ -z "${input// /}" ]]; then
 fi
 
 jq -c '.[]' <<< "$input" | while IFS= read -r finding; do
-    file=$(jq -r '.file // empty' <<< "$finding")
-    line=$(jq -r '.line // empty' <<< "$finding")
+    IFS=$'\t' read -r file line < <(jq -r '[.file // "", .line // ""] | @tsv' <<< "$finding")
 
     if [[ -z "$file" || "$file" == "null" ]]; then
         # Missing file, keep it if it's a general repo finding?
@@ -33,7 +32,7 @@ jq -c '.[]' <<< "$input" | while IFS= read -r finding; do
     fi
 
     # Check if line exists in file
-    if [[ -n "$line" && "$line" != "null" ]]; then
+    if [[ -n "$line" && "$line" =~ ^[0-9]+$ ]]; then
         # wc -l might return 0 for a 1-line file with no newline.
         # A safer way to count lines:
         max_line=$(awk 'END{print NR}' "$file")
@@ -43,4 +42,4 @@ jq -c '.[]' <<< "$input" | while IFS= read -r finding; do
     fi
 
     echo "$finding"
-done | jq -s '.' | sed 's/null/\[\]/' 
+done | jq -s '. // []'

--- a/.agents/skills/autoreview/validators/line-validator.sh
+++ b/.agents/skills/autoreview/validators/line-validator.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Line/schema validator for autoreview findings
+# Verifies that:
+# 1. The file exists
+# 2. The line number is valid (within the file's line count)
+# Input: JSON array of findings from STDIN
+# Output: JSON array of valid findings to STDOUT
+
+set -euo pipefail
+
+input=$(cat)
+
+# If input is empty or just whitespace, output empty array
+if [[ -z "${input// /}" ]]; then
+    echo "[]"
+    exit 0
+fi
+
+jq -c '.[]' <<< "$input" | while IFS= read -r finding; do
+    file=$(jq -r '.file // empty' <<< "$finding")
+    line=$(jq -r '.line // empty' <<< "$finding")
+
+    if [[ -z "$file" || "$file" == "null" ]]; then
+        # Missing file, keep it if it's a general repo finding?
+        # The schema requires a file. Reject.
+        continue
+    fi
+
+    # Check if file exists
+    if [[ ! -f "$file" ]]; then
+        continue
+    fi
+
+    # Check if line exists in file
+    if [[ -n "$line" && "$line" != "null" ]]; then
+        # wc -l might return 0 for a 1-line file with no newline.
+        # A safer way to count lines:
+        max_line=$(awk 'END{print NR}' "$file")
+        if (( line < 1 || line > max_line )); then
+            continue
+        fi
+    fi
+
+    echo "$finding"
+done | jq -s '.' | sed 's/null/\[\]/' 

--- a/.agents/skills/autoreview/validators/line-validator.sh
+++ b/.agents/skills/autoreview/validators/line-validator.sh
@@ -17,6 +17,12 @@ if [[ -z "${input// /}" ]]; then
     exit 0
 fi
 
+# Validate input is an array
+if ! jq -e 'type == "array"' <<< "$input" > /dev/null 2>&1; then
+    echo "[]"
+    exit 0
+fi
+
 jq -c '.[]' <<< "$input" | while IFS= read -r finding; do
     IFS=$'\t' read -r file line < <(jq -r '[.file // "", .line // ""] | @tsv' <<< "$finding")
 

--- a/tests/test-autoreview-validator.sh
+++ b/tests/test-autoreview-validator.sh
@@ -31,7 +31,7 @@ rm -rf "$TEST_OUTPUT_DIR"
 mkdir -p "$TEST_OUTPUT_DIR"
 
 # Create dummy file with 3 lines
-echo -e "line1\nline2\nline3" > "$TEST_OUTPUT_DIR/dummy.ts"
+printf "line1\nline2\nline3\n" > "$TEST_OUTPUT_DIR/dummy.ts"
 
 # Create input JSON
 cat <<EOF > "$TEST_OUTPUT_DIR/input.json"

--- a/tests/test-autoreview-validator.sh
+++ b/tests/test-autoreview-validator.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -euo pipefail
+
+# --- Test Configuration ---
+
+TEST_OUTPUT_DIR="./results/validator"
+VALIDATOR_SCRIPT="./.agents/skills/autoreview/validators/line-validator.sh"
+
+# --- Helper Functions ---
+
+function print_success() {
+  echo -e "\e[42m[ SUCCESS ]\e[0m $1"
+}
+
+function print_info() {
+  echo -e "\e[44m[ INFO ]\e[0m $1"
+}
+
+function print_error() {
+  echo -e "\e[41m[ ERROR ]\e[0m $1"
+  exit 1
+}
+
+# --- Test Setup ---
+
+print_info "Running Autoreview Line Validator Test"
+
+rm -rf "$TEST_OUTPUT_DIR"
+mkdir -p "$TEST_OUTPUT_DIR"
+
+# Create dummy file with 3 lines
+echo -e "line1\nline2\nline3" > "$TEST_OUTPUT_DIR/dummy.ts"
+
+# Create input JSON
+cat <<EOF > "$TEST_OUTPUT_DIR/input.json"
+[
+  {
+    "file": "$TEST_OUTPUT_DIR/dummy.ts",
+    "line": 2,
+    "finding": "valid finding"
+  },
+  {
+    "file": "$TEST_OUTPUT_DIR/missing.ts",
+    "line": 1,
+    "finding": "invalid file"
+  },
+  {
+    "file": "$TEST_OUTPUT_DIR/dummy.ts",
+    "line": 10,
+    "finding": "invalid line"
+  }
+]
+EOF
+
+chmod +x "$VALIDATOR_SCRIPT"
+
+# --- Test Case 1: Filter Invalid Findings ---
+
+print_info "Test Case 1: Filter invalid findings"
+
+output=$("$VALIDATOR_SCRIPT" < "$TEST_OUTPUT_DIR/input.json")
+valid_count=$(echo "$output" | jq 'length')
+
+if [[ "$valid_count" -ne 1 ]]; then
+  print_error "Test 1: Expected 1 valid finding, got $valid_count"
+fi
+
+valid_finding=$(echo "$output" | jq -r '.[0].finding')
+if [[ "$valid_finding" != "valid finding" ]]; then
+  print_error "Test 1: Expected 'valid finding', got '$valid_finding'"
+fi
+
+print_success "Test Case 1 passed"
+print_success "All Line Validator tests passed!"

--- a/tests/test-autoreview-validator.sh
+++ b/tests/test-autoreview-validator.sh
@@ -11,15 +11,18 @@ VALIDATOR_SCRIPT="./.agents/skills/autoreview/validators/line-validator.sh"
 # --- Helper Functions ---
 
 function print_success() {
-  echo -e "\e[42m[ SUCCESS ]\e[0m $1"
+  local msg="$1"
+  echo -e "\e[42m[ SUCCESS ]\e[0m $msg"
 }
 
 function print_info() {
-  echo -e "\e[44m[ INFO ]\e[0m $1"
+  local msg="$1"
+  echo -e "\e[44m[ INFO ]\e[0m $msg"
 }
 
 function print_error() {
-  echo -e "\e[41m[ ERROR ]\e[0m $1"
+  local msg="$1"
+  echo -e "\e[41m[ ERROR ]\e[0m $msg" >&2
   exit 1
 }
 


### PR DESCRIPTION
Implements Direction A from the maintainer's audit comment, adding a deterministic line validator to filter hallucinated findings and wiring it into the autoreview skill. Closes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation mechanism to verify autoreview findings reference valid files and line numbers.

* **Tests**
  * Added comprehensive tests for the new validation tool.

* **Documentation**
  * Updated autoreview orchestration instructions to incorporate the new validation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->