### PR TITLE
feat: unify LoadFileFormat singular/plural duality into single Formats property

### DIFF
--- a/.agents/skills/autoreview/OPERATIONS.local.md
+++ b/.agents/skills/autoreview/OPERATIONS.local.md
@@ -45,3 +45,10 @@
 - **lessons**: none
 - **suppressions**: none
 
+### 2026-06-29 antigravity:branch:issue-535
+
+- **findings**: 2 ACTION, 7 INFO (across 4 specialists). Empty formats list index out of range checks, test clone isolation, stale analyzer check.
+- **outcome**: accepted all findings (fixed RequestBuilder fallback, added defensive checks to index-0 access sites, corrected clone test isolation, and updated FgrFlatAccessAnalyzer to guard Formats). All 1155 tests passed.
+- **telemetry**: host=antigravity mode=branch specialists=4 bundle=21736c
+- **lessons**: The clone isolation test was using re-assignment which masked reference equality bugs. Asserting NotSame immediately after cloning ensures list isolation is verified properly.
+- **suppressions**: none

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -114,6 +114,10 @@ public static class RequestBuilder
             ? parsed.Encoding.ToUpperInvariant()
             : "UTF-8";
 
+        var formats = (multiFormats is not null && multiFormats.Count > 0)
+            ? multiFormats
+            : new List<LoadFileFormat> { GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat };
+
         return new FileGenerationRequest
         {
             Output = new OutputConfig
@@ -139,8 +143,7 @@ public static class RequestBuilder
             },
             LoadFile = new LoadFileConfig
             {
-                LoadFileFormat = GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat,
-                LoadFileFormats = multiFormats,
+                Formats = formats,
                 Encoding = encodingName,
                 IsEncodingExplicit = parsed.IsEncodingExplicit,
                 Distribution = GetDistributionFromName(parsed.Distribution ?? "proportional") ?? DistributionType.Proportional,

--- a/src/Config/LoadFileConfig.cs
+++ b/src/Config/LoadFileConfig.cs
@@ -2,9 +2,7 @@ namespace Zipper.Config;
 
 public record LoadFileConfig
 {
-    public LoadFileFormat LoadFileFormat { get; init; } = LoadFileFormat.Dat;
-
-    public List<LoadFileFormat>? LoadFileFormats { get; init; }
+    public IReadOnlyList<LoadFileFormat> Formats { get; init; } = [LoadFileFormat.Dat];
 
     public string Encoding { get; init; } = "UTF-8";
 

--- a/src/FileGenerationRequest.cs
+++ b/src/FileGenerationRequest.cs
@@ -30,9 +30,7 @@ namespace Zipper
                 Metadata = this.Metadata,
                 LoadFile = this.LoadFile with
                 {
-                    LoadFileFormats = this.LoadFile.LoadFileFormats is null
-                        ? null
-                        : new List<LoadFileFormat>(this.LoadFile.LoadFileFormats),
+                    Formats = new List<LoadFileFormat>(this.LoadFile.Formats),
                 },
                 Delimiters = this.Delimiters,
                 Bates = this.Bates,

--- a/src/LoadfileAuditWriter.cs
+++ b/src/LoadfileAuditWriter.cs
@@ -118,7 +118,7 @@ internal static class LoadfileAuditWriter
         IReadOnlyList<ChaosAnomaly>? anomalies = null,
         LoadFileFormat? format = null)
     {
-        var activeFormat = format ?? request.LoadFile.LoadFileFormat;
+        var activeFormat = format ?? (request.LoadFile.Formats.Count > 0 ? request.LoadFile.Formats[0] : LoadFileFormat.Dat);
         var (totalRecords, _) = ComputeRecordCounts(request, composedRecords, activeFormat);
         var formatName = activeFormat == LoadFileFormat.Opt
             ? "OPT (Image)"

--- a/src/LoadfileOnlyGenerator.cs
+++ b/src/LoadfileOnlyGenerator.cs
@@ -24,9 +24,9 @@ internal static class LoadfileOnlyGenerator
 
         var baseFileName = $"loadfile_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
 
-        var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
-            ? request.LoadFile.LoadFileFormats
-            : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
+        var formatsToGenerate = (request.LoadFile.Formats is not null && request.LoadFile.Formats.Count > 0)
+            ? request.LoadFile.Formats
+            : new List<LoadFileFormat> { LoadFileFormat.Dat };
 
         string primaryLoadFilePath = string.Empty;
         string primaryPropertiesPath = string.Empty;
@@ -65,7 +65,7 @@ internal static class LoadfileOnlyGenerator
                     format).ConfigureAwait(false);
                 generatedFiles.Add(propertiesPath);
 
-                if (format == request.LoadFile.LoadFileFormat || string.IsNullOrEmpty(primaryLoadFilePath))
+                if (format == formatsToGenerate[0] || string.IsNullOrEmpty(primaryLoadFilePath))
                 {
                     primaryLoadFilePath = loadFilePath;
                     primaryPropertiesPath = propertiesPath;

--- a/src/LoadfileOnlyMode.cs
+++ b/src/LoadfileOnlyMode.cs
@@ -16,7 +16,7 @@ namespace Zipper
         public async Task RunAsync(FileGenerationRequest request, CancellationToken cancellationToken = default)
         {
             Console.WriteLine("Starting loadfile-only generation...");
-            Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Format: {0}", request.LoadFile.LoadFileFormat));
+            Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Format: {0}", string.Join(", ", request.LoadFile.Formats)));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Count: {0:N0}", request.Output.FileCount));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Output Path: {0}", request.Output.OutputPath));
             Console.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, "  Encoding: {0}", request.LoadFile.Encoding));

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -50,9 +50,9 @@ internal class ZipArchiveSink : IArchiveSink
             CleanupOperations(outOfOrderBuffer, fileDataReader);
         }
 
