### PR TITLE
Extract path resolution from StandardModeValidator into RequestBuilder

### DIFF
--- a/src/Cli/CliValidator.cs
+++ b/src/Cli/CliValidator.cs
@@ -40,11 +40,6 @@ public static class CliValidator
             return false;
         }
 
-        if (parsed.OutputDirectory is null)
-        {
-            Console.Error.WriteLine("Error: --output-path is required or was invalid.");
-            return false;
-        }
 
         return true;
     }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -13,9 +13,15 @@ public static class RequestBuilder
         ["GB"] = 1024 * 1024 * 1024,
     };
 
-    public static FileGenerationRequest Build(ParsedArguments parsed)
+    public static FileGenerationRequest? Build(ParsedArguments parsed)
     {
         ArgumentNullException.ThrowIfNull(parsed);
+
+        var resolved = PathValidator.ResolveSecurePath(
+            parsed.OutputPathStr!,
+            Directory.GetCurrentDirectory());
+        if (resolved is null)
+            return null;
 
         var encoding = GetEncodingFromName(parsed.Encoding ?? "UTF-8");
 
@@ -112,7 +118,7 @@ public static class RequestBuilder
         {
             Output = new OutputConfig
             {
-                OutputPath = parsed.OutputDirectory!.FullName,
+                OutputPath = resolved.FullName,
                 FileCount = parsed.Count!.Value,
                 FileType = (parsed.FileType ?? "pdf").ToLowerInvariant(),
                 Folders = parsed.Folders,

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -18,7 +18,7 @@ public static class RequestBuilder
         ArgumentNullException.ThrowIfNull(parsed);
 
         var resolved = PathValidator.ResolveSecurePath(
-            parsed.OutputPathStr!,
+            parsed.OutputPathStr,
             Directory.GetCurrentDirectory());
         if (resolved is null)
             return null;

--- a/src/Cli/Validation/StandardModeValidator.cs
+++ b/src/Cli/Validation/StandardModeValidator.cs
@@ -4,9 +4,10 @@ internal static class StandardModeValidator
 {
     public static bool Validate(ParsedArguments parsed)
     {
-        if (parsed.OutputDirectory is null && !string.IsNullOrWhiteSpace(parsed.OutputPathStr))
+        if (string.IsNullOrWhiteSpace(parsed.OutputPathStr))
         {
-            parsed.OutputDirectory = PathValidator.ValidateAndCreateDirectory(parsed.OutputPathStr, Directory.GetCurrentDirectory());
+            Console.Error.WriteLine("Error: Output path is required.");
+            return false;
         }
 
         if (!string.IsNullOrEmpty(parsed.FileType) && !FileGeneratorFactory.IsKnownType(parsed.FileType))

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -12,7 +12,7 @@ namespace Zipper
         /// <param name="path">The path to validate and create DirectoryInfo from.</param>
         /// <param name="baseDirectory">The allowed base directory. Defaults to current directory if null.</param>
         /// <returns>Validated DirectoryInfo if safe, null if path is invalid.</returns>
-        public static DirectoryInfo? ValidateAndCreateDirectory(string path, string? baseDirectory = null)
+        public static DirectoryInfo? ResolveSecurePath(string path, string? baseDirectory = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -12,7 +12,7 @@ namespace Zipper
         /// <param name="path">The path to validate and create DirectoryInfo from.</param>
         /// <param name="baseDirectory">The allowed base directory. Defaults to current directory if null.</param>
         /// <returns>Validated DirectoryInfo if safe, null if path is invalid.</returns>
-        public static DirectoryInfo? ResolveSecurePath(string path, string? baseDirectory = null)
+        public static DirectoryInfo? ResolveSecurePath(string? path, string? baseDirectory = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -226,9 +226,11 @@ namespace Zipper.Tests
             var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", "../escape" });
             Assert.NotNull(result);
 
-            // Validation must fail (error path) so the caller exits with a non-zero code.
+            // Validation will pass because it's a structural check, but Build will reject it
             var isValid = CliValidator.Validate(result!);
-            Assert.False(isValid);
+            Assert.True(isValid);
+            var buildResult = RequestBuilder.Build(result!);
+            Assert.Null(buildResult);
         }
 
         /// <summary>
@@ -248,7 +250,9 @@ namespace Zipper.Tests
 
                 var isValid = CliValidator.Validate(result!);
                 Assert.True(isValid);
-                Assert.NotNull(result!.OutputDirectory);
+
+                var buildResult = RequestBuilder.Build(result!);
+                Assert.NotNull(buildResult);
             }
             finally
             {

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -157,6 +157,20 @@ namespace Zipper
         }
 
         [Fact]
+        public void ValidateAndParseArguments_WithInsecureOutputPath_ShouldReturnNull()
+        {
+            // Arrange
+            var insecurePath = OperatingSystem.IsWindows() ? "C:\\Windows\\System32" : "/etc";
+            var args = new[] { "--type", "pdf", "--count", "100", "--output-path", insecurePath };
+
+            // Act
+            var result = Cli.Pipeline.Build(args);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
         public void ValidateAndParseArguments_WithInvalidFoldersRange_ShouldReturnNull()
         {
             // Arrange

--- a/src/Zipper.Tests/CliValidatorTests.cs
+++ b/src/Zipper.Tests/CliValidatorTests.cs
@@ -12,7 +12,7 @@ namespace Zipper.Tests
             {
                 FileType = "pdf",
                 Count = 10,
-                OutputDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()),
+                OutputPathStr = Directory.GetCurrentDirectory(),
             };
         }
 
@@ -88,10 +88,10 @@ namespace Zipper.Tests
         }
 
         [Fact]
-        public void Validate_NullOutputDirectory_ReturnsFalse()
+        public void Validate_NullOutputPathStr_ReturnsFalse()
         {
             var args = CreateValidArgs();
-            args.OutputDirectory = null;
+            args.OutputPathStr = null;
             Assert.False(CliValidator.Validate(args));
         }
 

--- a/src/Zipper.Tests/PathValidatorTests.cs
+++ b/src/Zipper.Tests/PathValidatorTests.cs
@@ -6,13 +6,13 @@ namespace Zipper
     public class PathValidatorTests
     {
         [Fact]
-        public void ValidateAndCreateDirectory_ValidPath_ReturnsDirectoryInfo()
+        public void ResolveSecurePath_ValidPath_ReturnsDirectoryInfo()
         {
             // Arrange
             string validPath = Directory.GetCurrentDirectory();
 
             // Act
-            var result = PathValidator.ValidateAndCreateDirectory(validPath);
+            var result = PathValidator.ResolveSecurePath(validPath);
 
             // Assert
             Assert.NotNull(result);
@@ -20,16 +20,16 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_NullOrEmptyPath_ReturnsNull()
+        public void ResolveSecurePath_NullOrEmptyPath_ReturnsNull()
         {
             // Arrange & Act & Assert
-            Assert.Null(PathValidator.ValidateAndCreateDirectory(null!));
-            Assert.Null(PathValidator.ValidateAndCreateDirectory(string.Empty));
-            Assert.Null(PathValidator.ValidateAndCreateDirectory("   "));
+            Assert.Null(PathValidator.ResolveSecurePath(null!));
+            Assert.Null(PathValidator.ResolveSecurePath(string.Empty));
+            Assert.Null(PathValidator.ResolveSecurePath("   "));
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_PathWithTraversal_ReturnsNull()
+        public void ResolveSecurePath_PathWithTraversal_ReturnsNull()
         {
             // Arrange
             string baseDir = Directory.GetCurrentDirectory();
@@ -44,13 +44,13 @@ namespace Zipper
             // Act & Assert
             foreach (string path in traversalPaths)
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                var result = PathValidator.ResolveSecurePath(path, baseDir);
                 Assert.Null(result); // Traversal escaping base directory should be blocked
             }
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_RelativePathWithTraversal_ReturnsNull()
+        public void ResolveSecurePath_RelativePathWithTraversal_ReturnsNull()
         {
             // Arrange
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
@@ -68,7 +68,7 @@ namespace Zipper
                 // Act & Assert
                 foreach (string path in relativePaths)
                 {
-                    var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                    var result = PathValidator.ResolveSecurePath(path, baseDir);
                     Assert.Null(result);
                 }
             }
@@ -79,7 +79,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_MixedSlashesWithTraversal_ReturnsNull()
+        public void ResolveSecurePath_MixedSlashesWithTraversal_ReturnsNull()
         {
             // Arrange
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
@@ -97,7 +97,7 @@ namespace Zipper
                 // Act & Assert
                 foreach (string path in mixedPaths)
                 {
-                    var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                    var result = PathValidator.ResolveSecurePath(path, baseDir);
                     Assert.Null(result);
                 }
             }
@@ -108,7 +108,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_DotPaths_Valid()
+        public void ResolveSecurePath_DotPaths_Valid()
         {
             // Arrange - These are safe paths (no traversal)
             string[] dotPaths =
@@ -123,7 +123,7 @@ namespace Zipper
             // Act & Assert
             foreach (string path in dotPaths)
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path);
+                var result = PathValidator.ResolveSecurePath(path);
                 Assert.NotNull(result); // Dot paths without traversal are valid
             }
         }
@@ -162,7 +162,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithInvalidCharactersInFileName_HandlesGracefully()
+        public void ResolveSecurePath_WithInvalidCharactersInFileName_HandlesGracefully()
         {
             // Arrange - Test that PathValidator handles various edge cases without crashing
             // PathValidator.GetInvalidFileNameChars() returns different results on different platforms
@@ -176,26 +176,26 @@ namespace Zipper
             // Act & Assert - Should not throw exceptions, returns null or DirectoryInfo depending on platform
             foreach (string path in edgeCasePaths)
             {
-                var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(path));
+                var exception = Record.Exception(() => PathValidator.ResolveSecurePath(path));
                 Assert.Null(exception);
             }
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithPathTooLong_DoesNotThrow()
+        public void ResolveSecurePath_WithPathTooLong_DoesNotThrow()
         {
             // Arrange - Create a path longer than max path length
             string longPath = Path.Combine(Directory.GetCurrentDirectory(), new string('a', 300));
 
             // Act
-            var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(longPath));
+            var exception = Record.Exception(() => PathValidator.ResolveSecurePath(longPath));
 
             // Assert
             Assert.Null(exception);
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithComplexTraversalAttempts_ReturnsNull()
+        public void ResolveSecurePath_WithComplexTraversalAttempts_ReturnsNull()
         {
             // Arrange - Complex traversal attack patterns
             string baseDir = Directory.GetCurrentDirectory();
@@ -211,13 +211,13 @@ namespace Zipper
             // Act & Assert
             foreach (string path in complexTraversals)
             {
-                var result = PathValidator.ValidateAndCreateDirectory(path, baseDir);
+                var result = PathValidator.ResolveSecurePath(path, baseDir);
                 Assert.Null(result); // Complex traversal attacks should be blocked
             }
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithVariousExceptionPaths_HandlesGracefully()
+        public void ResolveSecurePath_WithVariousExceptionPaths_HandlesGracefully()
         {
             // Arrange - Paths that might trigger different exceptions
             string[] exceptionPaths =
@@ -232,7 +232,7 @@ namespace Zipper
             // Act & Assert
             foreach (string path in exceptionPaths)
             {
-                var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(path));
+                var exception = Record.Exception(() => PathValidator.ResolveSecurePath(path));
                 Assert.Null(exception);
             }
         }
@@ -254,7 +254,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_CanonicalTraversalAttempt_ReturnsNull()
+        public void ResolveSecurePath_CanonicalTraversalAttempt_ReturnsNull()
         {
             // Arrange
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBase_" + Guid.NewGuid().ToString());
@@ -266,7 +266,7 @@ namespace Zipper
                 string escapePath = Path.Combine(baseDir, "..", "..", "etc", "passwd");
 
                 // Act
-                var result = PathValidator.ValidateAndCreateDirectory(escapePath, baseDir);
+                var result = PathValidator.ResolveSecurePath(escapePath, baseDir);
 
                 // Assert
                 Assert.Null(result); // Canonical path escapes baseDir, should be rejected
@@ -278,29 +278,29 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithUncPath_DoesNotThrow()
+        public void ResolveSecurePath_WithUncPath_DoesNotThrow()
         {
             var baseDir = Directory.GetCurrentDirectory();
             var uncPath = @"\\server\share\folder";
-            var exception = Record.Exception(() => PathValidator.ValidateAndCreateDirectory(uncPath, baseDir));
+            var exception = Record.Exception(() => PathValidator.ResolveSecurePath(uncPath, baseDir));
             Assert.Null(exception);
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithUnicodeCharacters_ReturnsDirectoryInfo()
+        public void ResolveSecurePath_WithUnicodeCharacters_ReturnsDirectoryInfo()
         {
             var tempPath = Directory.GetCurrentDirectory();
             var unicodePath = Path.Combine(tempPath, "über-cool_文件_パス");
-            var result = PathValidator.ValidateAndCreateDirectory(unicodePath);
+            var result = PathValidator.ResolveSecurePath(unicodePath);
             Assert.NotNull(result);
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_WithTrailingSeparator_NormalizesPath()
+        public void ResolveSecurePath_WithTrailingSeparator_NormalizesPath()
         {
             var tempPath = Directory.GetCurrentDirectory().TrimEnd(Path.DirectorySeparatorChar);
             var pathWithTrailing = tempPath + Path.DirectorySeparatorChar;
-            var result = PathValidator.ValidateAndCreateDirectory(pathWithTrailing);
+            var result = PathValidator.ResolveSecurePath(pathWithTrailing);
             Assert.NotNull(result);
             Assert.Equal(tempPath, result.FullName.TrimEnd(Path.DirectorySeparatorChar));
         }
@@ -333,7 +333,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_SymlinkEscapingBase_ReturnsNull()
+        public void ResolveSecurePath_SymlinkEscapingBase_ReturnsNull()
         {
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseSymlinkTest_" + Guid.NewGuid().ToString());
             string targetDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperTargetSymlinkTest_" + Guid.NewGuid().ToString());
@@ -366,7 +366,7 @@ namespace Zipper
                     return;
                 }
 
-                var result = PathValidator.ValidateAndCreateDirectory(linkPath, baseDir);
+                var result = PathValidator.ResolveSecurePath(linkPath, baseDir);
                 Assert.Null(result);
             }
             finally
@@ -385,7 +385,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_SymlinkWithChildSuffix_EscapingBase_ReturnsNull()
+        public void ResolveSecurePath_SymlinkWithChildSuffix_EscapingBase_ReturnsNull()
         {
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseSuffixTest_" + Guid.NewGuid().ToString());
             string targetDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperTargetSuffixTest_" + Guid.NewGuid().ToString());
@@ -421,7 +421,7 @@ namespace Zipper
                 // The child segment does not exist on disk, so resolution must walk up to the
                 // symlink and rebuild the path from the resolved target plus the child suffix.
                 var escapePath = Path.Combine(linkPath, "child");
-                var result = PathValidator.ValidateAndCreateDirectory(escapePath, baseDir);
+                var result = PathValidator.ResolveSecurePath(escapePath, baseDir);
                 Assert.Null(result);
             }
             finally
@@ -432,7 +432,7 @@ namespace Zipper
         }
 
         [Fact]
-        public void ValidateAndCreateDirectory_SymlinkWithChildSuffix_InsideBase_ReturnsDirectoryInfo()
+        public void ResolveSecurePath_SymlinkWithChildSuffix_InsideBase_ReturnsDirectoryInfo()
         {
             string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "ZipperBaseInsideTest_" + Guid.NewGuid().ToString());
             string targetDir = Path.Combine(baseDir, "real");
@@ -465,7 +465,7 @@ namespace Zipper
                 }
 
                 var insidePath = Path.Combine(linkPath, "child");
-                var result = PathValidator.ValidateAndCreateDirectory(insidePath, baseDir);
+                var result = PathValidator.ResolveSecurePath(insidePath, baseDir);
 
                 Assert.NotNull(result);
                 var comparison = OperatingSystem.IsWindows()

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -12,7 +12,7 @@ namespace Zipper.Tests
             {
                 FileType = "pdf",
                 Count = 100,
-                OutputDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()),
+                OutputPathStr = Directory.GetCurrentDirectory(),
             };
         }
 
@@ -23,22 +23,45 @@ namespace Zipper.Tests
             var result = RequestBuilder.Build(parsed);
 
             Assert.NotNull(result);
-            Assert.Equal(Directory.GetCurrentDirectory(), result.Output.OutputPath);
-            Assert.Equal(100, result.Output.FileCount);
-            Assert.Equal("pdf", result.Output.FileType);
-            Assert.Equal(1, result.Output.Folders);
-            Assert.Equal(DistributionType.Proportional, result.LoadFile.Distribution);
-            Assert.False(result.Metadata.WithMetadata);
-            Assert.False(result.Output.WithText);
-            Assert.False(result.Output.IncludeLoadFile);
-            Assert.Equal(0, result.LoadFile.AttachmentRate);
-            Assert.Null(result.Bates);
+            Assert.Equal(Directory.GetCurrentDirectory(), result!.Output.OutputPath);
+            Assert.Equal(100, result!.Output.FileCount);
+            Assert.Equal("pdf", result!.Output.FileType);
+            Assert.Equal(1, result!.Output.Folders);
+            Assert.Equal(DistributionType.Proportional, result!.LoadFile.Distribution);
+            Assert.False(result!.Metadata.WithMetadata);
+            Assert.False(result!.Output.WithText);
+            Assert.False(result!.Output.IncludeLoadFile);
+            Assert.Equal(0, result!.LoadFile.AttachmentRate);
+            Assert.Null(result!.Bates);
         }
 
         [Fact]
         public void Build_NullArg_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => RequestBuilder.Build(null!));
+        }
+
+        [Fact]
+        public void Build_WithValidPath_ResolvesDirectory()
+        {
+            var parsed = CreateParsedArgs();
+            parsed.OutputPathStr = Directory.GetCurrentDirectory();
+
+            var result = RequestBuilder.Build(parsed);
+
+            Assert.NotNull(result);
+            Assert.Equal(Directory.GetCurrentDirectory(), result!.Output.OutputPath);
+        }
+
+        [Fact]
+        public void Build_WithInvalidPath_ReturnsNull()
+        {
+            var parsed = CreateParsedArgs();
+            parsed.OutputPathStr = string.Empty; // Invalid path
+
+            var result = RequestBuilder.Build(parsed);
+
+            Assert.Null(result);
         }
 
         [Fact]
