### PR TITLE
feat: restrict ChaosEngine construction to loadfile-only mode

### DIFF
--- a/.agents/skills/autoreview/OPERATIONS.local.md
+++ b/.agents/skills/autoreview/OPERATIONS.local.md
@@ -61,3 +61,11 @@
 - **lessons**: none
 - **suppressions**: none
 
+### 2026-07-01 antigravity:branch:issue-561
+
+- **findings**: 1 INFO (unused chaosEngine parameters in ZipArchiveSink helper methods)
+- **outcome**: accepted (cleaned up unused parameters from the four helper methods in ZipArchiveSink.cs).
+- **telemetry**: host=antigravity mode=branch specialists=1 bundle=2800c
+- **lessons**: none
+- **suppressions**: none
+

--- a/src/LoadFileAuditWriter.cs
+++ b/src/LoadFileAuditWriter.cs
@@ -170,8 +170,8 @@ internal static class LoadFileAuditWriter
             },
             ChaosMode = new AuditChaosMode
             {
-                Enabled = request.Chaos.ChaosMode,
-                TargetAmount = request.Chaos.ChaosAmount,
+                Enabled = request.Chaos.ChaosMode && anomalies is not null,
+                TargetAmount = request.Chaos.ChaosMode && anomalies is not null ? request.Chaos.ChaosAmount : null,
                 TotalAnomalies = anomalies?.Count ?? 0,
                 InjectedAnomalies = anomalies is not null && anomalies.Count > 0
                     ? anomalies.Select(a => new AuditAnomalyEntry

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -172,7 +172,7 @@ internal static class ProductionSetGenerator
         var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (datStream.ConfigureAwait(false))
         {
-            await datWriter.WriteAsync(datStream, request, fileDataList, null, cancellationToken).ConfigureAwait(false);
+            await datWriter.WriteAsync(datStream, request, fileDataList, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         var datAuditJson = LoadFileAuditWriter.GenerateAuditJson(datPath, request, fileDataList, null, LoadFileFormat.Dat);
@@ -184,7 +184,7 @@ internal static class ProductionSetGenerator
         var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (optStream.ConfigureAwait(false))
         {
-            await optWriter.WriteAsync(optStream, request, fileDataList, null, cancellationToken).ConfigureAwait(false);
+            await optWriter.WriteAsync(optStream, request, fileDataList, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         var optAuditJson = LoadFileAuditWriter.GenerateAuditJson(optPath, request, fileDataList, null, LoadFileFormat.Opt);

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -169,27 +169,25 @@ internal static class ProductionSetGenerator
         // Write DAT load file — build a fresh ChaosEngine per format (engines are stateful)
         var datPath = Path.Combine(dataDir, "loadfile.dat");
         var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
-        var datChaosEngine = LoadFileAuditWriter.BuildChaosEngine(request, fileDataList, LoadFileFormat.Dat);
         var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (datStream.ConfigureAwait(false))
         {
-            await datWriter.WriteAsync(datStream, request, fileDataList, datChaosEngine, cancellationToken).ConfigureAwait(false);
+            await datWriter.WriteAsync(datStream, request, fileDataList, null, cancellationToken).ConfigureAwait(false);
         }
 
-        var datAuditJson = LoadFileAuditWriter.GenerateAuditJson(datPath, request, fileDataList, datChaosEngine?.Anomalies, LoadFileFormat.Dat);
+        var datAuditJson = LoadFileAuditWriter.GenerateAuditJson(datPath, request, fileDataList, null, LoadFileFormat.Dat);
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson).ConfigureAwait(false);
 
         // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
         var optWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, LoadFiles.WriterMode.ProductionSet);
-        var optChaosEngine = LoadFileAuditWriter.BuildChaosEngine(request, fileDataList, LoadFileFormat.Opt);
         var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
         await using (optStream.ConfigureAwait(false))
         {
-            await optWriter.WriteAsync(optStream, request, fileDataList, optChaosEngine, cancellationToken).ConfigureAwait(false);
+            await optWriter.WriteAsync(optStream, request, fileDataList, null, cancellationToken).ConfigureAwait(false);
         }
 
-        var optAuditJson = LoadFileAuditWriter.GenerateAuditJson(optPath, request, fileDataList, optChaosEngine?.Anomalies, LoadFileFormat.Opt);
+        var optAuditJson = LoadFileAuditWriter.GenerateAuditJson(optPath, request, fileDataList, null, LoadFileFormat.Opt);
 
         // Save OPT properties with a slightly different name to avoid overwriting DAT properties
         await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson).ConfigureAwait(false);

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -148,7 +148,7 @@ internal class ZipArchiveSink : IArchiveSink
     {
         var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
         using var loadFileStream = loadFileEntry.Open();
-        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, null).ConfigureAwait(false);
+        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles).ConfigureAwait(false);
     }
 
     private async Task GenerateLoadFileToDiskAsync(
@@ -160,7 +160,7 @@ internal class ZipArchiveSink : IArchiveSink
         var fileStream = new FileStream(currentFilePath, FileMode.Create);
         await using (fileStream.ConfigureAwait(false))
         {
-            await loadFileWriter.WriteAsync(fileStream, request, processedFiles, null).ConfigureAwait(false);
+            await loadFileWriter.WriteAsync(fileStream, request, processedFiles).ConfigureAwait(false);
             await fileStream.FlushAsync().ConfigureAwait(false);
         }
     }

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -124,19 +124,17 @@ internal class ZipArchiveSink : IArchiveSink
         var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
         var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
 
-        var chaosEngine = LoadFileAuditWriter.BuildChaosEngine(request, processedFiles, format);
-
         if (request.Output.IncludeLoadFile)
         {
-            await GenerateLoadFileToArchiveAsync(archive, request, processedFiles, loadFileWriter, chaosEngine, actualLoadFileName).ConfigureAwait(false);
-            await EmitAuditToArchiveAsync(archive, request, processedFiles, chaosEngine, format, actualLoadFileName).ConfigureAwait(false);
+            await GenerateLoadFileToArchiveAsync(archive, request, processedFiles, loadFileWriter, actualLoadFileName).ConfigureAwait(false);
+            await EmitAuditToArchiveAsync(archive, request, processedFiles, format, actualLoadFileName).ConfigureAwait(false);
             return actualLoadFileName;
         }
         else
         {
             var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
-            await GenerateLoadFileToDiskAsync(request, processedFiles, loadFileWriter, chaosEngine, currentFilePath).ConfigureAwait(false);
-            await EmitAuditToDiskAsync(request, processedFiles, chaosEngine, format, currentFilePath).ConfigureAwait(false);
+            await GenerateLoadFileToDiskAsync(request, processedFiles, loadFileWriter, currentFilePath).ConfigureAwait(false);
+            await EmitAuditToDiskAsync(request, processedFiles, format, currentFilePath).ConfigureAwait(false);
             return currentFilePath;
         }
     }
