### PR TITLE
refactor: move BatesNumberConfig to src/Config/ for discoverability

### DIFF
--- a/src/BatesSequence.cs
+++ b/src/BatesSequence.cs
@@ -1,14 +1,7 @@
 using System.Globalization;
+using Zipper.Config;
 
 namespace Zipper;
-
-public record BatesNumberConfig
-{
-    public string Prefix { get; init; } = "DOC";
-    public long Start { get; init; } = 1;
-    public int Digits { get; init; } = 8;
-    public long Increment { get; init; } = 1;
-}
 
 public record BatesNumber(string Prefix, string FormattedNumber)
 {

--- a/src/Cli/Validation/CrossCuttingValidator.cs
+++ b/src/Cli/Validation/CrossCuttingValidator.cs
@@ -1,3 +1,4 @@
+using Zipper.Config;
 using Zipper.Profiles;
 
 namespace Zipper.Cli.Validation;

--- a/src/Config/BatesNumberConfig.cs
+++ b/src/Config/BatesNumberConfig.cs
@@ -1,0 +1,9 @@
+namespace Zipper.Config;
+
+public record BatesNumberConfig
+{
+    public string Prefix { get; init; } = "DOC";
+    public long Start { get; init; } = 1;
+    public int Digits { get; init; } = 8;
+    public long Increment { get; init; } = 1;
+}

--- a/src/Zipper.Tests/AllWritersTests.cs
+++ b/src/Zipper.Tests/AllWritersTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Zipper.Config;
 using Zipper.LoadFiles;
 
 namespace Zipper.Tests;

--- a/src/Zipper.Tests/BatesSequenceTests.cs
+++ b/src/Zipper.Tests/BatesSequenceTests.cs
@@ -1,9 +1,18 @@
 using Xunit;
+using Zipper.Config;
 
 namespace Zipper
 {
     public class BatesSequenceTests
     {
+        [Fact]
+        public void BatesNumberConfig_ShouldBeInConfigNamespace()
+        {
+            var type = typeof(BatesSequence).Assembly.GetType("Zipper.Config.BatesNumberConfig");
+            Assert.NotNull(type);
+            Assert.Equal("Zipper.Config", type.Namespace);
+        }
+
         [Fact]
         public void Generate_WithDefaultConfig_ShouldGenerateCorrectNumber()
         {

--- a/src/Zipper.Tests/CsvLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/CsvLoadFileWriterTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Zipper.Config;
 using Zipper.LoadFiles;
 
 namespace Zipper.Tests;

--- a/src/Zipper.Tests/ModeAdapterTests.cs
+++ b/src/Zipper.Tests/ModeAdapterTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Zipper.Config;
 
 namespace Zipper.Tests
 {

--- a/src/Zipper.Tests/ProductionManifestWriterTests.cs
+++ b/src/Zipper.Tests/ProductionManifestWriterTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Xunit;
+using Zipper.Config;
 using Zipper.Profiles;
 
 namespace Zipper.Tests;

--- a/src/Zipper.Tests/ProductionSetPlannerTests.cs
+++ b/src/Zipper.Tests/ProductionSetPlannerTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Zipper.Config;
 
 namespace Zipper.Tests;
 


### PR DESCRIPTION
## Release Notes
Relocated the `BatesNumberConfig` record to its own file in `src/Config/` under the `Zipper.Config` namespace to align with all other sub-configurations.

## Description
This PR addresses issue #536 by moving `BatesNumberConfig` from `src/BatesSequence.cs` to a new file `src/Config/BatesNumberConfig.cs`. It updates all references and usings across the project and test files, and adds a namespace unit test.

Closes #536

## Type of Change
- [x] Refactor

## Testing Done
- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture
- [x] No deviation from the architecture diagrams.

## Affected Requirements
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Bates number configuration option with default prefix, start value, digit count, and increment settings.
  * The configuration type is now available from the shared configuration namespace.

* **Bug Fixes**
  * Updated sequence-related behavior to use the centralized configuration type consistently.
  * Expanded automated checks to confirm expected console output and error handling across run modes.

* **Tests**
  * Added coverage for configuration namespace placement and mode execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->