-        var formatsToGenerate = request.LoadFile.LoadFileFormats?.Count > 0
-            ? request.LoadFile.LoadFileFormats
-            : new List<LoadFileFormat> { request.LoadFile.LoadFileFormat };
+        var formatsToGenerate = (request.LoadFile.Formats is not null && request.LoadFile.Formats.Count > 0)
+            ? request.LoadFile.Formats
+            : new List<LoadFileFormat> { LoadFileFormat.Dat };
 
         string actualLoadFilePath = loadFilePath;
         var baseFileName = Path.GetFileNameWithoutExtension(loadFileName);

--- a/src/Zipper.Analyzers.Tests/FgrFlatAccessAnalyzerTests.cs
+++ b/src/Zipper.Analyzers.Tests/FgrFlatAccessAnalyzerTests.cs
@@ -10,7 +10,7 @@ namespace Zipper.Analyzers.Tests;
 
 /// <summary>
 /// Fixture-driven tests for <see cref="FgrFlatAccessAnalyzer"/>.
-/// Verifies that all 35 flat pass-through properties on FileGenerationRequest
+/// Verifies that all 36 flat pass-through properties on FileGenerationRequest
 /// are detected, sub-config accesses are not reported, and accesses inside
 /// FileGenerationRequest.cs itself are suppressed.
 /// </summary>
@@ -48,12 +48,12 @@ class T
             .Select(name => new object[] { name });
 
     /// <summary>
-    /// Exactly 35 flat pass-through property names are tracked.
+    /// Exactly 36 flat pass-through property names are tracked.
     /// </summary>
     [Fact]
-    public void FlatPropertyNames_Contains35Names()
+    public void FlatPropertyNames_Contains36Names()
     {
-        Assert.Equal(35, FgrFlatAccessAnalyzer.FlatPropertyNames.Count);
+        Assert.Equal(36, FgrFlatAccessAnalyzer.FlatPropertyNames.Count);
     }
 
     /// <summary>