@@ -146,25 +144,23 @@ internal class ZipArchiveSink : IArchiveSink
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
         ILoadFileWriter loadFileWriter,
-        ChaosEngine? chaosEngine,
         string actualLoadFileName)
     {
         var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
         using var loadFileStream = loadFileEntry.Open();
-        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles, null).ConfigureAwait(false);
     }
 
     private async Task GenerateLoadFileToDiskAsync(
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
         ILoadFileWriter loadFileWriter,
-        ChaosEngine? chaosEngine,
         string currentFilePath)
     {
         var fileStream = new FileStream(currentFilePath, FileMode.Create);
         await using (fileStream.ConfigureAwait(false))
         {
-            await loadFileWriter.WriteAsync(fileStream, request, processedFiles, chaosEngine).ConfigureAwait(false);
+            await loadFileWriter.WriteAsync(fileStream, request, processedFiles, null).ConfigureAwait(false);
             await fileStream.FlushAsync().ConfigureAwait(false);
         }
     }
@@ -173,11 +169,10 @@ internal class ZipArchiveSink : IArchiveSink
         ZipArchive archive,
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
-        ChaosEngine? chaosEngine,
         LoadFileFormat format,
         string actualLoadFileName)
     {
-        var auditJson = LoadFileAuditWriter.GenerateAuditJson(actualLoadFileName, request, processedFiles, chaosEngine?.Anomalies, format);
+        var auditJson = LoadFileAuditWriter.GenerateAuditJson(actualLoadFileName, request, processedFiles, null, format);
         var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
         using var propertiesStream = propertiesEntry.Open();
         using var propertiesWriter = new StreamWriter(propertiesStream);
@@ -187,11 +182,10 @@ internal class ZipArchiveSink : IArchiveSink
     private async Task EmitAuditToDiskAsync(
         FileGenerationRequest request,
         DiskBackedFileDataList processedFiles,
-        ChaosEngine? chaosEngine,
         LoadFileFormat format,
         string currentFilePath)
     {
-        var auditJson = LoadFileAuditWriter.GenerateAuditJson(currentFilePath, request, processedFiles, chaosEngine?.Anomalies, format);
+        var auditJson = LoadFileAuditWriter.GenerateAuditJson(currentFilePath, request, processedFiles, null, format);
         await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
     }
 

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -639,4 +639,64 @@ public class ProductionSetTests : IDisposable
             }
         }
     }
