### PR TITLE
Fix: resolve chaos scenario amount before printing

### DIFF
--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -43,25 +43,7 @@ internal static class LoadfileOnlyGenerator
 
                 var emptyRecords = Array.Empty<FileData>();
 
-                if (request.Chaos.ChaosMode && !string.IsNullOrEmpty(request.Chaos.ChaosScenario))
-                {
-                    var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
-                    if (scenario != null)
-                    {
-                        if (string.IsNullOrEmpty(request.Chaos.ChaosAmount))
-                        {
-                            request.Chaos = request.Chaos with { ChaosAmount = scenario.DefaultAmount };
-                        }
 
-                        request.Chaos = request.Chaos with { ChaosTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes };
-
-                        Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine($"  Warning: Chaos scenario '{request.Chaos.ChaosScenario}' not found; falling back to the supplied --chaos-types/--chaos-amount (if any).");
-                    }
-                }
 
                 ChaosEngine? chaosEngine = LoadfileAuditWriter.BuildChaosEngine(request, emptyRecords, format);
 

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -16,6 +16,26 @@ namespace Zipper
 
             if (request.Chaos.ChaosMode)
             {
+                if (!string.IsNullOrEmpty(request.Chaos.ChaosScenario))
+                {
+                    var scenario = ChaosScenarios.GetByName(request.Chaos.ChaosScenario);
+                    if (scenario != null)
+                    {
+                        if (string.IsNullOrEmpty(request.Chaos.ChaosAmount))
+                        {
+                            request.Chaos = request.Chaos with { ChaosAmount = scenario.DefaultAmount };
+                        }
+
+                        request.Chaos = request.Chaos with { ChaosTypes = string.IsNullOrEmpty(scenario.ChaosTypes) ? null : scenario.ChaosTypes };
+
+                        Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Chaos Scenario: {0} ({1})", scenario.Name, scenario.Description));
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"  Warning: Chaos scenario '{request.Chaos.ChaosScenario}' not found; falling back to the supplied --chaos-types/--chaos-amount (if any).");
+                    }
+                }
+
                 Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Chaos Mode: Enabled (amount: {0})", request.Chaos.ChaosAmount ?? "1%"));
                 if (!string.IsNullOrEmpty(request.Chaos.ChaosTypes))
                 {

--- a/src/Zipper.Tests/GenerationModeTests.cs
+++ b/src/Zipper.Tests/GenerationModeTests.cs
@@ -119,4 +119,40 @@ public class GenerationModeTests
             }
         }
     }
+
+    [Fact]
+    public async Task Main_LoadfileOnlyModeWithChaosScenario_PrintsResolvedChaosAmount()
+    {
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        var originalOut = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+
+        try
+        {
+            var args = new[]
+            {
+                "--loadfile-only", "--count", "5", "--output-path", tempDir,
+                "--chaos-mode", "--chaos-scenario", "structured-import-failures", "--seed", "42",
+            };
+            var result = await Program.Main(args);
+
+            Assert.Equal(0, result);
+            var output = sw.ToString();
+
+            // structured-import-failures has a default amount of 3%
+            Assert.Contains("Chaos Mode: Enabled (amount: 3%)", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("Chaos Mode: Enabled (amount: 1%)", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loadfile-only mode now recognizes named chaos scenarios and applies their recommended chaos amount and types automatically.
  * If a scenario has no chaos types, the app now clears that setting instead of keeping a previous value.

* **Bug Fixes**
  * Improved fallback behavior when an unknown chaos scenario is entered, preserving any manually provided chaos settings and showing a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->