### PR TITLE
refactor: archive-sink seam for Standard pipeline

### DIFF
--- a/src/DiskBackedFileDataList.cs
+++ b/src/DiskBackedFileDataList.cs
@@ -37,10 +37,16 @@ namespace Zipper
         {
             lock (this.syncRoot)
             {
+                ObjectDisposedException.ThrowIf(this.writer is null, this);
                 this.writer?.Flush();
                 this.writeStream?.Flush(true);
             }
 
+            return GetEnumeratorCore();
+        }
+
+        private IEnumerator<FileData> GetEnumeratorCore()
+        {
             using var readStream = new FileStream(this.tempFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, 4096);
             using var reader = new BinaryReader(readStream, Encoding.UTF8);
 

--- a/src/IArchiveSink.cs
+++ b/src/IArchiveSink.cs
@@ -1,0 +1,15 @@
+using System.Threading.Channels;
+
+namespace Zipper
+{
+    internal interface IArchiveSink
+    {
+        Task<string> CreateArchiveAsync(
+            string zipFilePath,
+            string loadFileName,
+            string loadFilePath,
+            FileGenerationRequest request,
+            ChannelReader<FileData> fileDataReader,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -14,14 +14,13 @@ namespace Zipper
         private readonly PerformanceMonitor performanceMonitor = new PerformanceMonitor();
         private readonly IArchiveSink archiveSink;
 
-        public ParallelFileGenerator()
+        public ParallelFileGenerator() : this(new ZipArchiveSink())
         {
-            this.archiveSink = new ZipArchiveSink();
         }
 
         internal ParallelFileGenerator(IArchiveSink archiveSink)
         {
-            this.archiveSink = archiveSink;
+            this.archiveSink = archiveSink ?? throw new ArgumentNullException(nameof(archiveSink));
         }
 
         public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -12,6 +12,17 @@ namespace Zipper
     public class ParallelFileGenerator
     {
         private readonly PerformanceMonitor performanceMonitor = new PerformanceMonitor();
+        private readonly IArchiveSink archiveSink;
+
+        public ParallelFileGenerator()
+        {
+            this.archiveSink = new ZipArchiveSink();
+        }
+
+        internal ParallelFileGenerator(IArchiveSink archiveSink)
+        {
+            this.archiveSink = archiveSink;
+        }
 
         public async Task<FileGenerationResult> GenerateFilesAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
@@ -72,7 +83,7 @@ namespace Zipper
                 });
 
                 // Start the consumer task to write the archive concurrently
-                var consumerTask = ZipArchiveService.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader, cancellationToken);
+                var consumerTask = this.archiveSink.CreateArchiveAsync(zipFilePath, loadFileName, loadFilePath, request, resultChannel.Reader, cancellationToken);
 
                 // Generate files in parallel (producers)
                 var producerTasks = Enumerable.Range(0, request.Output.Concurrency)

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -2,255 +2,312 @@ using System.IO.Compression;
 using System.Threading.Channels;
 using Zipper.LoadFiles;
 
-namespace Zipper
+namespace Zipper;
+
+/// <summary>
+/// Handles ZIP archive creation and file writing operations
+/// Extracted from ParallelFileGenerator to follow single responsibility principle.
+/// </summary>
+internal class ZipArchiveSink : IArchiveSink
 {
     /// <summary>
-    /// Handles ZIP archive creation and file writing operations
-    /// Extracted from ParallelFileGenerator to follow single responsibility principle.
+    /// Creates a ZIP archive containing the generated files and optionally a load file.
     /// </summary>
-    internal sealed class ZipArchiveSink : IArchiveSink
+    /// <param name="zipFilePath">Path where the ZIP file should be created.</param>
+    /// <param name="loadFileName">Name of the load file (if included).</param>
+    /// <param name="loadFilePath">Path where load file should be saved separately (if not included in ZIP).</param>
+    /// <param name="request">File generation request parameters.</param>
+    /// <param name="fileDataReader">Channel reader for receiving generated file data.</param>
+    /// <returns>The actual load file path that was created (or original if included in ZIP).</returns>
+    public async Task<string?> CreateArchiveAsync(
+        string zipFilePath,
+        string loadFileName,
+        string loadFilePath,
+        FileGenerationRequest request,
+        ChannelReader<FileData> fileDataReader,
+        CancellationToken cancellationToken = default)
     {
-        /// <summary>
-        /// Creates a ZIP archive containing the generated files and optionally a load file.
-        /// </summary>
-        /// <param name="zipFilePath">Path where the ZIP file should be created.</param>
-        /// <param name="loadFileName">Name of the load file (if included).</param>
-        /// <param name="loadFilePath">Path where load file should be saved separately (if not included in ZIP).</param>
-        /// <param name="request">File generation request parameters.</param>
-        /// <param name="fileDataReader">Channel reader for receiving generated file data.</param>
-        /// <returns>The actual load file path that was created (or original if included in ZIP).</returns>
-        public async Task<string> CreateArchiveAsync(
-            string zipFilePath,
-            string loadFileName,
-            string loadFilePath,
-            FileGenerationRequest request,
-            ChannelReader<FileData> fileDataReader,
-            CancellationToken cancellationToken = default)
+        using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
+        using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, true);
+
+        using var processedFiles = new DiskBackedFileDataList();
+        var usedEntryPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var extractedTextContent = request.Output.WithText
+            ? (string.Equals(request.Output.FileType, "eml", StringComparison.OrdinalIgnoreCase)
+                ? PlaceholderFiles.EmlExtractedText
+                : PlaceholderFiles.ExtractedText)
+            : null;
+
+        var outOfOrderBuffer = new Dictionary<long, FileData>();
+
+        try
         {
-            using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
-            using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, true);
-
-            using var processedFiles = new DiskBackedFileDataList();
-            var usedEntryPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            // Pre-compute the extracted text content selection once, outside the loop
-            var extractedTextContent = request.Output.WithText
-                ? (string.Equals(request.Output.FileType, "eml", StringComparison.OrdinalIgnoreCase)
-                    ? PlaceholderFiles.EmlExtractedText
-                    : PlaceholderFiles.ExtractedText)
-                : null;
-
-            // Process generated files and write to archive
-            long nextExpectedIndex = 1;
-            var outOfOrderBuffer = new Dictionary<long, FileData>();
-
-            try
-            {
-                await foreach (var incomingFileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    if (incomingFileData.WorkItem.Index == nextExpectedIndex)
-                    {
-                        ProcessFileData(archive, incomingFileData, request, extractedTextContent, usedEntryPaths, processedFiles);
-                        nextExpectedIndex++;
-
-                        while (outOfOrderBuffer.Remove(nextExpectedIndex, out var buffered))
-                        {
-                            ProcessFileData(archive, buffered, request, extractedTextContent, usedEntryPaths, processedFiles);
-                            nextExpectedIndex++;
-                        }
-                    }
-                    else
-                    {
-                        outOfOrderBuffer[incomingFileData.WorkItem.Index] = incomingFileData;
-                    }
-                }
-            }
-            finally
-            {
-                foreach (var buffered in outOfOrderBuffer.Values)
-                {
-                    buffered.MemoryOwner?.Dispose();
-                }
-                outOfOrderBuffer.Clear();
-
-                while (fileDataReader.TryRead(out var leftover))
-                {
-                    leftover.MemoryOwner?.Dispose();
-                }
-            }
-
-            var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
-                ? request.LoadFile.LoadFileFormats
-                : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
-
-            string actualLoadFilePath = loadFilePath;
-            var baseFileName = Path.GetFileNameWithoutExtension(loadFileName);
-            var baseFilePath = Path.GetDirectoryName(loadFilePath) ?? string.Empty;
-
-            foreach (var format in formatsToGenerate)
-            {
-                var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
-                var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
-
-                // Build a fresh ChaosEngine per format (engines are stateful; sharing across formats is incorrect)
-                long totalRecords = format == LoadFileFormat.Opt
-                    ? processedFiles.Sum(f => request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
-                    : processedFiles.Count;
-
-                long totalChaosLines = format == LoadFileFormat.Opt
-                    ? totalRecords
-                    : totalRecords + 1;
-                var chaosEngine = ChaosEngineBuilder.Build(request, totalChaosLines, format);
-
-                if (request.Output.IncludeLoadFile)
-                {
-                    var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
-                    using (var loadFileStream = loadFileEntry.Open())
-                    {
-                        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
-                    }
-
-                    // Write audit file to ZIP
-                    var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, totalRecords, chaosEngine?.Anomalies, format);
-                    var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
-                    using (var propertiesStream = propertiesEntry.Open())
-                    using (var propertiesWriter = new StreamWriter(propertiesStream))
-                    {
-                        await propertiesWriter.WriteAsync(auditJson).ConfigureAwait(false);
-                    }
-
-                    // Return path within the ZIP archive when load file is included
-                    actualLoadFilePath = actualLoadFileName;
-                }
-                else
-                {
-                    var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
-                    var fileStream = new FileStream(currentFilePath, FileMode.Create);
-                    await using (fileStream.ConfigureAwait(false))
-                    {
-                        await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
-                        await fileStream.FlushAsync().ConfigureAwait(false);
-
-                        // Write audit file to disk
-                        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
-                        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
-
-                        actualLoadFilePath = currentFilePath;
-                    }
-                }
-            }
-
-            return actualLoadFilePath;
+            await DrainReaderAndOrderFilesAsync(archive, fileDataReader, request, extractedTextContent, usedEntryPaths, processedFiles, outOfOrderBuffer, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CleanupOperations(outOfOrderBuffer, fileDataReader);
         }
 
-        /// <summary>
-        /// Writes a single file to the ZIP archive. Skips if the entry path already exists.
-        /// </summary>
-        private static void ProcessFileData(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[]? extractedTextContent, HashSet<string> usedEntryPaths, DiskBackedFileDataList processedFiles)
+        var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
+            ? request.LoadFile.LoadFileFormats
+            : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
+
+        string actualLoadFilePath = loadFilePath;
+        var baseFileName = Path.GetFileNameWithoutExtension(loadFileName);
+        var baseFilePath = Path.GetDirectoryName(loadFilePath) ?? string.Empty;
+
+        foreach (var format in formatsToGenerate)
         {
-            try
+            actualLoadFilePath = await GenerateLoadFileAndAuditAsync(
+                archive, request, processedFiles, format, baseFileName, baseFilePath, loadFileName, actualLoadFilePath).ConfigureAwait(false);
+        }
+
+        return actualLoadFilePath;
+    }
+
+    private async Task DrainReaderAndOrderFilesAsync(
+        ZipArchive archive,
+        ChannelReader<FileData> fileDataReader,
+        FileGenerationRequest request,
+        byte[]? extractedTextContent,
+        HashSet<string> usedEntryPaths,
+        DiskBackedFileDataList processedFiles,
+        Dictionary<long, FileData> outOfOrderBuffer,
+        CancellationToken cancellationToken)
+    {
+        long nextExpectedIndex = 1;
+
+        await foreach (var incomingFileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (incomingFileData.WorkItem.Index == nextExpectedIndex)
             {
-                processedFiles.Add(fileData);
+                ProcessFileData(archive, incomingFileData, request, extractedTextContent, usedEntryPaths, processedFiles);
+                nextExpectedIndex++;
 
-                WriteFileToArchive(archive, fileData, usedEntryPaths);
-
-                if (request.Output.WithText)
+                while (outOfOrderBuffer.Remove(nextExpectedIndex, out var buffered))
                 {
-                    WriteExtractedTextToArchive(archive, fileData, request, extractedTextContent!, usedEntryPaths);
-                }
-
-                if (fileData.Attachment.HasValue)
-                {
-                    WriteAttachmentToArchive(archive, fileData, usedEntryPaths);
-                }
-
-                if (fileData.Attachment.HasValue && request.Output.WithText)
-                {
-                    WriteAttachmentTextToArchive(archive, fileData, usedEntryPaths);
+                    ProcessFileData(archive, buffered, request, extractedTextContent, usedEntryPaths, processedFiles);
+                    nextExpectedIndex++;
                 }
             }
-            finally
+            else
             {
-                fileData.MemoryOwner?.Dispose();
+                outOfOrderBuffer[incomingFileData.WorkItem.Index] = incomingFileData;
             }
         }
+    }
 
-        private static void WriteFileToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+    private void CleanupOperations(Dictionary<long, FileData> outOfOrderBuffer, ChannelReader<FileData> fileDataReader)
+    {
+        foreach (var buffered in outOfOrderBuffer.Values)
         {
-            var entryPath = fileData.WorkItem.FilePathInZip;
-            if (!usedEntryPaths.Add(entryPath))
-            {
-                return;
-            }
-
-            var entry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
-            using var entryStream = entry.Open();
-            entryStream.Write(fileData.Data.Span);
+            buffered.MemoryOwner?.Dispose();
         }
+        outOfOrderBuffer.Clear();
 
-        /// <summary>
-        /// Writes an attachment file to the ZIP archive. Skips if the entry path already exists.
-        /// </summary>
-        private static void WriteAttachmentToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+        while (fileDataReader.TryRead(out var leftover))
         {
-            if (!fileData.Attachment.HasValue)
-            {
-                return;
-            }
-
-            var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{fileData.Attachment.Value.filename}";
-            if (!usedEntryPaths.Add(entryPath))
-            {
-                return;
-            }
-
-            var attachmentEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
-            using var attachmentStream = attachmentEntry.Open();
-            attachmentStream.Write(fileData.Attachment.Value.content);
+            leftover.MemoryOwner?.Dispose();
         }
+    }
 
-        /// <summary>
-        /// Writes the extracted text for an attachment to the ZIP archive. Skips if the entry path already exists.
-        /// </summary>
-        private static void WriteAttachmentTextToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+    private async Task<string> GenerateLoadFileAndAuditAsync(
+        ZipArchive archive,
+        FileGenerationRequest request,
+        DiskBackedFileDataList processedFiles,
+        LoadFileFormat format,
+        string baseFileName,
+        string baseFilePath,
+        string loadFileName,
+        string actualLoadFilePath)
+    {
+        var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
+        var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
+
+        long totalRecords = format == LoadFileFormat.Opt
+            ? processedFiles.Sum(f => request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
+            : processedFiles.Count;
+
+        long totalChaosLines = format == LoadFileFormat.Opt
+            ? totalRecords
+            : totalRecords + 1;
+        var chaosEngine = ChaosEngineBuilder.Build(request, totalChaosLines, format);
+
+        if (request.Output.IncludeLoadFile)
         {
-            if (!fileData.Attachment.HasValue)
-            {
-                return;
-            }
-
-            var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment.Value.filename)}.txt";
-            var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attachmentTextFileName}";
-            if (!usedEntryPaths.Add(entryPath))
-            {
-                return;
-            }
-
-            var attachmentTextEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
-            using var attachmentTextStream = attachmentTextEntry.Open();
-            attachmentTextStream.Write(PlaceholderFiles.ExtractedText);
+            await GenerateLoadFileToArchiveAsync(archive, request, processedFiles, loadFileWriter, chaosEngine, actualLoadFileName).ConfigureAwait(false);
+            await EmitAuditToArchiveAsync(archive, request, totalRecords, chaosEngine, format, actualLoadFileName).ConfigureAwait(false);
+            return actualLoadFileName;
         }
-
-        /// <summary>
-        /// Writes an extracted text version of a file to the ZIP archive. Skips if the entry path already exists.
-        /// </summary>
-        private static void WriteExtractedTextToArchive(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[] textContent, HashSet<string> usedEntryPaths)
+        else
         {
-            System.Diagnostics.Debug.Assert(request.Output.WithText, "Should only be called when WithText is true");
+            var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
+            await GenerateLoadFileToDiskAsync(request, processedFiles, loadFileWriter, chaosEngine, currentFilePath).ConfigureAwait(false);
+            await EmitAuditToDiskAsync(request, totalRecords, chaosEngine, format, currentFilePath).ConfigureAwait(false);
+            return currentFilePath;
+        }
+    }
 
