### PR TITLE
docs: Code Review Guideline — project-specific false-positive guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ Individual file generators (`EmlFileGenerator.cs`, `TiffFileGenerator.cs`, `Offi
 - Distribution algorithms must be O(1) per file. Use `Span<T>`, `ArrayPool<T>`, avoid allocations in hot paths
 - ZIP entry paths always use `/`; normalize to backslashes with `.Replace('/', '\\')`, never `Replace(Path.DirectorySeparatorChar, '\\')` (a no-op on Windows, where the separator is already `\`)
 - **No copyright headers** — do not add `// <copyright ...>` to any files
+- **Review guardrails:** Before filing a finding, check `docs/code-review-guidelines.md` for project-specific patterns that look like issues but are deliberate. Applies to human review, robot reviewers (CodeRabbit, Gemini, Codex), and the autoreview skill.
 
 ### Test Naming Convention
 

--- a/docs/code-review-guidelines.md
+++ b/docs/code-review-guidelines.md
@@ -1,0 +1,44 @@
+# Code Review Guidelines
+
+Patterns in this repo that look like defects but are deliberate.
+Check this list before filing a finding. If a finding matches one of
+these, either skip it or file it with an explicit note that the
+guideline was considered and why an exception applies.
+
+## 1. Output-parity invariant (Critical Rule 6)
+
+Any code that produces Load File / Audit File / Production Set output
+must stay byte-for-byte identical to the legacy writers unless a golden
+baseline harness proves parity after the change.
+
+- Do NOT flag string.Replace / Substring / path-separator handling in
+  LoadfileAuditWriter, ProductionManifestWriter, StandardRowComposer,
+  DatComposer, OptComposer, ProductionSetGenerator output paths as
+  "inefficient" without first confirming a parity harness exists.
+- Whole-string Replace (vs extension-only slicing) is deliberate where
+  commented — it preserves historical byte output.
+- Filing such a finding: require the author to attach a golden-baseline
+  diff before acting on it.
+
+## 2. Required materialization (.ToList() on indexed paths)
+
+ToList() is correct, not wasteful, when the result is:
+  (a) stored in a field iterated once per record, or
+  (b) passed to LoadFileRecordBuilder.Build, which indexes by position
+      and reads .Count on IReadOnlyList<string>.
+
+Lazy IEnumerable would re-run the Select or fail to index.
+
+## 3. Deliberate-difference "duplication"
+
+Implementations that look similar may have deliberate differences for specific formats. For example, `FormatDelimiter` in `LoadfileAuditWriter` vs `ProductionManifestWriter` differ on empty sentinel (`"none"` vs `""`), ascii range (`<32` vs `<32 && >126`), and char fallback (first char vs full string).
+
+Different output formats shouldn't be merged if it adds parameters for a single-use case. YAGNI.
+
+## 4. Trivial-to-abstract duplication
+
+Minor shared logic (e.g., a few lines of shared constructor parse logic in `DateGenerator` vs `DateTimeColumnGenerator`) should not be abstracted if the main bodies differ significantly. A base class for a few lines is YAGNI.
+
+## 5. Already-covered test gaps
+
+Before flagging missing test coverage for specific exception paths (e.g., `NotImplementedException` or `ArgumentException`), ensure existing tests (like `GenerateContent_WithPptx_ShouldThrowNotImplementedException` or `WithInvalidCharactersInFileName`) don't already assert these paths.


### PR DESCRIPTION
Closes #527

## Release Notes
Added docs/code-review-guidelines.md to document deliberate patterns in the codebase to prevent false positives in code reviews.

## Description

This PR implements issue #527 by adding `docs/code-review-guidelines.md` and referencing it in `AGENTS.md` under the Code Style section. This document provides project-specific false-positive guardrails for human and robot reviewers to reduce noise during code review.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test coverage
- [x] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced email placeholder substitution to be more efficient and accurate.

* **Documentation**
  * Added code review guidelines for the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->