--- a/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
+++ b/src/Zipper.Analyzers/FgrFlatAccessAnalyzer.cs
@@ -67,9 +67,10 @@ public sealed class FgrFlatAccessAnalyzer : DiagnosticAnalyzer
             ["CustodianCountOverride"] = MetadataSub,
             ["WithFamilies"] = MetadataSub,
 
-            // LoadFile sub-config (5)
+            // LoadFile sub-config (6)
             ["LoadFileFormat"] = LoadFileSub,
             ["LoadFileFormats"] = LoadFileSub,
+            ["Formats"] = LoadFileSub,
             ["Encoding"] = LoadFileSub,
             ["Distribution"] = LoadFileSub,
             ["AttachmentRate"] = LoadFileSub,

--- a/src/Zipper.Tests/CancellationTests.cs
+++ b/src/Zipper.Tests/CancellationTests.cs
@@ -258,7 +258,7 @@ public class CancellationTests
             },
             LoadFile = new LoadFileConfig
             {
-                LoadFileFormat = LoadFileFormat.Dat,
+                Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
                 Encoding = "UTF-8",
             },
             Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
@@ -276,7 +276,7 @@ public class CancellationTests
             },
             LoadFile = new LoadFileConfig
             {
-                LoadFileFormat = LoadFileFormat.Dat,
+                Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
                 Encoding = "UTF-8",
             },
             Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },

--- a/src/Zipper.Tests/CliPipelineTests.cs
+++ b/src/Zipper.Tests/CliPipelineTests.cs
@@ -418,7 +418,7 @@ namespace Zipper
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(expected, result.LoadFile.LoadFileFormat);
+            Assert.Equal(expected, result.LoadFile.Formats[0]);
         }
 
         [Fact]

--- a/src/Zipper.Tests/FieldNamingTests.cs
+++ b/src/Zipper.Tests/FieldNamingTests.cs
@@ -49,7 +49,7 @@ public class FieldNamingTests : IDisposable
             },
             LoadFile = new LoadFileConfig
             {
-                LoadFileFormat = LoadFileFormat.Dat,
+                Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
                 Encoding = "UTF-8"
             },
             Metadata = new MetadataConfig

--- a/src/Zipper.Tests/FileGenerationRequestTests.cs
+++ b/src/Zipper.Tests/FileGenerationRequestTests.cs
@@ -169,27 +169,21 @@ namespace Zipper.Tests
         }
 
         [Fact]
-        public void Clone_LoadFileFormatsList_IsIsolatedFromOriginal()
+        public void Clone_FormatsList_IsIsolatedFromOriginal()
         {
             var original = new FileGenerationRequest
             {
-                LoadFile = new LoadFileConfig { LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat } },
+                LoadFile = new LoadFileConfig { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat } },
             };
             var clone = original.Clone();
 
-            clone.LoadFile.LoadFileFormats!.Add(LoadFileFormat.Csv);
+            Assert.NotSame(original.LoadFile.Formats, clone.LoadFile.Formats);
 
-            Assert.Single(original.LoadFile.LoadFileFormats!);
-            Assert.Equal(2, clone.LoadFile.LoadFileFormats!.Count);
-            Assert.NotSame(original.LoadFile.LoadFileFormats, clone.LoadFile.LoadFileFormats);
-        }
+            var newFormats = new List<LoadFileFormat>(clone.LoadFile.Formats) { LoadFileFormat.Csv };
+            clone.LoadFile = clone.LoadFile with { Formats = newFormats };
 
-        [Fact]
-        public void Clone_NullLoadFileFormats_RemainsNull()
-        {
-            var original = new FileGenerationRequest();
-            var clone = original.Clone();
-            Assert.Null(clone.LoadFile.LoadFileFormats);
+            Assert.Single(original.LoadFile.Formats);
+            Assert.Equal(2, clone.LoadFile.Formats.Count);
         }
     }
 }