-            var textFileName = fileData.WorkItem.FileName.Replace($".{request.Output.FileType}", ".txt", StringComparison.Ordinal);
-            var entryPath = $"{fileData.WorkItem.FolderName}/{textFileName}";
+    private async Task GenerateLoadFileToArchiveAsync(
+        ZipArchive archive,
+        FileGenerationRequest request,
+        DiskBackedFileDataList processedFiles,
+        ILoadFileWriter loadFileWriter,
+        dynamic? chaosEngine,
+        string actualLoadFileName)
+    {
+        var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
+        using var loadFileStream = loadFileEntry.Open();
+        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+    }
 
-            if (!usedEntryPaths.Add(entryPath))
+    private async Task GenerateLoadFileToDiskAsync(
+        FileGenerationRequest request,
+        DiskBackedFileDataList processedFiles,
+        ILoadFileWriter loadFileWriter,
+        dynamic? chaosEngine,
+        string currentFilePath)
+    {
+        var fileStream = new FileStream(currentFilePath, FileMode.Create);
+        await using (fileStream.ConfigureAwait(false))
+        {
+            await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+            await fileStream.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task EmitAuditToArchiveAsync(
+        ZipArchive archive,
+        FileGenerationRequest request,
+        long totalRecords,
+        dynamic? chaosEngine,
+        LoadFileFormat format,
+        string actualLoadFileName)
+    {
+        var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, totalRecords, chaosEngine?.Anomalies, format);
+        var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
+        using var propertiesStream = propertiesEntry.Open();
+        using var propertiesWriter = new StreamWriter(propertiesStream);
+        await propertiesWriter.WriteAsync(auditJson).ConfigureAwait(false);
+    }
+
+    private async Task EmitAuditToDiskAsync(
+        FileGenerationRequest request,
+        long totalRecords,
+        dynamic? chaosEngine,
+        LoadFileFormat format,
+        string currentFilePath)
+    {
+        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
+        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
+    }
+
+    private static void ProcessFileData(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[]? extractedTextContent, HashSet<string> usedEntryPaths, DiskBackedFileDataList processedFiles)
+    {
+        try
+        {
+            processedFiles.Add(fileData);
+
+            WriteFileToArchive(archive, fileData, usedEntryPaths);
+
+            if (request.Output.WithText)
             {
-                return;
+                WriteExtractedTextToArchive(archive, fileData, request, extractedTextContent!, usedEntryPaths);
             }
 
-            var textEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
-            using var textEntryStream = textEntry.Open();
+            if (fileData.Attachment.HasValue)
+            {
+                WriteAttachmentToArchive(archive, fileData, usedEntryPaths);
+            }
 
-            // O(1): write pre-computed byte[] directly, no string round-trip
-            textEntryStream.Write(textContent);
+            if (fileData.Attachment.HasValue && request.Output.WithText)
+            {
+                WriteAttachmentTextToArchive(archive, fileData, usedEntryPaths);
+            }
         }
+        finally
+        {
+            fileData.MemoryOwner?.Dispose();
+        }
+    }
+
+    private static void WriteFileToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+    {
+        var entryPath = fileData.WorkItem.FilePathInZip;
+        if (!usedEntryPaths.Add(entryPath))
+        {
+            return;
+        }
+
+        var entry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
+        using var entryStream = entry.Open();
+        entryStream.Write(fileData.Data.Span);
+    }
+
+    /// <summary>
+    /// Writes an attachment file to the ZIP archive. Skips if the entry path already exists.
+    /// </summary>
+    private static void WriteAttachmentToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+    {
+        if (!fileData.Attachment.HasValue)
+        {
+            return;
+        }
+
+        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{fileData.Attachment.Value.filename}";
+        if (!usedEntryPaths.Add(entryPath))
+        {
+            return;
+        }
+
+        var attachmentEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
+        using var attachmentStream = attachmentEntry.Open();
+        attachmentStream.Write(fileData.Attachment.Value.content);
+    }
+
+    /// <summary>
+    /// Writes the extracted text for an attachment to the ZIP archive. Skips if the entry path already exists.
+    /// </summary>
+    private static void WriteAttachmentTextToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
+    {
+        if (!fileData.Attachment.HasValue)
+        {
+            return;
+        }
+
+        var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment.Value.filename)}.txt";
+        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attachmentTextFileName}";
+        if (!usedEntryPaths.Add(entryPath))
+        {
+            return;
+        }
+
+        var attachmentTextEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
+        using var attachmentTextStream = attachmentTextEntry.Open();
+        attachmentTextStream.Write(PlaceholderFiles.ExtractedText);
+    }
+
+    /// <summary>
+    /// Writes an extracted text version of a file to the ZIP archive. Skips if the entry path already exists.
+    /// </summary>
+    private static void WriteExtractedTextToArchive(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[] textContent, HashSet<string> usedEntryPaths)
+    {
+        System.Diagnostics.Debug.Assert(request.Output.WithText, "Should only be called when WithText is true");
+
+        var textFileName = fileData.WorkItem.FileName.Replace($".{request.Output.FileType}", ".txt", StringComparison.Ordinal);
+        var entryPath = $"{fileData.WorkItem.FolderName}/{textFileName}";
+
+        if (!usedEntryPaths.Add(entryPath))
+        {
+            return;
+        }
+
+        var textEntry = archive.CreateEntry(entryPath, CompressionLevel.Optimal);
+        using var textEntryStream = textEntry.Open();
+
+        // O(1): write pre-computed byte[] directly, no string round-trip
+        textEntryStream.Write(textContent);
     }
 }

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -61,7 +61,7 @@ internal class ZipArchiveSink : IArchiveSink
         foreach (var format in formatsToGenerate)
         {
             actualLoadFilePath = await GenerateLoadFileAndAuditAsync(
-                archive, request, processedFiles, format, baseFileName, baseFilePath, loadFileName, actualLoadFilePath).ConfigureAwait(false);
+                archive, request, processedFiles, format, baseFileName, baseFilePath).ConfigureAwait(false);
         }
 
         return actualLoadFilePath;
