### PR TITLE
fix: replace Path.DirectorySeparatorChar with '/' for Windows path correctness

### DIFF
--- a/.agents/skills/autoreview/OPERATIONS.local.md
+++ b/.agents/skills/autoreview/OPERATIONS.local.md
@@ -52,3 +52,12 @@
 - **telemetry**: host=antigravity mode=branch specialists=4 bundle=21736c
 - **lessons**: The clone isolation test was using re-assignment which masked reference equality bugs. Asserting NotSame immediately after cloning ensures list isolation is verified properly.
 - **suppressions**: none
+
+### 2026-07-01 antigravity:branch:issue-557
+
+- **findings**: 0
+- **outcome**: accepted / clean review
+- **telemetry**: host=antigravity mode=branch specialists=1 bundle=1800c
+- **lessons**: none
+- **suppressions**: none
+

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -335,9 +335,9 @@ internal sealed class DatComposer : ILoadFileComposer
                 var attach = fileData.Attachment!.Value;
                 var childExt = Path.GetExtension(attach.filename);
                 var childBates = childId;
-                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace(Path.DirectorySeparatorChar, '\\');
-                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace(Path.DirectorySeparatorChar, '\\');
-                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\');
+                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace('/', '\\');
+                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\');
+                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\');
 
                 yield return this.MakeRecord(
                     childId,

--- a/src/LoadFiles/OptComposer.cs
+++ b/src/LoadFiles/OptComposer.cs
@@ -112,7 +112,7 @@ internal sealed class OptComposer : ILoadFileComposer
             {
                 string childBates = $"{baseBatesNumber}_A001";
                 string childImagePath = isProductionSet
-                    ? Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace(Path.DirectorySeparatorChar, '\\')
+                    ? Path.Combine("IMAGES", volume, $"{childBates}.tif").Replace('/', '\\')
                     : $"IMAGES\\{childBates}.tif";
                 yield return MakeRecord(childBates, volume, childImagePath, "Y", "1");
             }

--- a/src/Zipper.Tests/LoadFiles/PathSeparatorCorrectnessTests.cs
+++ b/src/Zipper.Tests/LoadFiles/PathSeparatorCorrectnessTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 using Zipper.Config;
 using Zipper.LoadFiles;

--- a/src/Zipper.Tests/LoadFiles/PathSeparatorCorrectnessTests.cs
+++ b/src/Zipper.Tests/LoadFiles/PathSeparatorCorrectnessTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Zipper.Config;
+using Zipper.LoadFiles;
+
+namespace Zipper.Tests.LoadFiles;
+
+public class PathSeparatorCorrectnessTests
+{
+    [Fact]
+    public void DatComposer_ComposeProduction_ShouldNormalizePathsToBackslashes()
+    {
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig { FileType = "eml" },
+            Metadata = new MetadataConfig { WithFamilies = true, Seed = 42 },
+            Bates = new BatesNumberConfig { Prefix = "DOC", Start = 1, Digits = 8 }
+        };
+
+        var files = new List<FileData>
+        {
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderName = "Folder/SubFolder",
+                    FilePathInZip = "NATIVES/Folder/SubFolder/DOC00000001.eml"
+                },
+                DataLength = 100,
+                Attachment = ("attachment.pdf", new byte[] { 1, 2, 3 })
+            }
+        };
+
+        var composer = new DatComposer(request, WriterMode.ProductionSet);
+        var records = composer.Compose(files).ToList();
+
+        Assert.Equal(2, records.Count);
+
+        // Parent record assertions
+        var parentRecord = records[0];
+        Assert.True(parentRecord.Values.TryGetValue("NATIVE_PATH", out var parentNativePath));
+        Assert.True(parentRecord.Values.TryGetValue("TEXT_PATH", out var parentTextPath));
+        Assert.True(parentRecord.Values.TryGetValue("IMAGE_PATH", out var parentImagePath));
+
+        Assert.Contains("\\", parentNativePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", parentNativePath, StringComparison.Ordinal);
+        Assert.Contains("\\", parentTextPath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", parentTextPath, StringComparison.Ordinal);
+        Assert.Contains("\\", parentImagePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", parentImagePath, StringComparison.Ordinal);
+
+        // Child record assertions
+        var childRecord = records[1];
+        Assert.True(childRecord.Values.TryGetValue("NATIVE_PATH", out var childNativePath));
+        Assert.True(childRecord.Values.TryGetValue("TEXT_PATH", out var childTextPath));
+        Assert.True(childRecord.Values.TryGetValue("IMAGE_PATH", out var childImagePath));
+
+        Assert.Contains("\\", childNativePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", childNativePath, StringComparison.Ordinal);
+        Assert.Contains("\\", childTextPath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", childTextPath, StringComparison.Ordinal);
+        Assert.Contains("\\", childImagePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", childImagePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptComposer_ComposeProduction_ShouldNormalizePathsToBackslashes()
+    {
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig { FileType = "eml" },
+            Metadata = new MetadataConfig { WithFamilies = true, Seed = 42 },
+            Bates = new BatesNumberConfig { Prefix = "DOC", Start = 1, Digits = 8 }
+        };
+
+        var files = new List<FileData>
+        {
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderName = "Folder/SubFolder",
+                    FilePathInZip = "NATIVES/Folder/SubFolder/DOC00000001.eml"
+                },
+                DataLength = 100,
+                Attachment = ("attachment.pdf", new byte[] { 1, 2, 3 })
+            }
+        };
+
+        var composer = new OptComposer(request, WriterMode.ProductionSet);
+        var records = composer.Compose(files).ToList();
+
+        // One record per page. Since page count defaults to 1, we have 1 parent page + 1 attachment page = 2 records.
+        Assert.Equal(2, records.Count);
+
+        // Parent record assertions
+        var parentRecord = records[0];
+        Assert.True(parentRecord.Values.TryGetValue("ImagePath", out var parentImagePath));
+        Assert.Contains("\\", parentImagePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", parentImagePath, StringComparison.Ordinal);
+
+        // Child record assertions
+        var childRecord = records[1];
+        Assert.True(childRecord.Values.TryGetValue("ImagePath", out var childImagePath));
+        Assert.Contains("\\", childImagePath, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", childImagePath, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Release Notes
Fixes an issue on Windows where `Path.DirectorySeparatorChar` is used incorrectly to normalize forward slashes to backslashes in paths. Forward slashes are now normalized explicitly to backslashes on all platforms.

## Description

This PR replaces platform-dependent `.Replace(Path.DirectorySeparatorChar, '\\')` calls with `.Replace('/', '\\')` in `DatComposer.cs` and `OptComposer.cs` to ensure path normalization works correctly on Windows. It also adds unit tests to guard against regressions.

Closes #557

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Test coverage
- [ ] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production file composition by normalizing ZIP-style forward slashes to backslashes in generated path fields, ensuring consistent output across environments.

* **Tests**
  * Added automated runtime tests covering the main production composition flows to confirm path separator normalization (backslashes present, forward slashes absent) and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->