--- a/src/Zipper.Tests/LoadFiles/TextOutputPolicyTests.cs
+++ b/src/Zipper.Tests/LoadFiles/TextOutputPolicyTests.cs
@@ -13,7 +13,7 @@ public class TextOutputPolicyTests
         {
             LoadFile = new LoadFileConfig
             {
-                LoadFileFormat = format,
+                Formats = new List<LoadFileFormat> { format },
                 Encoding = encoding ?? "UTF-8",
                 IsEncodingExplicit = isExplicit
             },

--- a/src/Zipper.Tests/LoadfileAuditWriterTests.cs
+++ b/src/Zipper.Tests/LoadfileAuditWriterTests.cs
@@ -12,7 +12,7 @@ public class LoadfileAuditWriterTests
         var request = new FileGenerationRequest();
         request.LoadFile = request.LoadFile with
         {
-            LoadFileFormat = LoadFileFormat.Opt,
+            Formats = new List<LoadFileFormat> { LoadFileFormat.Opt },
             Encoding = "UTF-8",
             IsEncodingExplicit = false
         };
@@ -53,7 +53,7 @@ public class LoadfileAuditWriterTests
         var request = new FileGenerationRequest();
         request.LoadFile = request.LoadFile with
         {
-            LoadFileFormat = LoadFileFormat.Dat,
+            Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
             Encoding = "UTF-8",
             IsEncodingExplicit = true
         };
@@ -96,7 +96,7 @@ public class LoadfileAuditWriterTests
     {
         // Arrange
         var request = new FileGenerationRequest();
-        request.LoadFile = request.LoadFile with { LoadFileFormat = LoadFileFormat.Dat };
+        request.LoadFile = request.LoadFile with { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat } };
         request.Chaos = request.Chaos with
         {
             ChaosMode = true,
@@ -145,7 +145,7 @@ public class LoadfileAuditWriterTests
     {
         // Arrange
         var request = new FileGenerationRequest();
-        request.LoadFile = request.LoadFile with { LoadFileFormat = LoadFileFormat.Dat };
+        request.LoadFile = request.LoadFile with { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat } };
         request.Delimiters = request.Delimiters with
         {
             ColumnDelimiter = "\u0014", // Device Control 4
@@ -172,7 +172,7 @@ public class LoadfileAuditWriterTests
     {
         // Arrange
         var request = new FileGenerationRequest();
-        request.LoadFile = request.LoadFile with { LoadFileFormat = LoadFileFormat.Dat };
+        request.LoadFile = request.LoadFile with { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat } };
         request.Delimiters = request.Delimiters with
         {
             ColumnDelimiter = string.Empty,
@@ -202,7 +202,7 @@ public class LoadfileAuditWriterTests
         var expectedPropertiesFile = Path.ChangeExtension(tempFile, null) + "_properties.json";
 
         var request = new FileGenerationRequest();
-        request.LoadFile = request.LoadFile with { LoadFileFormat = LoadFileFormat.Dat };
+        request.LoadFile = request.LoadFile with { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat } };
 
         try
         {

--- a/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
+++ b/src/Zipper.Tests/LoadfileOnlyGeneratorTests.cs
@@ -40,7 +40,7 @@ namespace Zipper
                 },
                 LoadFile = new LoadFileConfig
                 {
-                    LoadFileFormat = format,
+                    Formats = new List<LoadFileFormat> { format },
                     Encoding = "UTF-8",
                 },
                 Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
@@ -470,8 +470,7 @@ namespace Zipper
                 },
                 LoadFile = new LoadFileConfig
                 {
-                    LoadFileFormat = LoadFileFormat.Dat,
-                    LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
+                    Formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
                     Encoding = "UTF-8",
                 },
                 Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
@@ -504,8 +503,7 @@ namespace Zipper
                 },
                 LoadFile = new LoadFileConfig
                 {
-                    LoadFileFormat = LoadFileFormat.Dat,
-                    LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
+                    Formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
                     Encoding = "UTF-8",
                 },
                 Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },
@@ -535,7 +533,7 @@ namespace Zipper
                 },
                 LoadFile = new LoadFileConfig
                 {
-                    LoadFileFormat = LoadFileFormat.Opt,
+                    Formats = new List<LoadFileFormat> { LoadFileFormat.Opt },
                     Encoding = "UTF-8",
                 },
                 Delimiters = new DelimiterConfig { EndOfLine = "CRLF" },