@@ -52,9 +75,9 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.True(result.Chaos.ChaosMode);
-            Assert.Equal("5%", result.Chaos.ChaosAmount);
-            Assert.Equal("quotes,columns", result.Chaos.ChaosTypes);
+            Assert.True(result!.Chaos.ChaosMode);
+            Assert.Equal("5%", result!.Chaos.ChaosAmount);
+            Assert.Equal("quotes,columns", result!.Chaos.ChaosTypes);
         }
 
         [Fact]
@@ -67,9 +90,9 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.True(result.LoadfileOnly);
-            Assert.Equal("LF", result.Delimiters.EndOfLine);
-            Assert.Equal(LoadFileFormat.Opt, result.LoadFile.LoadFileFormat);
+            Assert.True(result!.LoadfileOnly);
+            Assert.Equal("LF", result!.Delimiters.EndOfLine);
+            Assert.Equal(LoadFileFormat.Opt, result!.LoadFile.LoadFileFormat);
         }
 
         [Fact]
@@ -81,8 +104,8 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.True(result.Production.ProductionSet);
-            Assert.Equal(1000, result.Production.VolumeSize);
+            Assert.True(result!.Production.ProductionSet);
+            Assert.Equal(1000, result!.Production.VolumeSize);
         }
 
         [Fact]
