### PR TITLE
refactor: deepen LoadfileAuditWriter as single audit authority

### DIFF
--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -20,21 +20,65 @@ internal static class LoadfileAuditWriter
     /// </summary>
     /// <param name="outputPath">Path to the generated load file.</param>
     /// <param name="request">File generation request.</param>
-    /// <param name="totalRecords">Total records written.</param>
+    /// <param name="composedRecords">The generated records.</param>
     /// <param name="anomalies">List of chaos anomalies (empty if chaos disabled).</param>
     /// <param name="format">The explicit load file format.</param>
     /// <returns>Path to the generated properties file.</returns>
     public static async Task<string> WriteAsync(
         string outputPath,
         FileGenerationRequest request,
-        long totalRecords,
+        IReadOnlyCollection<FileData> composedRecords,
         IReadOnlyList<ChaosAnomaly>? anomalies = null,
         LoadFileFormat? format = null)
     {
         var propertiesPath = Path.ChangeExtension(outputPath, null) + "_properties.json";
-        var json = GenerateAuditJson(outputPath, request, totalRecords, anomalies, format);
+        var json = GenerateAuditJson(outputPath, request, composedRecords, anomalies, format);
         await File.WriteAllTextAsync(propertiesPath, json).ConfigureAwait(false);
         return propertiesPath;
+    }
+
+    /// <summary>
+    /// Computes total lines and builds the ChaosEngine for the specified format.
+    /// </summary>
+    public static ChaosEngine? BuildChaosEngine(
+        FileGenerationRequest request,
+        IReadOnlyCollection<FileData> composedRecords,
+        LoadFileFormat format)
+    {
+        var (_, totalLines) = ComputeRecordCounts(request, composedRecords, format);
+        return ChaosEngineBuilder.Build(request, totalLines, format);
+    }
+
+    private static (long TotalRecords, long TotalLines) ComputeRecordCounts(
+        FileGenerationRequest request,
+        IReadOnlyCollection<FileData> composedRecords,
+        LoadFileFormat format)
+    {
+        long totalRecords;
+        if (composedRecords.Count == 0 && request.Output.FileCount > 0)
+        {
+            totalRecords = request.Output.FileCount;
+        }
+        else
+        {
+            if (format == LoadFileFormat.Opt)
+            {
+                totalRecords = composedRecords.Sum(f =>
+                    (request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
+                    + (request.Metadata.WithFamilies && request.Output.IsEml && f.Attachment.HasValue ? 1 : 0));
+            }
+            else
+            {
+                totalRecords = composedRecords.Count;
+                if (request.Metadata.WithFamilies && request.Output.IsEml)
+                {
+                    totalRecords += composedRecords.Count(f => f.Attachment.HasValue);
+                }
+            }
+        }
+
+        long totalLines = format == LoadFileFormat.Opt ? totalRecords : totalRecords + 1;
+        return (totalRecords, totalLines);
     }
 
     /// <summary>
@@ -42,18 +86,19 @@ internal static class LoadfileAuditWriter
     /// </summary>
     /// <param name="outputPath">Path to the generated load file.</param>
     /// <param name="request">File generation request.</param>
-    /// <param name="totalRecords">Total records written.</param>
+    /// <param name="composedRecords">The generated records.</param>
     /// <param name="anomalies">List of chaos anomalies.</param>
     /// <param name="format">The explicit load file format.</param>
     /// <returns>The properties JSON string.</returns>
     public static string GenerateAuditJson(
         string outputPath,
         FileGenerationRequest request,
-        long totalRecords,
+        IReadOnlyCollection<FileData> composedRecords,
         IReadOnlyList<ChaosAnomaly>? anomalies = null,
         LoadFileFormat? format = null)
     {
         var activeFormat = format ?? request.LoadFile.LoadFileFormat;
+        var (totalRecords, _) = ComputeRecordCounts(request, composedRecords, activeFormat);
         var formatName = activeFormat == LoadFileFormat.Opt
             ? "OPT (Image)"
             : "DAT (Metadata)";

--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -61,24 +61,45 @@ internal static class LoadfileAuditWriter
         }
         else
         {
-            if (format == LoadFileFormat.Opt)
+            totalRecords = format switch
             {
-                totalRecords = composedRecords.Sum(f =>
-                    (request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
-                    + (request.Metadata.WithFamilies && request.Output.IsEml && f.Attachment.HasValue ? 1 : 0));
-            }
-            else
-            {
-                totalRecords = composedRecords.Count;
-                if (request.Metadata.WithFamilies && request.Output.IsEml)
-                {
-                    totalRecords += composedRecords.Count(f => f.Attachment.HasValue);
-                }
-            }
+                LoadFileFormat.Opt => ComputeOptRecordCount(request, composedRecords),
+                _ => ComputeDatRecordCount(request, composedRecords)
+            };
         }
 
         long totalLines = format == LoadFileFormat.Opt ? totalRecords : totalRecords + 1;
         return (totalRecords, totalLines);
+    }
+
+    private static long ComputeOptRecordCount(FileGenerationRequest request, IReadOnlyCollection<FileData> composedRecords)
+    {
+        long total = 0;
+        bool includePageCount = request.Tiff.ShouldIncludePageCount(request.Output);
+        bool withFamilies = request.Metadata.WithFamilies && request.Output.IsEml;
+
+        foreach (var f in composedRecords)
+        {
+            total += (includePageCount ? Math.Max(1, f.PageCount) : 1) +
+                     (withFamilies && f.Attachment.HasValue ? 1 : 0);
+        }
+        return total;
+    }
+
+    private static long ComputeDatRecordCount(FileGenerationRequest request, IReadOnlyCollection<FileData> composedRecords)
+    {
+        long total = composedRecords.Count;
+        if (request.Metadata.WithFamilies && request.Output.IsEml)
+        {
+            foreach (var f in composedRecords)
+            {
+                if (f.Attachment.HasValue)
+                {
+                    total++;
+                }
+            }
+        }
+        return total;
     }
 
     /// <summary>

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -41,9 +41,7 @@ internal static class LoadfileOnlyGenerator
                 var loadFilePath = Path.Combine(request.Output.OutputPath, $"{baseFileName}{extension}");
                 generatedFiles.Add(loadFilePath);
 