@@ -119,9 +119,7 @@ internal class ZipArchiveSink : IArchiveSink
         DiskBackedFileDataList processedFiles,
         LoadFileFormat format,
         string baseFileName,
-        string baseFilePath,
-        string loadFileName,
-        string actualLoadFilePath)
+        string baseFilePath)
     {
         var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
         var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
@@ -235,7 +233,7 @@ internal class ZipArchiveSink : IArchiveSink
 
     private static void WriteFileToArchive(ZipArchive archive, FileData fileData, HashSet<string> usedEntryPaths)
     {
-        var entryPath = fileData.WorkItem.FilePathInZip;
+        var entryPath = fileData.WorkItem.FilePathInZip.Replace('\\', '/');
         if (!usedEntryPaths.Add(entryPath))
         {
             return;
@@ -256,7 +254,8 @@ internal class ZipArchiveSink : IArchiveSink
             return;
         }
 
-        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{fileData.Attachment.Value.filename}";
+        var sanitizedFilename = Path.GetFileName(fileData.Attachment.Value.filename.Replace('\\', '/'));
+        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{sanitizedFilename}".Replace('\\', '/');
         if (!usedEntryPaths.Add(entryPath))
         {
             return;
@@ -277,8 +276,9 @@ internal class ZipArchiveSink : IArchiveSink
             return;
         }
 
-        var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(fileData.Attachment.Value.filename)}.txt";
-        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attachmentTextFileName}";
+        var sanitizedFilename = Path.GetFileName(fileData.Attachment.Value.filename.Replace('\\', '/'));
+        var attachmentTextFileName = $"{Path.GetFileNameWithoutExtension(sanitizedFilename)}.txt";
+        var entryPath = $"{fileData.WorkItem.FolderName}/{fileData.WorkItem.Index}_{attachmentTextFileName}".Replace('\\', '/');
         if (!usedEntryPaths.Add(entryPath))
         {
             return;
@@ -297,7 +297,7 @@ internal class ZipArchiveSink : IArchiveSink
         System.Diagnostics.Debug.Assert(request.Output.WithText, "Should only be called when WithText is true");
 
         var textFileName = fileData.WorkItem.FileName.Replace($".{request.Output.FileType}", ".txt", StringComparison.Ordinal);
-        var entryPath = $"{fileData.WorkItem.FolderName}/{textFileName}";
+        var entryPath = $"{fileData.WorkItem.FolderName}/{textFileName}".Replace('\\', '/');
 
         if (!usedEntryPaths.Add(entryPath))
         {

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -8,7 +8,7 @@ namespace Zipper
     /// Handles ZIP archive creation and file writing operations
     /// Extracted from ParallelFileGenerator to follow single responsibility principle.
     /// </summary>
-    internal static class ZipArchiveService
+    internal sealed class ZipArchiveSink : IArchiveSink
     {
         /// <summary>
         /// Creates a ZIP archive containing the generated files and optionally a load file.
@@ -19,7 +19,7 @@ namespace Zipper
         /// <param name="request">File generation request parameters.</param>
         /// <param name="fileDataReader">Channel reader for receiving generated file data.</param>
         /// <returns>The actual load file path that was created (or original if included in ZIP).</returns>
-        public static async Task<string> CreateArchiveAsync(
+        public async Task<string> CreateArchiveAsync(
             string zipFilePath,
             string loadFileName,
             string loadFilePath,

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -19,7 +19,7 @@ internal class ZipArchiveSink : IArchiveSink
     /// <param name="request">File generation request parameters.</param>
     /// <param name="fileDataReader">Channel reader for receiving generated file data.</param>
     /// <returns>The actual load file path that was created (or original if included in ZIP).</returns>
-    public async Task<string?> CreateArchiveAsync(
+    public async Task<string> CreateArchiveAsync(
         string zipFilePath,
         string loadFileName,
         string loadFilePath,

--- a/src/Zipper.Tests/DiskBackedFileDataListTests.cs
+++ b/src/Zipper.Tests/DiskBackedFileDataListTests.cs
@@ -1,0 +1,153 @@
+using Xunit;
+using Zipper.Emails;
+
+namespace Zipper.Tests
+{
+    public class DiskBackedFileDataListTests
+    {
+        [Fact]
+        public void RoundTrip_WithAllFieldsPopulated_PreservesData()
+        {
+            using var list = new DiskBackedFileDataList();
+
+            var original = new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 42,
+                    FolderNumber = 3,
+                    FolderName = "folder_003",
+                    FileName = "test.txt",
+                    FilePathInZip = "folder_003/test.txt"
+                },
+                DataLength = 1024,
+                PageCount = 5,
+                Hash = "abcdef1234567890",
+                Attachment = ("attach.pdf", Array.Empty<byte>()),
+                Email = new Email
+                {
+                    To = "to@example.com",
+                    From = "from@example.com",
+                    Subject = "Test Subject",
+                    SentDate = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+                }
+            };
+
+            list.Add(original);
+
+            var result = list.Single();
+
+            Assert.Equal(original.WorkItem.Index, result.WorkItem.Index);
+            Assert.Equal(original.WorkItem.FolderNumber, result.WorkItem.FolderNumber);
+            Assert.Equal(original.WorkItem.FolderName, result.WorkItem.FolderName);
+            Assert.Equal(original.WorkItem.FileName, result.WorkItem.FileName);
+            Assert.Equal(original.WorkItem.FilePathInZip, result.WorkItem.FilePathInZip);
+
+            Assert.Equal(original.DataLength, result.DataLength);
+            Assert.Equal(original.PageCount, result.PageCount);
+            Assert.Equal(original.Hash, result.Hash);
+
+            Assert.True(result.Attachment.HasValue);
+            Assert.Equal(original.Attachment.Value.filename, result.Attachment.Value.filename);
+            Assert.Empty(result.Attachment.Value.content);
+
+            Assert.NotNull(result.Email);
+            Assert.Equal(original.Email.To, result.Email.To);
+            Assert.Equal(original.Email.From, result.Email.From);
+            Assert.Equal(original.Email.Subject, result.Email.Subject);
+            Assert.Equal(original.Email.SentDate, result.Email.SentDate);
+        }
+
+        [Fact]
+        public void RoundTrip_WithNullOrEmptyEdgeCases_PreservesData()
+        {
+            using var list = new DiskBackedFileDataList();
+
+            var original = new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderNumber = 0,
+                    FolderName = string.Empty,
+                    FileName = string.Empty,
+                    FilePathInZip = string.Empty
+                },
+                DataLength = 0,
+                PageCount = 0,
+                Hash = string.Empty,
+                Attachment = null,
+                Email = null
+            };
+
+            list.Add(original);
+
+            var result = list.Single();
+
+            Assert.Equal(original.WorkItem.Index, result.WorkItem.Index);
+            Assert.Equal(string.Empty, result.WorkItem.FolderName);
+            Assert.Equal(string.Empty, result.WorkItem.FileName);
+            Assert.Equal(string.Empty, result.WorkItem.FilePathInZip);
+            Assert.Equal(0, result.DataLength);
+            Assert.Equal(0, result.PageCount);
+            Assert.Equal(string.Empty, result.Hash);
+            Assert.False(result.Attachment.HasValue);
+            Assert.Null(result.Email);
+        }
+
+        [Fact]
+        public void Dispose_RemovesTempFile()
+        {
+            using (var list = new DiskBackedFileDataList())
+            {
+                list.Add(new FileData { WorkItem = new FileWorkItem { Index = 1 } });
+
+                // Get the temp file path by reflection or assume it's created. We can just test that we don't leak files.
+                // Wait, DiskBackedFileDataList creates a temp file in constructor.
+                // We will test if Dispose throws, and we can also assert that it's safe to call multiple times.
+            }
+
+            // Should not throw on double dispose
+            var doubleDisposeList = new DiskBackedFileDataList();
+            doubleDisposeList.Dispose();
+            doubleDisposeList.Dispose();
+        }
+
+        [Fact]
+        public void Add_AfterDispose_ThrowsObjectDisposedException()
+        {
+            var list = new DiskBackedFileDataList();
+            list.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => list.Add(new FileData { WorkItem = new FileWorkItem { Index = 1 } }));
+        }
+
+        [Fact]
+        public void Enumerable_MultipleItems_AreReturnedInOrder()
+        {
+            using var list = new DiskBackedFileDataList();
+
+            for (int i = 0; i < 100; i++)
+            {
+                list.Add(new FileData { WorkItem = new FileWorkItem { Index = i } });
+            }
+
+            Assert.Equal(100, list.Count);
+
+            int expected = 0;
+            foreach (var item in list)
+            {
+                Assert.Equal(expected++, item.WorkItem.Index);
+            }
+
+            Assert.Equal(100, expected);
+        }
+
+        [Fact]
+        public void Indexer_ThrowsNotSupportedException()
+        {
+            using var list = new DiskBackedFileDataList();
+            Assert.Throws<NotSupportedException>(() => list[0]);
+        }
+    }
+}

--- a/src/Zipper.Tests/DiskBackedFileDataListTests.cs
+++ b/src/Zipper.Tests/DiskBackedFileDataListTests.cs
@@ -1,153 +1,164 @@
 using Xunit;
 using Zipper.Emails;
 
-namespace Zipper.Tests
+namespace Zipper.Tests;
+
+public class DiskBackedFileDataListTests
 {
-    public class DiskBackedFileDataListTests
+    [Fact]
+    public void RoundTrip_EmptyList_ReturnsNoElements()
     {
-        [Fact]
-        public void RoundTrip_WithAllFieldsPopulated_PreservesData()
+        using var list = new DiskBackedFileDataList();
+        Assert.Empty(list);
+
+        var enumerated = list.ToList();
+        Assert.Empty(enumerated);
+    }
+
+    [Fact]
+    public void RoundTrip_SerializeDeserialize_PreservesAllFields()
+    {
+        using var list = new DiskBackedFileDataList();
+
+        var originalData = new FileData
         {
-            using var list = new DiskBackedFileDataList();
-
-            var original = new FileData
+            WorkItem = new FileWorkItem
             {
-                WorkItem = new FileWorkItem
-                {
-                    Index = 42,
-                    FolderNumber = 3,
-                    FolderName = "folder_003",
-                    FileName = "test.txt",
-                    FilePathInZip = "folder_003/test.txt"
-                },
-                DataLength = 1024,
-                PageCount = 5,
-                Hash = "abcdef1234567890",
-                Attachment = ("attach.pdf", Array.Empty<byte>()),
-                Email = new Email
-                {
-                    To = "to@example.com",
-                    From = "from@example.com",
-                    Subject = "Test Subject",
-                    SentDate = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc)
-                }
-            };
-
-            list.Add(original);
-
-            var result = list.Single();
-
-            Assert.Equal(original.WorkItem.Index, result.WorkItem.Index);
-            Assert.Equal(original.WorkItem.FolderNumber, result.WorkItem.FolderNumber);
-            Assert.Equal(original.WorkItem.FolderName, result.WorkItem.FolderName);
-            Assert.Equal(original.WorkItem.FileName, result.WorkItem.FileName);
-            Assert.Equal(original.WorkItem.FilePathInZip, result.WorkItem.FilePathInZip);
-
-            Assert.Equal(original.DataLength, result.DataLength);
-            Assert.Equal(original.PageCount, result.PageCount);
-            Assert.Equal(original.Hash, result.Hash);
-
-            Assert.True(result.Attachment.HasValue);
-            Assert.Equal(original.Attachment.Value.filename, result.Attachment.Value.filename);
-            Assert.Empty(result.Attachment.Value.content);
-
-            Assert.NotNull(result.Email);
-            Assert.Equal(original.Email.To, result.Email.To);
-            Assert.Equal(original.Email.From, result.Email.From);
-            Assert.Equal(original.Email.Subject, result.Email.Subject);
-            Assert.Equal(original.Email.SentDate, result.Email.SentDate);
-        }
-
-        [Fact]
-        public void RoundTrip_WithNullOrEmptyEdgeCases_PreservesData()
-        {
-            using var list = new DiskBackedFileDataList();
-
-            var original = new FileData
+                Index = 42,
+                FolderNumber = 3,
+                FolderName = "folder_003",
+                FileName = "00000042.pdf",
+                FilePathInZip = "folder_003/00000042.pdf"
+            },
+            DataLength = 1024,
+            PageCount = 5,
+            Hash = "abcdef1234567890",
+            Attachment = ("test_attach.txt", Array.Empty<byte>()),
+            Email = new Email
             {
-                WorkItem = new FileWorkItem
-                {
-                    Index = 1,
-                    FolderNumber = 0,
-                    FolderName = string.Empty,
-                    FileName = string.Empty,
-                    FilePathInZip = string.Empty
-                },
-                DataLength = 0,
-                PageCount = 0,
-                Hash = string.Empty,
-                Attachment = null,
-                Email = null
-            };
-
-            list.Add(original);
-
-            var result = list.Single();
-
-            Assert.Equal(original.WorkItem.Index, result.WorkItem.Index);
-            Assert.Equal(string.Empty, result.WorkItem.FolderName);
-            Assert.Equal(string.Empty, result.WorkItem.FileName);
-            Assert.Equal(string.Empty, result.WorkItem.FilePathInZip);
-            Assert.Equal(0, result.DataLength);
-            Assert.Equal(0, result.PageCount);
-            Assert.Equal(string.Empty, result.Hash);
-            Assert.False(result.Attachment.HasValue);
-            Assert.Null(result.Email);
-        }
-
-        [Fact]
-        public void Dispose_RemovesTempFile()
-        {
-            using (var list = new DiskBackedFileDataList())
-            {
-                list.Add(new FileData { WorkItem = new FileWorkItem { Index = 1 } });
-
-                // Get the temp file path by reflection or assume it's created. We can just test that we don't leak files.
-                // Wait, DiskBackedFileDataList creates a temp file in constructor.
-                // We will test if Dispose throws, and we can also assert that it's safe to call multiple times.
+                To = "to@example.com",
+                From = "from@example.com",
+                Subject = "Test Subject",
+                SentDate = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc)
             }
+        };
 
-            // Should not throw on double dispose
-            var doubleDisposeList = new DiskBackedFileDataList();
-            doubleDisposeList.Dispose();
-            doubleDisposeList.Dispose();
-        }
+        list.Add(originalData);
 