+
+    [Fact]
+    public async Task GenerateAsync_ChaosModeEnabled_DoesNotApplyChaos()
+    {
+        // Arrange
+        var tempDir = Directory.GetCurrentDirectory();
+        var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = outputPath,
+                    FileCount = 5,
+                    FileType = "pdf",
+                },
+                Chaos = new ChaosConfig
+                {
+                    ChaosMode = true,
+                    ChaosAmount = "100%",
+                    ChaosTypes = "columns",
+                },
+                Production = new ProductionConfig
+                {
+                    ProductionSet = true,
+                },
+                Bates = new BatesNumberConfig
+                {
+                    Prefix = "ABC",
+                    Start = 1,
+                    Digits = 6,
+                },
+                LoadfileOnly = true, // bypass the exception guard in ProductionSetGenerator
+            };
+
+            // Act
+            var result = await ProductionSetGenerator.GenerateAsync(request);
+
+            // Assert
+            var propertiesPath = Path.Combine(result.ProductionPath, "DATA", "loadfile_properties.json");
+            Assert.True(File.Exists(propertiesPath));
+            var json = await File.ReadAllTextAsync(propertiesPath);
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+            var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
+
+            // Assert that totalAnomalies is 0 because ChaosEngine should not be constructed/used in ProductionSetGenerator
+            Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
+        }
+        finally
+        {
+            if (Directory.Exists(outputPath))
+            {
+                Directory.Delete(outputPath, true);
+            }
+        }
+    }
 }
