### PR TITLE
feat: make mode adapters testable via constructor injection

### DIFF
--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -9,6 +9,7 @@ namespace Zipper
 
         public LoadfileOnlyMode(Func<FileGenerationRequest, CancellationToken, Task<LoadfileOnlyResult>> generate)
         {
+            ArgumentNullException.ThrowIfNull(generate);
             _generate = generate;
         }
 

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -5,6 +5,13 @@ namespace Zipper
     /// </summary>
     internal class LoadfileOnlyMode : IGenerationMode
     {
+        private readonly Func<FileGenerationRequest, CancellationToken, Task<LoadfileOnlyResult>> _generate;
+
+        public LoadfileOnlyMode(Func<FileGenerationRequest, CancellationToken, Task<LoadfileOnlyResult>> generate)
+        {
+            _generate = generate;
+        }
+
         public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("Starting loadfile-only generation...");
@@ -43,7 +50,7 @@ namespace Zipper
                 }
             }
 
-            var result = await LoadfileOnlyGenerator.GenerateAsync(request, cancellationToken).ConfigureAwait(false);
+            var result = await _generate(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Load file: {0}", result.LoadFilePath));

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -5,6 +5,13 @@ namespace Zipper
     /// </summary>
     internal class ProductionSetMode : IGenerationMode
     {
+        private readonly Func<FileGenerationRequest, CancellationToken, Task<ProductionSetResult>> _generate;
+
+        public ProductionSetMode(Func<FileGenerationRequest, CancellationToken, Task<ProductionSetResult>> generate)
+        {
+            _generate = generate;
+        }
+
         public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("Starting production set generation...");
@@ -21,7 +28,7 @@ namespace Zipper
                 Console.WriteLine("  ZIP Output: Enabled");
             }
 
-            var result = await ProductionSetGenerator.GenerateAsync(request, cancellationToken).ConfigureAwait(false);
+            var result = await _generate(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nProduction set complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Production: {0}", result.ProductionPath));

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -9,6 +9,7 @@ namespace Zipper
 
         public ProductionSetMode(Func<FileGenerationRequest, CancellationToken, Task<ProductionSetResult>> generate)
         {
+            ArgumentNullException.ThrowIfNull(generate);
             _generate = generate;
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -71,9 +71,9 @@ namespace Zipper
         {
             return (request.LoadfileOnly, request.Production.ProductionSet) switch
             {
-                (true, _) => new LoadfileOnlyMode(),
-                (_, true) => new ProductionSetMode(),
-                _ => new StandardMode(),
+                (true, _) => new LoadfileOnlyMode((req, ct) => LoadfileOnlyGenerator.GenerateAsync(req, ct)),
+                (_, true) => new ProductionSetMode((req, ct) => ProductionSetGenerator.GenerateAsync(req, ct)),
+                _ => new StandardMode((req, ct) => new ParallelFileGenerator().GenerateFilesAsync(req, ct)),
             };
         }
     }

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -5,6 +5,13 @@ namespace Zipper
     /// </summary>
     internal class StandardMode : IGenerationMode
     {
+        private readonly Func<FileGenerationRequest, CancellationToken, Task<FileGenerationResult>> _generate;
+
+        public StandardMode(Func<FileGenerationRequest, CancellationToken, Task<FileGenerationResult>> generate)
+        {
+            _generate = generate;
+        }
+
         public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Chaos.ChaosMode)
@@ -39,10 +46,7 @@ namespace Zipper
                 Console.WriteLine("  Load File: Will be included in zip archive.");
             }
 
-            // Use parallel file generator for improved performance
-            var generator = new ParallelFileGenerator();
-
-            var result = await generator.GenerateFilesAsync(request, cancellationToken).ConfigureAwait(false);
+            var result = await _generate(request, cancellationToken).ConfigureAwait(false);
 
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "\n\nGeneration complete in {0:F1} seconds.", result.GenerationTime.TotalSeconds));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Archive created: {0}", result.ZipFilePath));

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -9,6 +9,7 @@ namespace Zipper
 
         public StandardMode(Func<FileGenerationRequest, CancellationToken, Task<FileGenerationResult>> generate)
         {
+            ArgumentNullException.ThrowIfNull(generate);
             _generate = generate;
         }
 

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -91,7 +91,7 @@ namespace Zipper
             request.Chaos = request.Chaos with { ChaosMode = true };
             request.LoadfileOnly = false; // ensure we're targeting standard/generation mode
 