-        [Fact]
-        public void Add_AfterDispose_ThrowsObjectDisposedException()
+        Assert.Single(list);
+
+        var resultList = list.ToList();
+        var deserializedData = Assert.Single(resultList);
+
+        // Compare properties
+        Assert.Equal(originalData.WorkItem.Index, deserializedData.WorkItem.Index);
+        Assert.Equal(originalData.WorkItem.FolderNumber, deserializedData.WorkItem.FolderNumber);
+        Assert.Equal(originalData.WorkItem.FolderName, deserializedData.WorkItem.FolderName);
+        Assert.Equal(originalData.WorkItem.FileName, deserializedData.WorkItem.FileName);
+        Assert.Equal(originalData.WorkItem.FilePathInZip, deserializedData.WorkItem.FilePathInZip);
+
+        Assert.Equal(originalData.DataLength, deserializedData.DataLength);
+        Assert.Equal(originalData.PageCount, deserializedData.PageCount);
+        Assert.Equal(originalData.Hash, deserializedData.Hash);
+
+        Assert.True(deserializedData.Attachment.HasValue);
+        Assert.Equal(originalData.Attachment.Value.filename, deserializedData.Attachment.Value.filename);
+
+        Assert.NotNull(deserializedData.Email);
+        Assert.Equal(originalData.Email.To, deserializedData.Email.To);
+        Assert.Equal(originalData.Email.From, deserializedData.Email.From);
+        Assert.Equal(originalData.Email.Subject, deserializedData.Email.Subject);
+        Assert.Equal(originalData.Email.SentDate, deserializedData.Email.SentDate);
+    }
+
+    [Fact]
+    public void RoundTrip_NullAndEmptyValues_PreservedProperly()
+    {
+        using var list = new DiskBackedFileDataList();
+
+        var originalData = new FileData
         {
-            var list = new DiskBackedFileDataList();
-            list.Dispose();
-
-            Assert.Throws<ObjectDisposedException>(() => list.Add(new FileData { WorkItem = new FileWorkItem { Index = 1 } }));
-        }
-
-        [Fact]
-        public void Enumerable_MultipleItems_AreReturnedInOrder()
-        {
-            using var list = new DiskBackedFileDataList();
-
-            for (int i = 0; i < 100; i++)
+            WorkItem = new FileWorkItem
             {
-                list.Add(new FileData { WorkItem = new FileWorkItem { Index = i } });
-            }
+                Index = 1,
+                FolderNumber = 1,
+                FolderName = "",
+                FileName = null!,
+                FilePathInZip = ""
+            },
+            DataLength = 0,
+            PageCount = 0,
+            Hash = null!,
+            Attachment = null,
+            Email = null
+        };
 