@@ -95,10 +118,10 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.NotNull(result.Bates);
-            Assert.Equal("CL001", result.Bates.Prefix);
-            Assert.Equal(100, result.Bates.Start);
-            Assert.Equal(6, result.Bates.Digits);
+            Assert.NotNull(result!.Bates);
+            Assert.Equal("CL001", result!.Bates.Prefix);
+            Assert.Equal(100, result!.Bates.Start);
+            Assert.Equal(6, result!.Bates.Digits);
         }
 
         [Fact]
@@ -109,7 +132,7 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.NotNull(result.Metadata.ColumnProfile);
+            Assert.NotNull(result!.Metadata.ColumnProfile);
         }
 
         [Fact]
@@ -120,8 +143,8 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.Equal(",", result.Delimiters.ColumnDelimiter);
-            Assert.Equal("\"", result.Delimiters.QuoteDelimiter);
+            Assert.Equal(",", result!.Delimiters.ColumnDelimiter);
+            Assert.Equal("\"", result!.Delimiters.QuoteDelimiter);
         }
 
         [Fact]
@@ -134,8 +157,8 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.Equal("|", result.Delimiters.ColumnDelimiter);
-            Assert.Equal("\"", result.Delimiters.QuoteDelimiter);
+            Assert.Equal("|", result!.Delimiters.ColumnDelimiter);
+            Assert.Equal("\"", result!.Delimiters.QuoteDelimiter);
         }
 
         [Fact]