--- a/src/Zipper.Tests/ModeAdapterTests.cs
+++ b/src/Zipper.Tests/ModeAdapterTests.cs
@@ -99,7 +99,7 @@ namespace Zipper.Tests
                 {
                     LoadFile = new Config.LoadFileConfig
                     {
-                        LoadFileFormat = LoadFileFormat.Dat,
+                        Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
                         Encoding = "utf-8"
                     },
                     Output = new Config.OutputConfig

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -565,7 +565,7 @@ public class ProductionSetTests : IDisposable
                 Production = new ProductionConfig { ProductionSet = true },
                 Bates = new BatesNumberConfig { Prefix = "PLAN", Start = 1, Digits = 8 },
                 Tiff = new TiffConfig { PageRange = (3, 3) }, // Multi-page TIFF (3 pages)
-                LoadFile = new LoadFileConfig { LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Opt } }
+                LoadFile = new LoadFileConfig { Formats = new List<LoadFileFormat> { LoadFileFormat.Opt } }
             };
 
             // Act

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -92,7 +92,8 @@ namespace Zipper.Tests
 
             Assert.True(result!.LoadfileOnly);
             Assert.Equal("LF", result!.Delimiters.EndOfLine);
-            Assert.Equal(LoadFileFormat.Opt, result!.LoadFile.LoadFileFormat);
+            Assert.Single(result!.LoadFile.Formats);
+            Assert.Equal(LoadFileFormat.Opt, result!.LoadFile.Formats[0]);
         }
 
         [Fact]
@@ -183,10 +184,10 @@ namespace Zipper.Tests
 
             var result = RequestBuilder.Build(parsed);
 
-            Assert.NotNull(result!.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Dat, result!.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Opt, result!.LoadFile.LoadFileFormats);
-            Assert.Contains(LoadFileFormat.Csv, result!.LoadFile.LoadFileFormats);
+            Assert.Equal(3, result!.LoadFile.Formats.Count);
+            Assert.Contains(LoadFileFormat.Dat, result!.LoadFile.Formats);
+            Assert.Contains(LoadFileFormat.Opt, result!.LoadFile.Formats);
+            Assert.Contains(LoadFileFormat.Csv, result!.LoadFile.Formats);
         }
 
         [Fact]

--- a/src/Zipper.Tests/TempDirectoryTestBase.cs
+++ b/src/Zipper.Tests/TempDirectoryTestBase.cs
@@ -52,7 +52,7 @@ public abstract class TempDirectoryTestBase : IDisposable
             LoadFile = new LoadFileConfig
             {
                 Encoding = "Unicode (UTF-8)",
-                LoadFileFormat = LoadFileFormat.Dat,
+                Formats = new List<LoadFileFormat> { LoadFileFormat.Dat },
             },
             Metadata = new MetadataConfig { WithMetadata = true },
         };

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -340,7 +340,7 @@ namespace Zipper.Tests
                     Concurrency = 1,
                     IncludeLoadFile = true,
                 },
-                LoadFile = new LoadFileConfig { LoadFileFormats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Csv, LoadFileFormat.Opt } },
+                LoadFile = new LoadFileConfig { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Csv, LoadFileFormat.Opt } },
             };
 
             var testFiles = new List<FileData>();


### PR DESCRIPTION
Closes #535

## Release Notes

Unifies the LoadFileFormat (singular) and LoadFileFormats (plural) properties in LoadFileConfig into a single non-nullable Formats list property, simplifying load-file configuration logic across all call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Load-file handling now supports a unified list of formats, including multi-format requests and a sensible default when none is provided.

* **Bug Fixes**
  * Improved consistency in generated outputs, audit details, and primary file selection when multiple formats are involved.
  * Fixed clone behavior so copied requests keep their own independent format lists.

* **Tests**
  * Updated test coverage to match the new format-list behavior and verified analyzer expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->