-            Assert.Equal(100, list.Count);
+        list.Add(originalData);
 
-            int expected = 0;
-            foreach (var item in list)
-            {
-                Assert.Equal(expected++, item.WorkItem.Index);
-            }
+        var resultList = list.ToList();
+        var deserializedData = Assert.Single(resultList);
 
-            Assert.Equal(100, expected);
-        }
+        Assert.Equal("", deserializedData.WorkItem.FolderName);
+        Assert.Equal("", deserializedData.WorkItem.FileName);
+        Assert.Equal("", deserializedData.WorkItem.FilePathInZip);
+        Assert.Equal("", deserializedData.Hash);
+        Assert.False(deserializedData.Attachment.HasValue);
+        Assert.Null(deserializedData.Email);
+    }
 
-        [Fact]
-        public void Indexer_ThrowsNotSupportedException()
+    [Fact]
+    public void Dispose_RemovesTempFile()
+    {
+        var list = new DiskBackedFileDataList();
+        list.Add(new FileData { WorkItem = new FileWorkItem { Index = 1 } });
+
+        var field = typeof(DiskBackedFileDataList).GetField("tempFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        var tempFilePath = Assert.IsType<string>(field!.GetValue(list));
+        Assert.True(File.Exists(tempFilePath));
+
+        list.Dispose();
+        Assert.False(File.Exists(tempFilePath));
+        list.Dispose(); // idempotent
+    }
+
+    [Fact]
+    public void Threshold_ManyItems_ArePersistedAndReadProperly()
+    {
+        using var list = new DiskBackedFileDataList();
+
+        int itemCount = 10000;
+        for (int i = 0; i < itemCount; i++)
         {
-            using var list = new DiskBackedFileDataList();
-            Assert.Throws<NotSupportedException>(() => list[0]);
+            list.Add(new FileData
+            {
+                WorkItem = new FileWorkItem { Index = i, FileName = $"file_{i}.txt" },
+                DataLength = i
+            });
         }
+
+        Assert.Equal(itemCount, list.Count);
+
+        int index = 0;
+        foreach (var item in list)
+        {
+            Assert.Equal(index, item.WorkItem.Index);
+            Assert.Equal($"file_{index}.txt", item.WorkItem.FileName);
+            Assert.Equal(index, item.DataLength);
+            index++;
+        }
+
+        Assert.Equal(itemCount, index);
+    }
+
+    [Fact]
+    public void Operations_AfterDispose_ThrowObjectDisposedException()
+    {
+        var list = new DiskBackedFileDataList();
+        list.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => list.Add(new FileData()));
+        Assert.Throws<ObjectDisposedException>(() => list.ToList());
+        Assert.Throws<ObjectDisposedException>(() => list.GetEnumerator());
     }
 }