-            var mode = new StandardMode();
+            var mode = new StandardMode((req, ct) => new ParallelFileGenerator().GenerateFilesAsync(req, ct));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => mode.RunAsync(request));
         }

--- a/src/Zipper.Tests/GenerationRunnerTests.cs
+++ b/src/Zipper.Tests/GenerationRunnerTests.cs
@@ -91,9 +91,15 @@ namespace Zipper
             request.Chaos = request.Chaos with { ChaosMode = true };
             request.LoadfileOnly = false; // ensure we're targeting standard/generation mode
 
-            var mode = new StandardMode((req, ct) => new ParallelFileGenerator().GenerateFilesAsync(req, ct));
+            var generatorCalled = false;
+            var mode = new StandardMode((req, ct) =>
+            {
+                generatorCalled = true;
+                return Task.FromResult(new FileGenerationResult());
+            });
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => mode.RunAsync(request));
+            Assert.False(generatorCalled);
         }
 
         private static async Task<(int exitCode, string stdout, string stderr)> RunWithCapture(IGenerationMode mode, FileGenerationRequest request, CancellationToken token = default)

--- a/src/Zipper.Tests/ModeAdapterTests.cs
+++ b/src/Zipper.Tests/ModeAdapterTests.cs
@@ -1,11 +1,8 @@
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Zipper.Tests
 {
+    [Collection("ConsoleTests")]
     public class StandardModeTests
     {
         [Fact]
@@ -72,6 +69,7 @@ namespace Zipper.Tests
         }
     }
 
+    [Collection("ConsoleTests")]
     public class LoadfileOnlyModeTests
     {
         [Fact]
@@ -125,6 +123,7 @@ namespace Zipper.Tests
         }
     }
 