-                long totalLines = format == LoadFileFormat.Opt
-                    ? request.Output.FileCount
-                    : request.Output.FileCount + 1;
+                var emptyRecords = Array.Empty<FileData>();
 
                 if (request.Chaos.ChaosMode && !string.IsNullOrEmpty(request.Chaos.ChaosScenario))
                 {
@@ -65,7 +63,7 @@ internal static class LoadfileOnlyGenerator
                     }
                 }
 
-                ChaosEngine? chaosEngine = ChaosEngineBuilder.Build(request, totalLines, format);
+                ChaosEngine? chaosEngine = LoadfileAuditWriter.BuildChaosEngine(request, emptyRecords, format);
 
                 ILoadFileWriter writer = LoadFileWriterFactory.CreateWriter(
                     format == LoadFileFormat.Opt ? LoadFileFormat.Opt : LoadFileFormat.Dat,
@@ -74,13 +72,13 @@ internal static class LoadfileOnlyGenerator
                 var fileStream = new FileStream(loadFilePath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
                 await using (fileStream.ConfigureAwait(false))
                 {
-                    await writer.WriteAsync(fileStream, request, new List<FileData>(), chaosEngine, cancellationToken).ConfigureAwait(false);
+                    await writer.WriteAsync(fileStream, request, emptyRecords, chaosEngine, cancellationToken).ConfigureAwait(false);
                 }
 
                 string propertiesPath = await LoadfileAuditWriter.WriteAsync(
                     loadFilePath,
                     request,
-                    request.Output.FileCount,
+                    emptyRecords,
                     chaosEngine?.Anomalies,
                     format).ConfigureAwait(false);
                 generatedFiles.Add(propertiesPath);

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -164,40 +164,30 @@ internal static class ProductionSetGenerator
 
         Console.WriteLine();
 
-        long totalRecords = fileDataList.Count;
-        if (request.Metadata.WithFamilies && request.Output.IsEml)
-        {
-            totalRecords += fileDataList.Count(f => f.Attachment.HasValue);
-        }
-
         // Write DAT load file — build a fresh ChaosEngine per format (engines are stateful)
         var datPath = Path.Combine(dataDir, "loadfile.dat");
         var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
-        long datTotalLines = totalRecords + 1; // header + data rows
-        var datChaosEngine = ChaosEngineBuilder.Build(request, datTotalLines, LoadFileFormat.Dat);
+        var datChaosEngine = LoadfileAuditWriter.BuildChaosEngine(request, fileDataList, LoadFileFormat.Dat);
         var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (datStream.ConfigureAwait(false))
         {
             await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine, cancellationToken).ConfigureAwait(false);
         }
 
-        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, totalRecords, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
+        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datPath, request, fileDataList, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson).ConfigureAwait(false);
 
         // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
         var optWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, LoadFiles.WriterMode.ProductionSet);