--- a/src/Zipper.Tests/InMemorySink.cs
+++ b/src/Zipper.Tests/InMemorySink.cs
@@ -1,49 +1,48 @@
 using System.Threading.Channels;
 
-namespace Zipper
+namespace Zipper;
+
+internal class InMemorySink : IArchiveSink
 {
-    internal class InMemorySink : IArchiveSink
+    public List<FileData> CapturedEntries { get; } = new List<FileData>();
+    public bool IsFaulted { get; set; }
+    public Exception? FaultException { get; set; }
+
+    public async Task<string> CreateArchiveAsync(
+        string zipFilePath,
+        string loadFileName,
+        string loadFilePath,
+        FileGenerationRequest request,
+        ChannelReader<FileData> fileDataReader,
+        CancellationToken cancellationToken = default)
     {
-        public List<FileData> CapturedEntries { get; } = new List<FileData>();
-        public bool IsFaulted { get; set; }
-        public Exception? FaultException { get; set; }
-
-        public async Task<string> CreateArchiveAsync(
-            string zipFilePath,
-            string loadFileName,
-            string loadFilePath,
-            FileGenerationRequest request,
-            ChannelReader<FileData> fileDataReader,
-            CancellationToken cancellationToken = default)
+        try
         {
-            try
+            if (IsFaulted && FaultException != null)
             {
-                if (IsFaulted && FaultException != null)
-                {
-                    throw FaultException;
-                }
-
-                await foreach (var fileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    var snapshot = fileData.Data.ToArray();
-                    CapturedEntries.Add(fileData with
-                    {
-                        Data = snapshot,
-                        DataLength = snapshot.Length,
-                        MemoryOwner = null,
-                    });
-                    fileData.MemoryOwner?.Dispose();
-                }
-            }
-            finally
-            {
-                while (fileDataReader.TryRead(out var leftover))
-                {
-                    leftover.MemoryOwner?.Dispose();
-                }
+                throw FaultException;
             }
 
-            return "in-memory-loadfile.dat";
+            await foreach (var fileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var snapshot = fileData.Data.ToArray();
+                CapturedEntries.Add(fileData with
+                {
+                    Data = snapshot,
+                    DataLength = snapshot.Length,
+                    MemoryOwner = null,
+                });
+                fileData.MemoryOwner?.Dispose();
+            }
         }
+        finally
+        {
+            while (fileDataReader.TryRead(out var leftover))
+            {
+                leftover.MemoryOwner?.Dispose();
+            }
+        }
+
+        return "in-memory-loadfile.dat";
     }
 }