+    [Collection("ConsoleTests")]
     public class ProductionSetModeTests
     {
         [Fact]

--- a/src/Zipper.Tests/ModeAdapterTests.cs
+++ b/src/Zipper.Tests/ModeAdapterTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Zipper.Tests
+{
+    public class StandardModeTests
+    {
+        [Fact]
+        public async Task RunAsync_WithValidRequest_LogsConfigAndResult()
+        {
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+
+            try
+            {
+                var mode = new StandardMode((req, ct) => Task.FromResult(new FileGenerationResult
+                {
+                    GenerationTime = TimeSpan.FromSeconds(5),
+                    FilesPerSecond = 100.0,
+                    ZipFilePath = "/out/test.zip",
+                    ActualZipSize = 1024,
+                    ZipSizeVerification = new ZipSizeVerificationResult(true, 0.0)
+                }));
+
+                var request = new FileGenerationRequest
+                {
+                    Output = new Config.OutputConfig
+                    {
+                        FileType = "pdf",
+                        FileCount = 5,
+                        OutputPath = "/out",
+                        Folders = 1
+                    },
+                    LoadFile = new Config.LoadFileConfig
+                    {
+                        Encoding = "utf-8",
+                        Distribution = DistributionType.Proportional
+                    }
+                };
+
+                await mode.RunAsync(request, CancellationToken.None);
+
+                var consoleOutput = output.ToString();
+                Assert.True(consoleOutput.Contains("Starting parallel file generation...", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Generation complete in 5.0 seconds.", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Archive created: /out/test.zip", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Performance: 100.0 files/second", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        [Fact]
+        public async Task RunAsync_WithChaosMode_ThrowsInvalidOperationException()
+        {
+            var mode = new StandardMode((req, ct) => Task.FromResult(new FileGenerationResult()));
+            var request = new FileGenerationRequest
+            {
+                Chaos = new Config.ChaosConfig
+                {
+                    ChaosMode = true
+                }
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => mode.RunAsync(request, CancellationToken.None));
+        }
+    }
+
+    public class LoadfileOnlyModeTests
+    {
+        [Fact]
+        public async Task RunAsync_WithValidRequest_LogsResult()
+        {
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+
+            try
+            {
+                var mode = new LoadfileOnlyMode((req, ct) => Task.FromResult(new LoadfileOnlyResult
+                {
+                    LoadFilePath = "/out/test.dat",
+                    PropertiesFilePath = "/out/test.json",
+                    TotalRecords = 42,
+                    GenerationTime = TimeSpan.FromSeconds(2.5)
+                }));
+
+                var request = new FileGenerationRequest
+                {
+                    LoadFile = new Config.LoadFileConfig
+                    {
+                        LoadFileFormat = LoadFileFormat.Dat,
+                        Encoding = "utf-8"
+                    },
+                    Output = new Config.OutputConfig
+                    {
+                        FileCount = 42,
+                        OutputPath = "/out"
+                    },
+                    Delimiters = new Config.DelimiterConfig
+                    {
+                        EndOfLine = "\r\n"
+                    }
+                };
+
+                await mode.RunAsync(request, CancellationToken.None);
+
+                var consoleOutput = output.ToString();
+                Assert.True(consoleOutput.Contains("Starting loadfile-only generation...", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Generation complete in 2.5 seconds.", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Load file: /out/test.dat", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Properties: /out/test.json", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Records: 42", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+
+    public class ProductionSetModeTests
+    {
+        [Fact]
+        public async Task RunAsync_WithValidRequest_LogsProductionDetails()
+        {
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+
+            try
+            {
+                var mode = new ProductionSetMode((req, ct) => Task.FromResult(new ProductionSetResult
+                {
+                    ProductionPath = "/out/prod",
+                    ZipFilePath = "/out/prod.zip",
+                    DatFilePath = "/out/prod/prod.dat",
+                    OptFilePath = "/out/prod/prod.opt",
+                    ManifestPath = "/out/prod/manifest.txt",
+                    TotalDocuments = 3,
+                    BatesRange = "TST00000001-TST00000003",
+                    VolumeCount = 1,
+                    GenerationTime = TimeSpan.FromSeconds(3.5)
+                }));
+
+                var request = new FileGenerationRequest
+                {
+                    Output = new Config.OutputConfig
+                    {
+                        FileType = "pdf",
+                        FileCount = 3,
+                        OutputPath = "/out"
+                    },
+                    Production = new Config.ProductionConfig
+                    {
+                        VolumeSize = 1000,
+                        ProductionZip = true
+                    },
+                    Bates = new BatesNumberConfig { Prefix = "TST", Start = 1, Digits = 8 }
+                };
+
+                await mode.RunAsync(request, CancellationToken.None);
+
+                var consoleOutput = output.ToString();
+                Assert.True(consoleOutput.Contains("Starting production set generation...", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Production set complete in 3.5 seconds.", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Production: /out/prod", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Documents: 3", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Bates Range: TST00000001-TST00000003", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Volumes: 1", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("DAT: /out/prod/prod.dat", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("OPT: /out/prod/prod.opt", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("Manifest: /out/prod/manifest.txt", StringComparison.Ordinal));
+                Assert.True(consoleOutput.Contains("ZIP: /out/prod.zip", StringComparison.Ordinal));
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/src/Zipper.Tests/ModeAdapterTests.cs
+++ b/src/Zipper.Tests/ModeAdapterTests.cs
@@ -67,6 +67,12 @@ namespace Zipper.Tests
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => mode.RunAsync(request, CancellationToken.None));
         }
+
+        [Fact]
+        public void Constructor_WithNullGenerate_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StandardMode(null!));
+        }
     }
 
     [Collection("ConsoleTests")]
@@ -120,6 +126,12 @@ namespace Zipper.Tests
             {
                 Console.SetOut(originalOut);
             }
+        }
+
+        [Fact]
+        public void Constructor_WithNullGenerate_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new LoadfileOnlyMode(null!));
         }
     }
 
@@ -182,6 +194,12 @@ namespace Zipper.Tests
             {
                 Console.SetOut(originalOut);
             }
+        }
+
+        [Fact]
+        public void Constructor_WithNullGenerate_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ProductionSetMode(null!));
         }
     }
 }


### PR DESCRIPTION
Closes #534

## Release Notes
This pull request refactors the three generation mode adapters (`StandardMode`, `LoadfileOnlyMode`, `ProductionSetMode`) to accept their generator dependencies via constructor injection (delegates), allowing them to be fully unit tested. The CLI orchestration has been updated accordingly, and new unit tests have been added to verify that config and result output are correctly written to the console in each mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how generation work is wired into the app, making mode selection more flexible without changing the user-facing flow.

* **Tests**
  * Added coverage for standard, loadfile-only, and production-set runs.
  * Verified expected console output, successful completion details, and error handling when chaos mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->