+

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -644,59 +644,27 @@ public class ProductionSetTests : IDisposable
     public async Task GenerateAsync_ChaosModeEnabled_DoesNotApplyChaos()
     {
         // Arrange
-        var tempDir = Directory.GetCurrentDirectory();
-        var outputPath = Path.Combine(tempDir, Guid.NewGuid().ToString());
-        Directory.CreateDirectory(outputPath);
-
-        try
+        var request = this.CreateTestRequest(count: 5, batesPrefix: "ABC", batesDigits: 6);
+        request.Chaos = new ChaosConfig
         {
-            var request = new FileGenerationRequest
-            {
-                Output = new OutputConfig
-                {
-                    OutputPath = outputPath,
-                    FileCount = 5,
-                    FileType = "pdf",
-                },
-                Chaos = new ChaosConfig
-                {
-                    ChaosMode = true,
-                    ChaosAmount = "100%",
-                    ChaosTypes = "columns",
-                },
-                Production = new ProductionConfig
-                {
-                    ProductionSet = true,
-                },
-                Bates = new BatesNumberConfig
-                {
-                    Prefix = "ABC",
-                    Start = 1,
-                    Digits = 6,
-                },
-                LoadfileOnly = true, // bypass the exception guard in ProductionSetGenerator
-            };
+            ChaosMode = true,
+            ChaosAmount = "100%",
+            ChaosTypes = "columns",
+        };
+        request.LoadfileOnly = true; // bypass the exception guard in ProductionSetGenerator
 
-            // Act
-            var result = await ProductionSetGenerator.GenerateAsync(request);
+        // Act
+        var result = await ProductionSetGenerator.GenerateAsync(request);
 
-            // Assert
-            var propertiesPath = Path.Combine(result.ProductionPath, "DATA", "loadfile_properties.json");
-            Assert.True(File.Exists(propertiesPath));
-            var json = await File.ReadAllTextAsync(propertiesPath);
-            var doc = System.Text.Json.JsonDocument.Parse(json);
-            var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
+        // Assert
+        var propertiesPath = Path.Combine(result.ProductionPath, "DATA", "loadfile_properties.json");
+        Assert.True(File.Exists(propertiesPath));
+        var json = await File.ReadAllTextAsync(propertiesPath);
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
 
-            // Assert that totalAnomalies is 0 because ChaosEngine should not be constructed/used in ProductionSetGenerator
-            Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
-        }
-        finally
-        {
-            if (Directory.Exists(outputPath))
-            {
-                Directory.Delete(outputPath, true);
-            }
-        }
+        // Assert that totalAnomalies is 0 because ChaosEngine should not be constructed/used in ProductionSetGenerator
+        Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
     }
 }
 

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -469,6 +469,63 @@ public class ZipArchiveServiceTests
         File.Delete(loadPath);
     }
 
+    [Fact]
+    public async Task CreateArchiveAsync_ChaosModeEnabled_DoesNotApplyChaos()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var zipPath = Path.Combine(tempDir, "test.zip");
+        var loadPath = Path.Combine(tempDir, "load.dat");
+        const int fileCount = 5;
+
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig
+            {
+                FileType = "pdf",
+                FileCount = fileCount,
+                Concurrency = 1,
+                IncludeLoadFile = false,
+            },
+            Chaos = new ChaosConfig
+            {
+                ChaosMode = true,
+                ChaosAmount = "100%",
+                ChaosTypes = "columns",
+            }
+        };
+
+        var testFiles = new List<FileData>();
+        for (int i = 1; i <= fileCount; i++)
+        {
+            testFiles.Add(this.CreateTestFileData(i));
+        }
+
+        var channel = Channel.CreateUnbounded<FileData>();
+        foreach (var file in testFiles)
+        {
+            await channel.Writer.WriteAsync(file);
+        }
+        channel.Writer.Complete();
+
+        // Act
+        await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+
+        // Assert — audit file totalRecords should equal fileCount
+        var propertiesPath = loadPath + "_properties.json";
+        Assert.True(File.Exists(propertiesPath));
+        var json = await File.ReadAllTextAsync(propertiesPath);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
+
+        // Assert that chaos was NOT enabled in the audit properties
+        Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
+
+        // Cleanup
+        Directory.Delete(tempDir, true);
+    }
+
     private class MockMemoryOwner : System.Buffers.IMemoryOwner<byte>
     {
         public bool IsDisposed { get; private set; }
@@ -477,3 +534,4 @@ public class ZipArchiveServiceTests
         public void Dispose() { IsDisposed = true; }
     }
 }
+

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -475,55 +475,62 @@ public class ZipArchiveServiceTests
         // Arrange
         var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