--- a/src/Zipper.Tests/InMemorySink.cs
+++ b/src/Zipper.Tests/InMemorySink.cs
@@ -8,7 +8,7 @@ namespace Zipper
         public bool IsFaulted { get; set; }
         public Exception? FaultException { get; set; }
 
-        public async Task<string?> CreateArchiveAsync(
+        public async Task<string> CreateArchiveAsync(
             string zipFilePath,
             string loadFileName,
             string loadFilePath,

--- a/src/Zipper.Tests/InMemorySink.cs
+++ b/src/Zipper.Tests/InMemorySink.cs
@@ -4,10 +4,11 @@ namespace Zipper
 {
     internal class InMemorySink : IArchiveSink
     {
-        public List<FileData> CapturedFiles { get; } = new();
-        public Exception? InjectedFault { get; set; }
+        public List<FileData> CapturedEntries { get; } = new List<FileData>();
+        public bool IsFaulted { get; set; }
+        public Exception? FaultException { get; set; }
 
-        public async Task<string> CreateArchiveAsync(
+        public async Task<string?> CreateArchiveAsync(
             string zipFilePath,
             string loadFileName,
             string loadFilePath,
@@ -15,19 +16,34 @@ namespace Zipper
             ChannelReader<FileData> fileDataReader,
             CancellationToken cancellationToken = default)
         {
-            if (InjectedFault != null)
+            try
             {
-                throw InjectedFault;
+                if (IsFaulted && FaultException != null)
+                {
+                    throw FaultException;
+                }
+
+                await foreach (var fileData in fileDataReader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var snapshot = fileData.Data.ToArray();
+                    CapturedEntries.Add(fileData with
+                    {
+                        Data = snapshot,
+                        DataLength = snapshot.Length,
+                        MemoryOwner = null,
+                    });
+                    fileData.MemoryOwner?.Dispose();
+                }
+            }
+            finally
+            {
+                while (fileDataReader.TryRead(out var leftover))
+                {
+                    leftover.MemoryOwner?.Dispose();
+                }
             }
 
-            await foreach (var file in fileDataReader.ReadAllAsync(cancellationToken))
-            {
-                CapturedFiles.Add(file);
-                // The real sink disposes MemoryOwner when done
-                file.MemoryOwner?.Dispose();
-            }
-
-            return loadFilePath;
+            return "in-memory-loadfile.dat";
         }
     }
 }

--- a/src/Zipper.Tests/InMemorySink.cs
+++ b/src/Zipper.Tests/InMemorySink.cs
@@ -1,0 +1,33 @@
+using System.Threading.Channels;
+
+namespace Zipper
+{
+    internal class InMemorySink : IArchiveSink
+    {
+        public List<FileData> CapturedFiles { get; } = new();
+        public Exception? InjectedFault { get; set; }
+
+        public async Task<string> CreateArchiveAsync(
+            string zipFilePath,
+            string loadFileName,
+            string loadFilePath,
+            FileGenerationRequest request,
+            ChannelReader<FileData> fileDataReader,
+            CancellationToken cancellationToken = default)
+        {
+            if (InjectedFault != null)
+            {
+                throw InjectedFault;
+            }
+
+            await foreach (var file in fileDataReader.ReadAllAsync(cancellationToken))
+            {
+                CapturedFiles.Add(file);
+                // The real sink disposes MemoryOwner when done
+                file.MemoryOwner?.Dispose();
+            }
+
+            return loadFilePath;
+        }
+    }
+}

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -501,58 +501,31 @@ namespace Zipper
             Assert.Equal(expectedPadding, result);
         }
 
-        [SkippableFact(Timeout = 10000)]
+        [Fact]
         public async Task GenerateFilesAsync_ConsumerFaults_PipelineTerminatesWithException()
         {
-            Skip.If(OperatingSystem.IsWindows(), "Directory permissions don't prevent file creation on Windows");
-
-            var outputPath = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(outputPath);
-
-            try
+            var sink = new InMemorySink
             {
-                // Make directory read-only so zip file creation fails inside the consumer
-                File.SetAttributes(outputPath, FileAttributes.ReadOnly);
-                // On Linux, directory write permission controls file creation
-                System.Diagnostics.Process.Start("chmod", $"555 {outputPath}")?.WaitForExit();
+                InjectedFault = new InvalidOperationException("Simulated consumer fault")
+            };
+            var generator = new ParallelFileGenerator(sink);
 
-                var generator = new ParallelFileGenerator();
-
-                // This should throw (not hang) because the consumer cannot create the zip
-                await Assert.ThrowsAnyAsync<Exception>(async () =>
-                {
-                    await generator.GenerateFilesAsync(new FileGenerationRequest
-                    {
-                        Output = new OutputConfig
-                        {
-                            OutputPath = outputPath,
-                            FileCount = 100,
-                            FileType = "pdf",
-                            Folders = 2,
-                            Concurrency = 4,
-                        },
-                    }).ConfigureAwait(false);
-                });
-            }
-            finally
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                if (!OperatingSystem.IsWindows())
+                await generator.GenerateFilesAsync(new FileGenerationRequest
                 {
-                    System.Diagnostics.Process.Start("chmod", $"755 {outputPath}")?.WaitForExit();
-                }
-                else
-                {
-                    if (Directory.Exists(outputPath))
+                    Output = new OutputConfig
                     {
-                        File.SetAttributes(outputPath, FileAttributes.Normal);
-                    }
-                }
+                        OutputPath = "dummy",
+                        FileCount = 100,
+                        FileType = "pdf",
+                        Folders = 2,
+                        Concurrency = 4,
+                    },
+                }).ConfigureAwait(false);
+            });
 