@@ -149,7 +172,7 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.Equal("\u0014", result.Delimiters.ColumnDelimiter);
+            Assert.Equal("\u0014", result!.Delimiters.ColumnDelimiter);
         }
 
         [Fact]
@@ -160,10 +183,10 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.NotNull(result.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Dat, result.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Opt, result.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Csv, result.LoadFile.LoadFileFormats);
+            Assert.NotNull(result!.LoadFile.LoadFileFormats);
+            Assert.Contains(LoadFileFormat.Dat, result!.LoadFile.LoadFileFormats);
+            Assert.Contains(LoadFileFormat.Opt, result!.LoadFile.LoadFileFormats);
+            Assert.Contains(LoadFileFormat.Csv, result!.LoadFile.LoadFileFormats);
         }
 
         [Fact]
@@ -175,7 +198,7 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.Equal("WINDOWS-1252", result.LoadFile.Encoding);
+            Assert.Equal("WINDOWS-1252", result!.LoadFile.Encoding);
         }
 
         [Fact]
@@ -186,7 +209,7 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.Equal("UTF-16", result.LoadFile.Encoding);
+            Assert.Equal("UTF-16", result!.LoadFile.Encoding);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output path handling so unsafe or outside-current-directory paths are rejected before file generation starts.
  * Standard CLI validation now requires a valid output path and returns a clear error when it’s missing.
  * Safer path resolution reduces the chance of creating output in unintended locations.

* **Tests**
  * Updated coverage for safe, unsafe, traversal, and symlink-based output paths.
  * Added CLI pipeline tests for insecure output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->