### PR TITLE
docs: resolve documentation drift between README and Requirements.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ Compatibility checklist:
 | `--col-delim` | ASCII 20 | `ascii:N` or `char:C` | Column delimiter (strict) |
 | `--quote-delim` | ASCII 254 | `ascii:N`, `char:C`, or `none` | Quote delimiter (strict) |
 | `--newline-delim` | ASCII 174 | `ascii:N` or `char:C` | Newline replacement (strict) |
-| `--multi-delim` | none | `ascii:N` or `char:C` | Multi-value separator |
-| `--nested-delim` | none | `ascii:N` or `char:C` | Nested value separator |
+| `--multi-delim` | `;` | `ascii:N` or `char:C` | Multi-value separator |
+| `--nested-delim` | `\` | `ascii:N` or `char:C` | Nested value separator |
 | `--chaos-mode` | false | flag | Enable Chaos Engine (dat/opt only) |
 | `--chaos-amount` | 1% | N or N% | Anomaly count/percentage |
 | `--chaos-types` | all | comma-separated types | Anomaly type filter |
@@ -248,6 +248,17 @@ Compatibility checklist:
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
 | `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
 | `--production-zip`, `--volume-size` | Require `--production-set` |
+
+### Delimiter Argument Modes
+
+The application supports two distinct sets of delimiter arguments. Standard DAT generation uses implicit default values (e.g., ASCII 20 column, ASCII 254 `þ` quote, `;` multi-value, `\` nested-value). Loadfile-Only Mode supports explicitly overriding all of these using strict-prefix arguments.
+
+| Argument Type | Mode Applied To | Format Example | Overrides |
+|---------------|-----------------|----------------|-----------|
+| Old-style (`--delimiter-column`, etc.) | Standard DAT & Loadfile-Only | Bare value (`20`, `,`) | `--dat-delimiters` preset |
+| Strict-prefix (`--col-delim`, etc.) | Loadfile-Only Mode only | Strict prefix (`ascii:20`, `char:,`) | Old-style arguments and `--dat-delimiters` |
+
+If both an old-style and a strict-prefix argument are specified (e.g. `--delimiter-column 20` and `--col-delim char:,`), the **strict-prefix argument wins**. Note that the strict-prefix arguments (`--col-delim`, `--quote-delim`, `--newline-delim`, `--multi-delim`, `--nested-delim`) are ONLY permitted in `--loadfile-only` mode.
 
 ### Maintainer Notes for Issue Authors
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Compatibility checklist:
 | `--quote-delim` | ASCII 254 | `ascii:N`, `char:C`, or `none` | Quote delimiter (strict) |
 | `--newline-delim` | ASCII 174 | `ascii:N` or `char:C` | Newline replacement (strict) |
 | `--multi-delim` | `;` | `ascii:N` or `char:C` | Multi-value separator |
-| `--nested-delim` | `\` | `ascii:N` or `char:C` | Nested value separator |
+| `--nested-delim` | `\\` | `ascii:N` or `char:C` | Nested value separator |
 | `--chaos-mode` | false | flag | Enable Chaos Engine (dat/opt only) |
 | `--chaos-amount` | 1% | N or N% | Anomaly count/percentage |
 | `--chaos-types` | all | comma-separated types | Anomaly type filter |

--- a/Requirements.md
+++ b/Requirements.md
@@ -127,7 +127,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - `--attachment-rate <number>`: (Optional) When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0.
 - `--target-zip-size <size>`: (Optional, Requires --count) Specifies a target size for the final Archive (e.g., 500MB, 10GB).
 - `--include-load-file`: (Optional) Includes the generated Load File in the root of the output Archive.
-- `--load-file-format <dat|opt|csv|edrm-xml|concordance>`: (Optional) The format of the Load File. Defaults to `dat`. See Section 8 for format specifications. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat` (see Section 8.7).
+- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) The format of the Load File. Defaults to `dat`. See [Section 8](#8-load-file-format-standards-e-discovery-industry-specifications) for format specifications and [Section 9](#9-updated-command-line-arguments) for format aliases. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat` (see Section 8.7).
 - `--bates-prefix <prefix>`: (Optional) Prefix for Bates numbering.
 - `--bates-start <number>`: (Optional) Starting number for Bates numbering. Defaults to 1.
 - `--bates-digits <number>`: (Optional) Number of digits for Bates numbering. Defaults to 8.
@@ -544,7 +544,7 @@ The following arguments are added or modified by the Load File and column profil
 
 ### Load File Arguments
 
-- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the Load File. Defaults to `dat`. Accepts `xml` and `concordance` as aliases.
+- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the Load File. Defaults to `dat`. Accepts `xml` as an alias for `edrm-xml`. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat`.
 - `--load-file-formats <format1,format2,...>`: (Optional) Generate multiple Load File formats simultaneously.
 - `--dat-delimiters <standard|csv>`: (Optional) Delimiter style for DAT files. Defaults to `standard` (ASCII 20/254/174).
 - `--delimiter-column <char|code>`: (Optional) Custom column delimiter for DAT files. Overrides `--dat-delimiters` preset.
@@ -606,6 +606,7 @@ This section clarifies behavior when multiple arguments interact:
 - **REQ-090**: The `--loadfile-only` mode shall generate a companion `_properties.json` audit file containing format details, encoding, delimiter configuration, and chaos anomaly manifest.
 - **REQ-091**: The `--loadfile-only` flag shall conflict with `--target-zip-size` and `--include-load-file`. The application must reject these combinations with a clear error message.
 - **REQ-092**: A new optional argument `--eol <CRLF|LF|CR>` shall control the line ending format. Defaults to `CRLF`.
+- **REQ-123**: A new optional argument `--loadfile-format <dat|opt>` shall be introduced as an alias for `--load-file-format` specifically for use in loadfile-only mode. Defaults to `dat`.
 - **REQ-093**: New strict-prefix delimiter arguments shall be introduced, requiring `--loadfile-only`:
   - `--col-delim <ascii:N|char:C>`: Column delimiter
   - `--quote-delim <ascii:N|char:C|none>`: Quote delimiter (supports `none` to omit quotes)

--- a/Requirements.md
+++ b/Requirements.md
@@ -127,7 +127,7 @@ The `zipper` application is a .NET Core command-line tool designed to generate l
 - `--attachment-rate <number>`: (Optional) When type is `eml`, specifies the percentage of Emails (0-100) that will receive a random Native File as an Attachment. Defaults to 0.
 - `--target-zip-size <size>`: (Optional, Requires --count) Specifies a target size for the final Archive (e.g., 500MB, 10GB).
 - `--include-load-file`: (Optional) Includes the generated Load File in the root of the output Archive.
-- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) The format of the Load File. Defaults to `dat`. See [Section 8](#8-load-file-format-standards-e-discovery-industry-specifications) for format specifications and [Section 9](#9-updated-command-line-arguments) for format aliases. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat` (see Section 8.7).
+- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) The format of the Load File. Defaults to `dat`. See [Section 8](#8-load-file-format-standards-e-discovery-industry-specifications) for format specifications and [Section 9](#9-updated-command-line-arguments) for format aliases. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat` (see [Section 8.7](#87-concordance-database-import-format-specification)).
 - `--bates-prefix <prefix>`: (Optional) Prefix for Bates numbering.
 - `--bates-start <number>`: (Optional) Starting number for Bates numbering. Defaults to 1.
 - `--bates-digits <number>`: (Optional) Number of digits for Bates numbering. Defaults to 8.
@@ -544,7 +544,7 @@ The following arguments are added or modified by the Load File and column profil
 
 ### Load File Arguments
 
-- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the Load File. Defaults to `dat`. Accepts `xml` as an alias for `edrm-xml`. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat`.
+- `--load-file-format <dat|opt|csv|edrm-xml|xml|concordance>`: (Optional) Output format for the Load File. Defaults to `dat`. Accepts `xml` as an alias for `edrm-xml`. Note: `concordance` is a distinct database-import variant, NOT an alias of `dat` (see [Section 8.7](#87-concordance-database-import-format-specification)).
 - `--load-file-formats <format1,format2,...>`: (Optional) Generate multiple Load File formats simultaneously.
 - `--dat-delimiters <standard|csv>`: (Optional) Delimiter style for DAT files. Defaults to `standard` (ASCII 20/254/174).
 - `--delimiter-column <char|code>`: (Optional) Custom column delimiter for DAT files. Overrides `--dat-delimiters` preset.


### PR DESCRIPTION
Closes #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated delimiter quick-reference with clarified default values for configuration
* Added new section explaining delimiter argument modes and precedence rules
* Expanded load file format documentation with additional format options and alias clarifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->