-        long optTotalLines = fileDataList.Sum(f =>
-            (request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
-            + (request.Metadata.WithFamilies && request.Output.IsEml && f.Attachment.HasValue ? 1 : 0));
-        var optChaosEngine = ChaosEngineBuilder.Build(request, optTotalLines, LoadFileFormat.Opt);
+        var optChaosEngine = LoadfileAuditWriter.BuildChaosEngine(request, fileDataList, LoadFileFormat.Opt);
         var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (optStream.ConfigureAwait(false))
         {
             await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine, cancellationToken).ConfigureAwait(false);
         }
 
-        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, optTotalLines, optChaosEngine?.Anomalies, LoadFileFormat.Opt);
+        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optPath, request, fileDataList, optChaosEngine?.Anomalies, LoadFileFormat.Opt);
 
         // Save OPT properties with a slightly different name to avoid overwriting DAT properties
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson).ConfigureAwait(false);

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -146,7 +146,7 @@ internal class ZipArchiveSink : IArchiveSink
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
         ILoadFileWriter loadFileWriter,
-        dynamic? chaosEngine,
+        ChaosEngine? chaosEngine,
         string actualLoadFileName)
     {
         var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
@@ -158,7 +158,7 @@ internal class ZipArchiveSink : IArchiveSink
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
         ILoadFileWriter loadFileWriter,
-        dynamic? chaosEngine,
+        ChaosEngine? chaosEngine,
         string currentFilePath)
     {
         var fileStream = new FileStream(currentFilePath, FileMode.Create);
@@ -173,7 +173,7 @@ internal class ZipArchiveSink : IArchiveSink
         ZipArchive archive,
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
-        dynamic? chaosEngine,
+        ChaosEngine? chaosEngine,
         LoadFileFormat format,
         string actualLoadFileName)
     {
@@ -187,7 +187,7 @@ internal class ZipArchiveSink : IArchiveSink
     private async Task EmitAuditToDiskAsync(
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
-        dynamic? chaosEngine,
+        ChaosEngine? chaosEngine,
         LoadFileFormat format,
         string currentFilePath)
     {

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -124,26 +124,19 @@ internal class ZipArchiveSink : IArchiveSink
         var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
         var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
 
-        long totalRecords = format == LoadFileFormat.Opt
-            ? processedFiles.Sum(f => request.Tiff.ShouldIncludePageCount(request.Output) ? Math.Max(1, f.PageCount) : 1)
-            : processedFiles.Count;
-
-        long totalChaosLines = format == LoadFileFormat.Opt
-            ? totalRecords
-            : totalRecords + 1;
-        var chaosEngine = ChaosEngineBuilder.Build(request, totalChaosLines, format);
+        var chaosEngine = LoadfileAuditWriter.BuildChaosEngine(request, processedFiles, format);
 
         if (request.Output.IncludeLoadFile)
         {
             await GenerateLoadFileToArchiveAsync(archive, request, processedFiles, loadFileWriter, chaosEngine, actualLoadFileName).ConfigureAwait(false);
-            await EmitAuditToArchiveAsync(archive, request, totalRecords, chaosEngine, format, actualLoadFileName).ConfigureAwait(false);
+            await EmitAuditToArchiveAsync(archive, request, processedFiles, chaosEngine, format, actualLoadFileName).ConfigureAwait(false);
             return actualLoadFileName;
         }
         else
         {
             var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
             await GenerateLoadFileToDiskAsync(request, processedFiles, loadFileWriter, chaosEngine, currentFilePath).ConfigureAwait(false);
-            await EmitAuditToDiskAsync(request, totalRecords, chaosEngine, format, currentFilePath).ConfigureAwait(false);
+            await EmitAuditToDiskAsync(request, processedFiles, chaosEngine, format, currentFilePath).ConfigureAwait(false);
             return currentFilePath;
         }
     }
@@ -179,12 +172,12 @@ internal class ZipArchiveSink : IArchiveSink
     private async Task EmitAuditToArchiveAsync(
         ZipArchive archive,
         FileGenerationRequest request,
-        long totalRecords,
+        DiskBackedFileDataList processedFiles,
         dynamic? chaosEngine,
         LoadFileFormat format,
         string actualLoadFileName)
     {
-        var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, totalRecords, chaosEngine?.Anomalies, format);
+        var auditJson = LoadfileAuditWriter.GenerateAuditJson(actualLoadFileName, request, processedFiles, chaosEngine?.Anomalies, format);
         var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
         using var propertiesStream = propertiesEntry.Open();
         using var propertiesWriter = new StreamWriter(propertiesStream);
@@ -193,12 +186,12 @@ internal class ZipArchiveSink : IArchiveSink
 
     private async Task EmitAuditToDiskAsync(
         FileGenerationRequest request,
-        long totalRecords,
+        DiskBackedFileDataList processedFiles,
         dynamic? chaosEngine,
         LoadFileFormat format,
         string currentFilePath)
     {
-        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, totalRecords, chaosEngine?.Anomalies, format);
+        var auditJson = LoadfileAuditWriter.GenerateAuditJson(currentFilePath, request, processedFiles, chaosEngine?.Anomalies, format);
         await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
     }
 

