### PR TITLE
test: enforce remaining build hardening properties in BuildPropsTests

### DIFF
--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -118,13 +118,26 @@ public class BuildPropsTests
     [InlineData("TreatWarningsAsErrors", "true")]
     [InlineData("AnalysisModeSecurity", "All")]
     [InlineData("Deterministic", "true")]
-    [InlineData("ContinuousIntegrationBuild", "true")]
     public void DirectoryBuildProps_ShouldHave_Property(string propertyName, string expectedValue)
     {
         var doc = LoadBuildProps();
         var elements = GetPropertyElements(doc, propertyName).ToList();
         var element = Assert.Single(elements);
         Assert.Equal(expectedValue, element.Value.Trim(), ignoreCase: true);
+    }
+
+    [Fact]
+    public void DirectoryBuildProps_ShouldHave_ContinuousIntegrationBuild_Conditional()
+    {
+        var doc = LoadBuildProps();
+        var elements = GetPropertyElements(doc, "ContinuousIntegrationBuild").ToList();
+        var element = Assert.Single(elements);
+        Assert.Equal("true", element.Value.Trim(), ignoreCase: true);
+
+        var condition = element.Attribute("Condition")?.Value;
+        Assert.NotNull(condition);
+        Assert.Contains("CI", condition, StringComparison.Ordinal);
+        Assert.Contains("GITHUB_ACTIONS", condition, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -111,4 +111,46 @@ public class BuildPropsTests
         var element = Assert.Single(elements);
         Assert.Equal("true", element.Value.Trim(), ignoreCase: true);
     }
+
+    [Theory]
+    [InlineData("EnableNETAnalyzers", "true")]
+    [InlineData("EnforceCodeStyleInBuild", "true")]
+    [InlineData("TreatWarningsAsErrors", "true")]
+    [InlineData("AnalysisModeSecurity", "All")]
+    [InlineData("Deterministic", "true")]
+    [InlineData("ContinuousIntegrationBuild", "true")]
+    public void DirectoryBuildProps_ShouldHave_Property(string propertyName, string expectedValue)
+    {
+        var doc = LoadBuildProps();
+        var elements = GetPropertyElements(doc, propertyName).ToList();
+        var element = Assert.Single(elements);
+        Assert.Equal(expectedValue, element.Value.Trim(), ignoreCase: true);
+    }
+
+    [Fact]
+    public void DirectoryBuildProps_ShouldHave_RequiredAnalyzers()
+    {
+        var doc = LoadBuildProps();
+        var packageReferences = GetPropertyElements(doc, "PackageReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => v != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("Roslynator.Analyzers", packageReferences);
+        Assert.Contains("Roslynator.Formatting.Analyzers", packageReferences);
+        Assert.Contains("Roslynator.CodeAnalysis.Analyzers", packageReferences);
+        Assert.Contains("Meziantou.Analyzer", packageReferences);
+        Assert.Contains("Microsoft.CodeAnalysis.BannedApiAnalyzers", packageReferences);
+    }
+
+    [Fact]
+    public void DirectoryBuildProps_ShouldHave_BannedSymbols()
+    {
+        var doc = LoadBuildProps();
+        var additionalFiles = GetPropertyElements(doc, "AdditionalFiles")
+            .Select(e => e.Attribute("Include")?.Value)
+            .ToList();
+
+        Assert.Contains("$(MSBuildThisFileDirectory)BannedSymbols.txt", additionalFiles);
+    }
 }


### PR DESCRIPTION
## Description

Adds `BuildPropsTests` tests to enforce the remaining build properties introduced during epic #421 (`AnalysisModeSecurity`, `Deterministic`, `EnableNETAnalyzers`, and third-party analyzer package references). This prevents the static analysis guardrails from silently regressing.

Closes #421

## Auto Review Closeout

- **Target**: `git show HEAD` (added unit tests for BuildPropsTests)
- **Effort**: Low (fast pass for single-file test patch)
- **Specialists dispatched**: Correctness (restricted to angles A-E)
- **Findings**:
  - No accepted findings. Tests correctly assert the presence of expected property configurations without complex logic.
- **Result**: Clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for build configuration validation, including assertions for build properties, required code analyzer packages, and configuration file requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->