-        var zipPath = Path.Combine(tempDir, "test.zip");
-        var loadPath = Path.Combine(tempDir, "load.dat");
-        const int fileCount = 5;
-
-        var request = new FileGenerationRequest
+        try
         {
-            Output = new OutputConfig
+            var zipPath = Path.Combine(tempDir, "test.zip");
+            var loadPath = Path.Combine(tempDir, "load.dat");
+            const int fileCount = 5;
+
+            var request = new FileGenerationRequest
             {
-                FileType = "pdf",
-                FileCount = fileCount,
-                Concurrency = 1,
-                IncludeLoadFile = false,
-            },
-            Chaos = new ChaosConfig
+                Output = new OutputConfig
+                {
+                    FileType = "pdf",
+                    FileCount = fileCount,
+                    Concurrency = 1,
+                    IncludeLoadFile = false,
+                },
+                Chaos = new ChaosConfig
+                {
+                    ChaosMode = true,
+                    ChaosAmount = "100%",
+                    ChaosTypes = "columns",
+                }
+            };
+
+            var testFiles = new List<FileData>();
+            for (int i = 1; i <= fileCount; i++)
             {
-                ChaosMode = true,
-                ChaosAmount = "100%",
-                ChaosTypes = "columns",
+                testFiles.Add(this.CreateTestFileData(i));
             }
-        };
 
-        var testFiles = new List<FileData>();
-        for (int i = 1; i <= fileCount; i++)
-        {
-            testFiles.Add(this.CreateTestFileData(i));
+            var channel = Channel.CreateUnbounded<FileData>();
+            foreach (var file in testFiles)
+            {
+                await channel.Writer.WriteAsync(file);
+            }
+            channel.Writer.Complete();
+
+            // Act
+            await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+
+            // Assert — audit file totalRecords should equal fileCount
+            var propertiesPath = loadPath + "_properties.json";
+            Assert.True(File.Exists(propertiesPath));
+            var json = await File.ReadAllTextAsync(propertiesPath);
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
+
+            // Assert that chaos was NOT enabled in the audit properties
+            Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
         }
-
-        var channel = Channel.CreateUnbounded<FileData>();
-        foreach (var file in testFiles)
+        finally
         {
-            await channel.Writer.WriteAsync(file);
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
         }
-        channel.Writer.Complete();
-
-        // Act
-        await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
-
-        // Assert — audit file totalRecords should equal fileCount
-        var propertiesPath = loadPath + "_properties.json";
-        Assert.True(File.Exists(propertiesPath));
-        var json = await File.ReadAllTextAsync(propertiesPath);
-        var doc = System.Text.Json.JsonDocument.Parse(json);
-        var chaosModeElement = doc.RootElement.GetProperty("chaosMode");
-
-        // Assert that chaos was NOT enabled in the audit properties
-        Assert.Equal(0, chaosModeElement.GetProperty("totalAnomalies").GetInt32());
-
-        // Cleanup
-        Directory.Delete(tempDir, true);
     }
 
     private class MockMemoryOwner : System.Buffers.IMemoryOwner<byte>


### PR DESCRIPTION
<!-- Release Notes: 1-2 sentences for small changes, 3-5 for larger ones. Plain prose. Key facts only. -->
## Release Notes
This PR restricts the construction and usage of the ChaosEngine strictly to the Loadfile-Only mode paths, eliminating speculative initialization in ProductionSetGenerator and ZipArchiveSink.

## Description

This PR addresses an architectural mismatch where `ChaosEngine` was previously initialized in `ProductionSetGenerator` and `ZipArchiveSink` even though those calls were functionally nullified by guard clauses. `ChaosEngine` construction is now scoped exclusively to Loadfile-Only mode in `LoadFileOnlyGenerator.cs`, and `null` is passed cleanly down standard and production set pipelines where chaos is not applicable.

Closes #561

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Test coverage
- [ ] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chaos mode is no longer applied to generated load files or audit JSON, so outputs now consistently show zero anomalies in these artifacts.
* **Tests**
  * Added regression coverage to verify chaos-enabled requests do not affect archive and production-set generation outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->