--- a/src/Zipper.Tests/LoadfileAuditWriterTests.cs
+++ b/src/Zipper.Tests/LoadfileAuditWriterTests.cs
@@ -17,9 +17,10 @@ public class LoadfileAuditWriterTests
             IsEncodingExplicit = false
         };
         request.Chaos = request.Chaos with { ChaosMode = false };
+        request.Output = request.Output with { FileCount = 100 };
 
         // Act
-        var json = LoadfileAuditWriter.GenerateAuditJson("test.opt", request, 100, null);
+        var json = LoadfileAuditWriter.GenerateAuditJson("test.opt", request, Array.Empty<FileData>(), null);
 
         // Assert
         using var doc = JsonDocument.Parse(json);
@@ -65,9 +66,10 @@ public class LoadfileAuditWriterTests
             NestedValueDelimiter = ":",
             EndOfLine = "CRLF"
         };
+        request.Output = request.Output with { FileCount = 50 };
 
         // Act
-        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, 50, null);
+        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, Array.Empty<FileData>(), null);
 
         // Assert
         using var doc = JsonDocument.Parse(json);
@@ -112,9 +114,10 @@ public class LoadfileAuditWriterTests
                 Description = "Mixed delimiters injected"
             }
         };
+        request.Output = request.Output with { FileCount = 200 };
 
         // Act
-        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, 200, anomalies);
+        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, Array.Empty<FileData>(), anomalies);
 
         // Assert
         using var doc = JsonDocument.Parse(json);
@@ -148,9 +151,10 @@ public class LoadfileAuditWriterTests
             ColumnDelimiter = "\u0014", // Device Control 4
             QuoteDelimiter = "\u00fe" // Thorn character
         };
+        request.Output = request.Output with { FileCount = 10 };
 
         // Act
-        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, 10, null);
+        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, Array.Empty<FileData>(), null);
 
         // Assert
         using var doc = JsonDocument.Parse(json);
@@ -175,9 +179,10 @@ public class LoadfileAuditWriterTests
             QuoteDelimiter = null!,
             NewlineDelimiter = string.Empty
         };
+        request.Output = request.Output with { FileCount = 10 };
 
         // Act
-        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, 10, null);
+        var json = LoadfileAuditWriter.GenerateAuditJson("test.dat", request, Array.Empty<FileData>(), null);
 
         // Assert
         using var doc = JsonDocument.Parse(json);
@@ -201,8 +206,9 @@ public class LoadfileAuditWriterTests
 
         try
         {
+            request.Output = request.Output with { FileCount = 42 };
             // Act
-            var path = await LoadfileAuditWriter.WriteAsync(tempFile, request, 42, null);
+            var path = await LoadfileAuditWriter.WriteAsync(tempFile, request, Array.Empty<FileData>(), null);
 
             // Assert
             Assert.Equal(expectedPropertiesFile, path);

--- a/src/Zipper.Tests/OptLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/OptLoadFileWriterTests.cs
@@ -170,10 +170,10 @@ public class OptLoadFileWriterTests : TempDirectoryTestBase
         var datContentWithUtf8 = await File.ReadAllTextAsync(datOutputPath, Encoding.UTF8);
         Assert.NotEmpty(datContentWithUtf8);
 
-        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optOutputPath, request, fileData.Count, null, LoadFileFormat.Opt);
+        var optAuditJson = LoadfileAuditWriter.GenerateAuditJson(optOutputPath, request, fileData, null, LoadFileFormat.Opt);
         Assert.Contains("\"encoding\": \"ANSI\"", optAuditJson, StringComparison.Ordinal);
 
-        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datOutputPath, request, fileData.Count, null, LoadFileFormat.Dat);
+        var datAuditJson = LoadfileAuditWriter.GenerateAuditJson(datOutputPath, request, fileData, null, LoadFileFormat.Dat);
         Assert.Contains("\"encoding\": \"UTF-8\"", datAuditJson, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Closes #486

Deepened LoadfileAuditWriter to act as the single audit authority, handling per-format record count math and chaos engine initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated audit file generation logic to compute record counts internally based on file data, improving the consistency of audit metadata generation across different output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->