### PR TITLE
investigate: enable more Meziantou.Analyzer rules across the codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -148,6 +148,23 @@ dotnet_diagnostic.MA0002.severity = none
 dotnet_diagnostic.MA0006.severity = none
 dotnet_diagnostic.MA0072.severity = none
 
+# Phase 1: Zero-risk promotions
+dotnet_diagnostic.MA0009.severity = error
+dotnet_diagnostic.MA0054.severity = error
+dotnet_diagnostic.MA0056.severity = error
+dotnet_diagnostic.MA0060.severity = error
+dotnet_diagnostic.MA0100.severity = error
+dotnet_diagnostic.MA0134.severity = error
+dotnet_diagnostic.MA0143.severity = error
+
+# Phase 2: Opt-in rules
+dotnet_diagnostic.MA0141.severity = warning
+dotnet_diagnostic.MA0142.severity = warning
+dotnet_diagnostic.MA0112.severity = warning
+dotnet_diagnostic.MA0137.severity = warning
+dotnet_diagnostic.MA0138.severity = warning
+
+
 
 # --- Performance quick wins ---
 dotnet_diagnostic.CA1510.severity = warning   # use ArgumentNullException.ThrowIfNull
@@ -196,6 +213,7 @@ dotnet_diagnostic.RCS1139.severity = none
 # assertions and fixtures. Scope the rules enabled above to production code only.
 [**/{Zipper.Tests,Zipper.Analyzers.Tests}/**.cs]
 dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.MA0137.severity = none
 dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1307.severity = none
 dotnet_diagnostic.CA1310.severity = none

--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -40,7 +40,7 @@ public static class CliValidator
             return false;
         }
 
-        if (parsed.OutputDirectory == null)
+        if (parsed.OutputDirectory is null)
         {
             Console.Error.WriteLine("Error: --output-path is required or was invalid.");
             return false;

--- a/src/Cli/Pipeline.cs
+++ b/src/Cli/Pipeline.cs
@@ -4,14 +4,14 @@ public static class Pipeline
 {
     public static FileGenerationRequest? Build(string[] args)
     {
-        if (args == null || args.Length == 0)
+        if (args is null || args.Length is 0)
         {
             HelpTextGenerator.Show();
             return null;
         }
 
         var parsedArgs = CliParser.Parse(args);
-        if (parsedArgs == null)
+        if (parsedArgs is null)
         {
             return null;
         }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -23,7 +23,7 @@ public static class RequestBuilder
         if (!string.IsNullOrEmpty(parsed.ColumnProfile))
         {
             profile = ColumnProfileLoader.Load(parsed.ColumnProfile);
-            if (profile == null)
+            if (profile is null)
             {
                 Console.Error.WriteLine($"Warning: Failed to load column profile '{parsed.ColumnProfile}'.");
             }
@@ -104,7 +104,7 @@ public static class RequestBuilder
             nestedDelim = ParseStrictDelimiter(parsed.NestedDelim);
         }
 
-        var encodingName = (encoding != null && !string.IsNullOrEmpty(parsed.Encoding))
+        var encodingName = (encoding is not null && !string.IsNullOrEmpty(parsed.Encoding))
             ? parsed.Encoding.ToUpperInvariant()
             : "UTF-8";
 

--- a/src/Cli/Validation/CrossCuttingValidator.cs
+++ b/src/Cli/Validation/CrossCuttingValidator.cs
@@ -23,13 +23,13 @@ internal static class CrossCuttingValidator
 
     private static bool ValidateEncodingAndDistribution(ParsedArguments parsed)
     {
-        if (!string.IsNullOrEmpty(parsed.Encoding) && RequestBuilder.GetEncodingFromName(parsed.Encoding) == null)
+        if (!string.IsNullOrEmpty(parsed.Encoding) && RequestBuilder.GetEncodingFromName(parsed.Encoding) is null)
         {
             Console.Error.WriteLine($"Error: Invalid encoding '{parsed.Encoding}'. Supported values are UTF-8, UTF-16, ANSI.");
             return false;
         }
 
-        if (!string.IsNullOrEmpty(parsed.Distribution) && RequestBuilder.GetDistributionFromName(parsed.Distribution) == null)
+        if (!string.IsNullOrEmpty(parsed.Distribution) && RequestBuilder.GetDistributionFromName(parsed.Distribution) is null)
         {
             Console.Error.WriteLine($"Error: Invalid distribution '{parsed.Distribution}'. Supported values are proportional, gaussian, exponential.");
             return false;
@@ -41,7 +41,7 @@ internal static class CrossCuttingValidator
     {
         if (!string.IsNullOrEmpty(parsed.LoadFileFormat))
         {
-            if (RequestBuilder.GetLoadFileFormat(parsed.LoadFileFormat) == null)
+            if (RequestBuilder.GetLoadFileFormat(parsed.LoadFileFormat) is null)
             {
                 Console.Error.WriteLine("Error: Invalid load file format. Supported values are dat, opt, csv, edrm-xml, xml, concordance.");
                 return false;
@@ -52,7 +52,7 @@ internal static class CrossCuttingValidator
         {
             foreach (var fmt in parsed.LoadFileFormats.Split(','))
             {
-                if (RequestBuilder.GetLoadFileFormat(fmt.Trim()) == null)
+                if (RequestBuilder.GetLoadFileFormat(fmt.Trim()) is null)
                 {
                     Console.Error.WriteLine($"Error: Invalid load file format '{fmt}'. Supported: dat, opt, csv, edrm-xml, xml, concordance.");
                     return false;
@@ -64,7 +64,7 @@ internal static class CrossCuttingValidator
 
     private static bool ValidateTiffPagesRange(ParsedArguments parsed)
     {
-        if (!string.IsNullOrEmpty(parsed.TiffPagesRange) && TiffMultiPageGenerator.ParsePageRange(parsed.TiffPagesRange) == null)
+        if (!string.IsNullOrEmpty(parsed.TiffPagesRange) && TiffMultiPageGenerator.ParsePageRange(parsed.TiffPagesRange) is null)
         {
             Console.Error.WriteLine("Error: Invalid TIFF pages range. Use format: <min>-<max> (e.g., 1-20).");
             return false;
@@ -282,7 +282,7 @@ internal static class CrossCuttingValidator
 
     private static bool ValidateBates(ParsedArguments parsed)
     {
-        if (parsed.BatesPrefix != null || parsed.BatesStart != null || parsed.BatesDigits != null)
+        if (parsed.BatesPrefix is not null || parsed.BatesStart is not null || parsed.BatesDigits is not null)
         {
             var config = new BatesNumberConfig
             {

--- a/src/Cli/Validation/StandardModeValidator.cs
+++ b/src/Cli/Validation/StandardModeValidator.cs
@@ -4,7 +4,7 @@ internal static class StandardModeValidator
 {
     public static bool Validate(ParsedArguments parsed)
     {
-        if (parsed.OutputDirectory == null && !string.IsNullOrWhiteSpace(parsed.OutputPathStr))
+        if (parsed.OutputDirectory is null && !string.IsNullOrWhiteSpace(parsed.OutputPathStr))
         {
             parsed.OutputDirectory = PathValidator.ValidateAndCreateDirectory(parsed.OutputPathStr, Directory.GetCurrentDirectory());
         }
@@ -36,7 +36,7 @@ internal static class StandardModeValidator
         if (!string.IsNullOrEmpty(parsed.TargetZipSize))
         {
             var parsedSize = RequestBuilder.ParseSize(parsed.TargetZipSize);
-            if (parsedSize == null)
+            if (parsedSize is null)
             {
                 Console.Error.WriteLine("Error: Invalid format for --target-zip-size. Use KB, MB, GB, etc. (e.g., 500MB, 10GB).");
                 return false;

--- a/src/Emails/EmailFactory.cs
+++ b/src/Emails/EmailFactory.cs
@@ -309,7 +309,7 @@ internal static class EmailFactory
 
             if (lookup.TryGetValue(keySpan, out var value))
             {
-                if (sb == null)
+                if (sb is null)
                 {
                     sb = new StringBuilder(template.Length * 2);
                     sb.Append(template, 0, openBraceIndex);
@@ -328,7 +328,7 @@ internal static class EmailFactory
             }
         }
 
-        if (sb == null)
+        if (sb is null)
         {
             return template;
         }

--- a/src/Emails/EmailSerializer.cs
+++ b/src/Emails/EmailSerializer.cs
@@ -178,7 +178,7 @@ internal static class EmailSerializer
 
     private static string GenerateBoundary(Random? seeded)
     {
-        if (seeded != null)
+        if (seeded is not null)
         {
             return $"----={seeded.Next():x8}{seeded.Next():x8}{seeded.Next():x8}{seeded.Next():x8}";
         }

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -34,7 +34,7 @@ internal sealed class DatComposer : ILoadFileComposer
         this.namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
         this.batesSequence = request.Bates != null ? BatesSequence.FromConfig(request.Bates) : null;
 
-        if (mode == WriterMode.LoadfileOnly && request.Metadata.ColumnProfile != null)
+        if (mode is WriterMode.LoadfileOnly && request.Metadata.ColumnProfile is not null)
         {
             var profile = request.Metadata.ColumnProfile;
             this.profileGenerator = new DataGenerator(
@@ -57,7 +57,7 @@ internal sealed class DatComposer : ILoadFileComposer
     public IEnumerable<LoadFileRecord> Compose(IReadOnlyList<FileData> processedFiles)
         => this.mode switch
         {
-            WriterMode.LoadfileOnly => this.profileGenerator != null
+            WriterMode.LoadfileOnly => this.profileGenerator is not null
                 ? this.ComposeProfile()
                 : this.ComposeLoadfileOnly(),
             WriterMode.ProductionSet => this.ComposeProduction(processedFiles),
@@ -322,7 +322,7 @@ internal sealed class DatComposer : ILoadFileComposer
 
         for (long i = 1; i <= this.request.Output.FileCount; i++)
         {
-            var recordId = this.batesSequence != null
+            var recordId = this.batesSequence is not null
                 ? this.batesSequence.Next().ToString()
                 : $"DOC{i:D8}";
 
@@ -383,7 +383,7 @@ internal sealed class DatComposer : ILoadFileComposer
     private (string ParentId, string ChildId, bool HasAttachment) GetFamilyIdentifiers(FileData fileData, FileGenerationRequest request)
     {
         bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-        string parentId = this.batesSequence != null
+        string parentId = this.batesSequence is not null
             ? this.batesSequence.Format(fileData.WorkItem.Index - 1).ToString()
             : $"DOC{fileData.WorkItem.Index:D8}";
         string childId = hasAttachment ? $"{parentId}_A001" : parentId;
@@ -393,14 +393,14 @@ internal sealed class DatComposer : ILoadFileComposer
     private static DataGenerator? GetEffectiveProfileGenerator(FileGenerationRequest request, DateTime now)
     {
         var profile = request.Metadata.ColumnProfile;
-        if (profile == null && request.Metadata.ShouldIncludeMetadataColumns(request.Output))
+        if (profile is null && request.Metadata.ShouldIncludeMetadataColumns(request.Output))
         {
             profile = request.Output.IsEml
                 ? BuiltInProfiles.LegacyEml
                 : BuiltInProfiles.LegacyWithMetadata;
         }
 
-        return profile != null ? new DataGenerator(profile, request.Metadata.Seed, now) : null;
+        return profile is not null ? new DataGenerator(profile, request.Metadata.Seed, now) : null;
     }
 
     private sealed record RowCtx

--- a/src/LoadFiles/DatComposingWriter.cs
+++ b/src/LoadFiles/DatComposingWriter.cs
@@ -33,7 +33,7 @@ internal sealed class DatComposingWriter : ILoadFileWriter
     {
         var composer = new DatComposer(request, this.mode);
         var serializer = new DatSerializer(request);
-        var policy = new TextOutputPolicy(request, LoadFileFormat.Dat, this.mode, chaosEngine != null);
+        var policy = new TextOutputPolicy(request, LoadFileFormat.Dat, this.mode, chaosEngine is not null);
 
         var records = composer.Compose(processedFiles);
         await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, policy.Encoding, policy.EndOfLine, chaosEngine, cancellationToken).ConfigureAwait(false);

--- a/src/LoadFiles/LoadFileEmitter.cs
+++ b/src/LoadFiles/LoadFileEmitter.cs
@@ -45,7 +45,7 @@ internal static class LoadFileEmitter
     {
         bool hasHeader = headerColumns is { Count: > 0 };
 
-        if (chaosEngine == null)
+        if (chaosEngine is null)
         {
             await EmitStreamingAsync(stream, serializer, hasHeader, headerColumns, records, encoding, eol, cancellationToken).ConfigureAwait(false);
         }
@@ -142,7 +142,7 @@ internal static class LoadFileEmitter
         await stream.WriteAsync(encoding.GetBytes(text + eol), cancellationToken).ConfigureAwait(false);
 
         var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
-        if (anomaly != null)
+        if (anomaly is not null)
         {
             await stream.WriteAsync(anomaly, cancellationToken).ConfigureAwait(false);
         }

--- a/src/LoadFiles/OptComposer.cs
+++ b/src/LoadFiles/OptComposer.cs
@@ -57,7 +57,7 @@ internal sealed class OptComposer : ILoadFileComposer
 
         for (long i = 1; i <= this.request.Output.FileCount; i++)
         {
-            string batesId = this.batesSequence != null
+            string batesId = this.batesSequence is not null
                 ? this.batesSequence.Next().ToString()
                 : $"IMG{i:D8}";
             string volume = "VOL001";
@@ -84,7 +84,7 @@ internal sealed class OptComposer : ILoadFileComposer
             {
                 baseBatesNumber = this.batesSequence!.Format(workItem.Index - 1).ToString();
             }
-            else if (this.batesSequence != null)
+            else if (this.batesSequence is not null)
             {
                 baseBatesNumber = this.batesSequence.Format(workItem.Index - 1).ToString();
             }

--- a/src/LoadFiles/OptComposingWriter.cs
+++ b/src/LoadFiles/OptComposingWriter.cs
@@ -41,7 +41,7 @@ internal sealed class OptComposingWriter : ILoadFileWriter
 
         // Standard (in-archive) OPT ignored chaos entirely; loadfile-only and production applied chaos.
         var effectiveChaos = this.mode == WriterMode.Standard ? null : chaosEngine;
-        var policy = new TextOutputPolicy(request, LoadFileFormat.Opt, this.mode, effectiveChaos != null);
+        var policy = new TextOutputPolicy(request, LoadFileFormat.Opt, this.mode, effectiveChaos is not null);
 
         var records = composer.Compose(processedFiles);
         await LoadFileEmitter.EmitAsync(stream, serializer, composer.HeaderColumns, records, policy.Encoding, policy.EndOfLine, effectiveChaos, cancellationToken).ConfigureAwait(false);

--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -173,7 +173,7 @@ internal static class LoadfileAuditWriter
                 Enabled = request.Chaos.ChaosMode,
                 TargetAmount = request.Chaos.ChaosAmount,
                 TotalAnomalies = anomalies?.Count ?? 0,
-                InjectedAnomalies = anomalies != null && anomalies.Count > 0
+                InjectedAnomalies = anomalies is not null && anomalies.Count > 0
                     ? anomalies.Select(a => new AuditAnomalyEntry
                     {
                         LineNumber = a.LineNumber,

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -137,7 +137,7 @@ namespace Zipper
                 long actualZipSize = 0;
                 ZipSizeVerificationResult? zipSizeVerification = null;
 
-                if (zipFilePath != null && File.Exists(zipFilePath))
+                if (zipFilePath is not null && File.Exists(zipFilePath))
                 {
                     actualZipSize = new FileInfo(zipFilePath).Length;
                     if (request.Output.TargetZipSize.HasValue)
@@ -163,8 +163,8 @@ namespace Zipper
                 this.performanceMonitor.Stop();
                 try
                 {
-                    if (zipFilePath != null && File.Exists(zipFilePath)) File.Delete(zipFilePath);
-                    if (loadFilePath != null && File.Exists(loadFilePath)) File.Delete(loadFilePath);
+                    if (zipFilePath is not null && File.Exists(zipFilePath)) File.Delete(zipFilePath);
+                    if (loadFilePath is not null && File.Exists(loadFilePath)) File.Delete(loadFilePath);
                 }
 #pragma warning disable CA1031
 #pragma warning disable RCS1075
@@ -274,7 +274,7 @@ namespace Zipper
                 ? MemoryPool<byte>.Shared.Rent(rentSize)
                 : null;
 
-            if (memoryOwner == null)
+            if (memoryOwner is null)
             {
                 var data = new byte[(int)totalSize];
                 Buffer.BlockCopy(fileContent, 0, data, 0, fileContent.Length);

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -25,7 +25,7 @@ namespace Zipper
                 // Let the OS resolve the full canonical path, resolving any ".." or "." components
                 string fullPath = GetRealPath(path);
 
-                if (baseDirectory != null)
+                if (baseDirectory is not null)
                 {
                     // Determine the base directory to restrict access to
                     string restrictToBase = GetRealPath(baseDirectory);
@@ -89,7 +89,7 @@ namespace Zipper
             {
                 string fullPath = GetRealPath(path);
 
-                if (baseDirectory != null)
+                if (baseDirectory is not null)
                 {
                     string restrictToBase = GetRealPath(baseDirectory);
                     string fullPathWithTrailing = fullPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
@@ -129,12 +129,12 @@ namespace Zipper
             DirectoryInfo? current = new DirectoryInfo(fullPath);
             var parts = new System.Collections.Generic.List<string>();
 
-            while (current != null)
+            while (current is not null)
             {
-                if (current.Exists && current.LinkTarget != null)
+                if (current.Exists && current.LinkTarget is not null)
                 {
                     var resolved = current.ResolveLinkTarget(true);
-                    if (resolved != null)
+                    if (resolved is not null)
                     {
                         parts.Reverse();
                         return (resolved.FullName, parts);

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -10,20 +10,19 @@ namespace Zipper
     /// </summary>
     public static class PerformanceBenchmarkRunner
     {
-        public static async Task RunBenchmarks()
+        public static async Task RunBenchmarksAsync()
         {
             Console.WriteLine("=== Performance Benchmark Suite ===");
             Console.WriteLine();
-
-            await BenchmarkParallelVsSequential().ConfigureAwait(false);
-            await BenchmarkMemoryPooling().ConfigureAwait(false);
-            await BenchmarkScalability().ConfigureAwait(false);
-            await BenchmarkAllocation().ConfigureAwait(false);
+            await BenchmarkParallelVsSequentialAsync().ConfigureAwait(false);
+            await BenchmarkMemoryPoolingAsync().ConfigureAwait(false);
+            await BenchmarkScalabilityAsync().ConfigureAwait(false);
+            await BenchmarkAllocationAsync().ConfigureAwait(false);
 
             Console.WriteLine("=== Benchmark Suite Complete ===");
         }
 
-        private static async Task BenchmarkAllocation()
+        private static async Task BenchmarkAllocationAsync()
         {
             Console.WriteLine("4. Allocation Impact");
             Console.WriteLine("===================");
@@ -76,7 +75,7 @@ namespace Zipper
             Console.WriteLine();
         }
 
-        private static async Task BenchmarkParallelVsSequential()
+        private static async Task BenchmarkParallelVsSequentialAsync()
         {
             Console.WriteLine("1. Parallel vs Sequential Generation");
             Console.WriteLine("=====================================");
@@ -94,7 +93,7 @@ namespace Zipper
             {
                 // Sequential baseline
                 var sw = Stopwatch.StartNew();
-                await GenerateSequentialFiles(fileCount, outputPath1).ConfigureAwait(false);
+                await GenerateSequentialFilesAsync(fileCount, outputPath1).ConfigureAwait(false);
                 sw.Stop();
                 var sequentialTime = sw.ElapsedMilliseconds;
 
@@ -133,7 +132,7 @@ namespace Zipper
             Console.WriteLine();
         }
 
-        private static Task BenchmarkMemoryPooling()
+        private static Task BenchmarkMemoryPoolingAsync()
         {
             Console.WriteLine("2. Memory Pool Performance");
             Console.WriteLine("===========================");
@@ -191,7 +190,7 @@ namespace Zipper
             return Task.CompletedTask;
         }
 
-        private static async Task BenchmarkScalability()
+        private static async Task BenchmarkScalabilityAsync()
         {
             Console.WriteLine("3. Scalability Test");
             Console.WriteLine("===================");
@@ -242,7 +241,7 @@ namespace Zipper
             Console.WriteLine();
         }
 
-        private static Task GenerateSequentialFiles(long count, string outputPath)
+        private static Task GenerateSequentialFilesAsync(long count, string outputPath)
         {
             return Task.Run(async () =>
             {

--- a/src/PerformanceBenchmarkRunner.cs
+++ b/src/PerformanceBenchmarkRunner.cs
@@ -241,26 +241,23 @@ namespace Zipper
             Console.WriteLine();
         }
 
-        private static Task GenerateSequentialFilesAsync(long count, string outputPath)
+        private static async Task GenerateSequentialFilesAsync(long count, string outputPath)
         {
-            return Task.Run(async () =>
+            var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+            var zipFilePath = Path.Combine(outputPath, $"{baseFileName}.zip");
+
+            using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
+            using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, true);
+
+            var placeholderContent = PlaceholderFiles.GetContent("pdf");
+
+            for (long i = 1; i <= count; i++)
             {
-                var baseFileName = $"archive_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
-                var zipFilePath = Path.Combine(outputPath, $"{baseFileName}.zip");
-
-                using var archiveStream = new FileStream(zipFilePath, FileMode.Create);
-                using var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, true);
-
-                var placeholderContent = PlaceholderFiles.GetContent("pdf");
-
-                for (long i = 1; i <= count; i++)
-                {
-                    var fileName = $"{i:D8}.pdf";
-                    var entry = archive.CreateEntry(fileName, CompressionLevel.Optimal);
-                    using var entryStream = entry.Open();
-                    await entryStream.WriteAsync(placeholderContent).ConfigureAwait(false);
-                }
-            });
+                var fileName = $"{i:D8}.pdf";
+                var entry = archive.CreateEntry(fileName, CompressionLevel.Optimal);
+                using var entryStream = entry.Open();
+                await entryStream.WriteAsync(placeholderContent).ConfigureAwait(false);
+            }
         }
 
         private static void CleanupDirectory(string path)

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -31,7 +31,7 @@ namespace Zipper
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  DAT: {0}", result.DatFilePath));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  OPT: {0}", result.OptFilePath));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Manifest: {0}", result.ManifestPath));
-            if (result.ZipFilePath != null)
+            if (result.ZipFilePath is not null)
             {
                 Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  ZIP: {0}", result.ZipFilePath));
             }

--- a/src/Profiles/ColumnProfile.cs
+++ b/src/Profiles/ColumnProfile.cs
@@ -74,8 +74,8 @@ public class ColumnProfile
                     Count = kv.Value.Count,
                     Distribution = kv.Value.Distribution,
                     Prefix = kv.Value.Prefix,
-                    Values = kv.Value.Values != null ? new List<string>(kv.Value.Values) : null,
-                    Weights = kv.Value.Weights != null ? new List<int>(kv.Value.Weights) : null,
+                    Values = kv.Value.Values is not null ? new List<string>(kv.Value.Values) : null,
+                    Weights = kv.Value.Weights is not null ? new List<int>(kv.Value.Weights) : null,
                 }, StringComparer.Ordinal),
             Columns = this.Columns.Select(col => new ColumnDefinition
             {
@@ -84,16 +84,16 @@ public class ColumnProfile
                 Required = col.Required,
                 EmptyPercentage = col.EmptyPercentage,
                 MultiValue = col.MultiValue,
-                MultiValueCount = col.MultiValueCount != null ? new RangeConfig { Min = col.MultiValueCount.Min, Max = col.MultiValueCount.Max } : null,
+                MultiValueCount = col.MultiValueCount is not null ? new RangeConfig { Min = col.MultiValueCount.Min, Max = col.MultiValueCount.Max } : null,
                 DataSource = col.DataSource,
-                Range = col.Range != null ? new RangeConfig { Min = col.Range.Min, Max = col.Range.Max } : null,
-                DateRange = col.DateRange != null ? new DateRangeConfig { Min = col.DateRange.Min, Max = col.DateRange.Max } : null,
+                Range = col.Range is not null ? new RangeConfig { Min = col.Range.Min, Max = col.Range.Max } : null,
+                DateRange = col.DateRange is not null ? new DateRangeConfig { Min = col.DateRange.Min, Max = col.DateRange.Max } : null,
                 Distribution = col.Distribution,
                 Format = col.Format,
                 TruePercentage = col.TruePercentage,
-                Weights = col.Weights != null ? new List<int>(col.Weights) : null,
+                Weights = col.Weights is not null ? new List<int>(col.Weights) : null,
                 Generator = col.Generator,
-                GeneratorParams = col.GeneratorParams != null ? new Dictionary<string, object>(col.GeneratorParams, StringComparer.Ordinal) : null,
+                GeneratorParams = col.GeneratorParams is not null ? new Dictionary<string, object>(col.GeneratorParams, StringComparer.Ordinal) : null,
             }).ToList(),
         };
         return cloned;

--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -24,7 +24,7 @@ public static class ColumnProfileLoader
     {
         // Check if it's a built-in profile name
         var builtIn = BuiltInProfiles.GetProfile(nameOrPath);
-        if (builtIn != null)
+        if (builtIn is not null)
         {
             return builtIn;
         }
@@ -51,7 +51,7 @@ public static class ColumnProfileLoader
             var json = File.ReadAllText(filePath);
             var profile = JsonSerializer.Deserialize<ColumnProfile>(json, ProfileSerializerOptions);
 
-            if (profile == null)
+            if (profile is null)
             {
                 throw new InvalidOperationException($"Failed to parse column profile from '{filePath}'.");
             }
@@ -90,12 +90,12 @@ public static class ColumnProfileLoader
         }
 
         // Null guards
-        if (profile.Columns == null || profile.Columns.Count == 0)
+        if (profile.Columns is null || profile.Columns.Count is 0)
         {
             throw new InvalidOperationException("Column profile must have at least one column.");
         }
 
-        if (profile.DataSources == null)
+        if (profile.DataSources is null)
         {
             throw new InvalidOperationException("Column profile must have a DataSources dictionary (can be empty).");
         }
@@ -146,7 +146,7 @@ public static class ColumnProfileLoader
         }
 
         // Validate date ranges
-        foreach (var column in profile.Columns.Where(c => c.DateRange != null))
+        foreach (var column in profile.Columns.Where(c => c.DateRange is not null))
         {
             if (!DateTime.TryParse(column.DateRange!.Min, CultureInfo.InvariantCulture, DateTimeStyles.None, out var minDate))
             {
@@ -185,9 +185,9 @@ public static class ColumnProfileLoader
         // Validate data source weights
         foreach (var (name, cfg) in profile.DataSources)
         {
-            if (cfg.Weights != null && cfg.Weights.Count > 0)
+            if (cfg.Weights is not null && cfg.Weights.Count > 0)
             {
-                var valCount = (cfg.Values != null && cfg.Values.Count > 0) ? cfg.Values.Count : cfg.Count;
+                var valCount = (cfg.Values is not null && cfg.Values.Count > 0) ? cfg.Values.Count : cfg.Count;
                 if (cfg.Weights.Count > valCount)
                 {
                     throw new InvalidOperationException(

--- a/src/Profiles/DataGenerator.cs
+++ b/src/Profiles/DataGenerator.cs
@@ -45,7 +45,7 @@ internal class DataGenerator
             foreach (var col in this.profile.Columns)
             {
                 col.EmptyPercentage = emptyPercentageOverride.Value;
-                if (emptyPercentageOverride.Value == 0 && col.MultiValueCount != null && col.MultiValueCount.Min == 0)
+                if (emptyPercentageOverride.Value is 0 && col.MultiValueCount is not null && col.MultiValueCount.Min is 0)
                 {
                     col.MultiValueCount = new RangeConfig { Min = 1, Max = Math.Max(1, col.MultiValueCount.Max) };
                 }

--- a/src/Profiles/Generation/CodedGenerator.cs
+++ b/src/Profiles/Generation/CodedGenerator.cs
@@ -49,7 +49,7 @@ internal sealed class CodedGenerator : IColumnValueGenerator
 
     private string PickValue(ColumnGenerationContext context)
     {
-        if (this.distributionIndices != null)
+        if (this.distributionIndices is not null)
         {
             var idx = this.distributionIndices[context.DocumentIndex % this.distributionIndices.Length];
             return this.values[idx % this.values.Length];

--- a/src/Profiles/Generation/LongTextGenerator.cs
+++ b/src/Profiles/Generation/LongTextGenerator.cs
@@ -11,7 +11,7 @@ internal sealed class LongTextGenerator : IColumnValueGenerator
         this.generatorName = col.Generator;
         this.minParagraphs = 1;
         this.maxParagraphs = 3;
-        if (col.GeneratorParams != null)
+        if (col.GeneratorParams is not null)
         {
             if (col.GeneratorParams.TryGetValue("min", out var minObj))
             {

--- a/src/Profiles/Generation/TextGenerator.cs
+++ b/src/Profiles/Generation/TextGenerator.cs
@@ -32,9 +32,9 @@ internal sealed class TextGenerator : IColumnValueGenerator
             return Path.GetExtension(context.FileData?.WorkItem.FilePathInZip ?? string.Empty).TrimStart('.');
         }
 
-        if (this.dataSourceValues != null)
+        if (this.dataSourceValues is not null)
         {
-            if (this.distributionIndices != null)
+            if (this.distributionIndices is not null)
             {
                 var idx = this.distributionIndices[context.DocumentIndex % this.distributionIndices.Length];
                 return this.dataSourceValues[idx % this.dataSourceValues.Length];

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -21,7 +21,7 @@ namespace Zipper
             {
                 try
                 {
-                    await PerformanceBenchmarkRunner.RunBenchmarks().ConfigureAwait(false);
+                    await PerformanceBenchmarkRunner.RunBenchmarksAsync().ConfigureAwait(false);
                     return 0;
                 }
                 catch (Exception ex)
@@ -38,7 +38,7 @@ namespace Zipper
             }
 
             var request = Cli.Pipeline.Build(args);
-            if (request == null)
+            if (request is null)
             {
                 return 1;
             }

--- a/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
+++ b/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
@@ -111,7 +111,7 @@ public sealed class FgrFlatAccessAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
     {
-        if (context == null)
+        if (context is null)
         {
             throw new ArgumentNullException(nameof(context));
         }

--- a/src/Zipper.Tests/BuildPropsTests.cs
+++ b/src/Zipper.Tests/BuildPropsTests.cs
@@ -146,7 +146,7 @@ public class BuildPropsTests
         var doc = LoadBuildProps();
         var packageReferences = GetPropertyElements(doc, "PackageReference")
             .Select(e => e.Attribute("Include")?.Value)
-            .Where(v => v != null)
+            .Where(v => v is not null)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         Assert.Contains("Roslynator.Analyzers", packageReferences);

--- a/src/Zipper.Tests/ChaosEngineTests.cs
+++ b/src/Zipper.Tests/ChaosEngineTests.cs
@@ -192,7 +192,7 @@ namespace Zipper
 
                 engine.Intercept(i, "Value1\u0014Value2", $"DOC{i:D8}");
                 var bytes = engine.GetEncodingAnomaly(i, i + 1, Encoding.UTF8);
-                if (bytes != null)
+                if (bytes is not null)
                 {
                     Assert.True(bytes.Length > 0);
                     gotAnomaly = true;

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -40,7 +40,7 @@ namespace Zipper.Tests
             foreach (var flag in flags)
             {
                 var result = CliParser.Parse(new[] { flag });
-                Assert.True(result == null, $"Expected null when {flag} is missing a value");
+                Assert.True(result is null, $"Expected null when {flag} is missing a value");
             }
         }
 

--- a/src/Zipper.Tests/Emails/EmailFactoryTests.cs
+++ b/src/Zipper.Tests/Emails/EmailFactoryTests.cs
@@ -113,7 +113,7 @@ namespace Zipper
             for (int i = 0; i < n; i++)
             {
                 var t = EmailFactory.Create(i, i, category, rng);
-                if (t.Cc != null)
+                if (t.Cc is not null)
                 {
                     withCc++;
                 }
@@ -150,7 +150,7 @@ namespace Zipper
             for (int i = 0; i < n; i++)
             {
                 var t = EmailFactory.Create(i, i, category, rng);
-                if (t.ReplyTo != null)
+                if (t.ReplyTo is not null)
                 {
                     withReplyTo++;
                 }

--- a/src/Zipper.Tests/InMemorySink.cs
+++ b/src/Zipper.Tests/InMemorySink.cs
@@ -18,7 +18,7 @@ internal class InMemorySink : IArchiveSink
     {
         try
         {
-            if (IsFaulted && FaultException != null)
+            if (IsFaulted && FaultException is not null)
             {
                 throw FaultException;
             }

--- a/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
+++ b/src/Zipper.Tests/PerformanceBenchmarkRunnerTests.cs
@@ -7,7 +7,7 @@ public class PerformanceBenchmarkRunnerTests
     [Fact]
     public async Task RunBenchmarks_CompletesWithoutThrowing()
     {
-        var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarks());
+        var exception = await Record.ExceptionAsync(() => PerformanceBenchmarkRunner.RunBenchmarksAsync());
         Assert.Null(exception);
     }
 }


### PR DESCRIPTION
Closes #541. Enabled Phase 1 rules to error and Phase 2 rules to warning. Fixed all arising MA0141, MA0142 and MA0137 violations. Suppressed MA0137 for tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark execution now uses an updated async entry point.

* **Refactor**
  * Modernized many null-checks to use current C# pattern-matching syntax.
  * Adjusted startup flow to call the renamed benchmark runner.

* **Chores**
  * Tightened analyzer rule settings, including clearer error/warning levels and test-specific suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->