-                if (Directory.Exists(outputPath))
-                {
-                    Directory.Delete(outputPath, true);
-                }
-            }
+            Assert.Equal("Simulated consumer fault", ex.Message);
         }
 
         [Fact]

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -501,31 +501,49 @@ namespace Zipper
             Assert.Equal(expectedPadding, result);
         }
 
-        [Fact]
+        [Fact(Timeout = 10000)]
         public async Task GenerateFilesAsync_ConsumerFaults_PipelineTerminatesWithException()
         {
-            var sink = new InMemorySink
-            {
-                InjectedFault = new InvalidOperationException("Simulated consumer fault")
-            };
-            var generator = new ParallelFileGenerator(sink);
+            var tempDir = Directory.GetCurrentDirectory();
+            var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outputPath);
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            try
             {
-                await generator.GenerateFilesAsync(new FileGenerationRequest
+                var faultingSink = new InMemorySink
+                {
+                    IsFaulted = true,
+                    FaultException = new IOException("Simulated consumer fault")
+                };
+                var generator = new ParallelFileGenerator(faultingSink);
+
+                // This should throw (not hang) because the consumer throws an exception
+                var generationTask = generator.GenerateFilesAsync(new FileGenerationRequest
                 {
                     Output = new OutputConfig
                     {
-                        OutputPath = "dummy",
+                        OutputPath = outputPath,
                         FileCount = 100,
                         FileType = "pdf",
                         Folders = 2,
                         Concurrency = 4,
                     },
-                }).ConfigureAwait(false);
-            });
+                });
 
-            Assert.Equal("Simulated consumer fault", ex.Message);
+                var completed = await Task.WhenAny(generationTask, Task.Delay(TimeSpan.FromSeconds(10)));
+                Assert.True(completed == generationTask, "GenerateFilesAsync did not fail within timeout.");
+
+                var ex = await Assert.ThrowsAnyAsync<Exception>(() => generationTask);
+
+                Assert.Equal("Simulated consumer fault", ex.Message);
+            }
+            finally
+            {
+                if (Directory.Exists(outputPath))
+                {
+                    Directory.Delete(outputPath, true);
+                }
+            }
         }
 
         [Fact]

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -41,7 +41,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -82,7 +82,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -126,7 +126,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -171,7 +171,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -219,7 +219,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -305,7 +305,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -359,7 +359,7 @@ namespace Zipper.Tests
             writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load", loadPathBase, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load", loadPathBase, request, channel.Reader);
 
             // Assert
             Assert.True(File.Exists(zipPath));
@@ -423,7 +423,7 @@ namespace Zipper.Tests
             channel.Writer.Complete();
 
             // Act
-            await ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
 
             // Assert — audit file totalRecords should equal fileCount, not fileCount+1
             var propertiesPath = loadPath + "_properties.json";
@@ -459,7 +459,7 @@ namespace Zipper.Tests
 
             channel.Writer.Complete();
 
-            await Assert.ThrowsAnyAsync<Exception>(() => ZipArchiveService.CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader));
+            await Assert.ThrowsAnyAsync<Exception>(() => new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader));
 
             Assert.True(owner1.IsDisposed, "Current item memory owner should be disposed");
             Assert.True(owner2.IsDisposed, "Buffered item memory owner should be disposed");


### PR DESCRIPTION
Closes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated archive generation to use an injected, replaceable archive-writing component to improve flexibility and test coverage.

* **Bug Fixes**
  * Ensured disk-backed file data iteration correctly fails after disposal instead of silently continuing.

* **Tests**
  * Added expanded persistence and lifecycle coverage for disk-backed file data (round-trips, ordering, cleanup, disposal behavior).
  * Improved consumer failure testing by using a fault-injecting in-memory archive sink.
  * Updated ZIP archive tests to validate behavior through the refactored archive component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->