### PR TITLE
feat: configurable hash fields (MD5/SHA1/SHA256) for Native Files

### DIFF
--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -562,6 +562,32 @@ public static class CliParser
                     }
 
                     break;
+                case "--hash-mode":
+                    if (TryGetValue(args, i, out var hashModeVal))
+                    {
+                        parsed.HashMode = hashModeVal;
+                        i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --hash-mode requires a value.");
+                        return null;
+                    }
+
+                    break;
+                case "--hash-algorithms":
+                    if (TryGetValue(args, i, out var hashAlgsVal))
+                    {
+                        parsed.HashAlgorithms = hashAlgsVal;
+                        i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --hash-algorithms requires a value.");
+                        return null;
+                    }
+
+                    break;
                 default:
                     Console.Error.WriteLine($"Error: Unknown argument or unconsumed value '{args[i]}'");
                     return null;

--- a/src/Cli/ParsedArguments.cs
+++ b/src/Cli/ParsedArguments.cs
@@ -91,4 +91,8 @@ public class ParsedArguments
     public bool ProductionZip { get; set; }
 
     public int? VolumeSize { get; set; }
+
+    public string? HashMode { get; set; }
+
+    public string? HashAlgorithms { get; set; }
 }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -118,6 +118,13 @@ public static class RequestBuilder
             ? multiFormats
             : new List<LoadFileFormat> { GetLoadFileFormat(parsed.LoadFileFormat ?? "dat") ?? LoadFileFormat.Dat };
 
+        var hashConfig = ParseHashConfig(parsed);
+        if (parsed.LoadfileOnly && hashConfig.Mode == HashMode.Actual)
+        {
+            Console.Error.WriteLine("error: --hash-mode actual is not supported with --loadfile-only (no file bytes to hash)");
+            return null;
+        }
+
         return new FileGenerationRequest
         {
             Output = new OutputConfig
@@ -183,7 +190,7 @@ public static class RequestBuilder
                 VolumeSize = parsed.VolumeSize ?? 5000,
             },
             LoadfileOnly = parsed.LoadfileOnly,
-            Hash = ParseHashConfig(parsed),
+            Hash = hashConfig,
         };
     }
 

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -183,6 +183,48 @@ public static class RequestBuilder
                 VolumeSize = parsed.VolumeSize ?? 5000,
             },
             LoadfileOnly = parsed.LoadfileOnly,
+            Hash = ParseHashConfig(parsed),
+        };
+    }
+
+    internal static HashConfig ParseHashConfig(ParsedArguments parsed)
+    {
+        var mode = HashMode.None;
+        if (!string.IsNullOrEmpty(parsed.HashMode))
+        {
+            mode = parsed.HashMode.ToLowerInvariant() switch
+            {
+                "actual" => HashMode.Actual,
+                "simulated" => HashMode.Simulated,
+                "none" => HashMode.None,
+                _ => HashMode.None,
+            };
+        }
+
+        var algorithms = new HashSet<HashAlgorithm>();
+        if (!string.IsNullOrEmpty(parsed.HashAlgorithms))
+        {
+            foreach (var alg in parsed.HashAlgorithms.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parsedAlg = alg.ToLowerInvariant() switch
+                {
+                    "md5" => HashAlgorithm.MD5,
+                    "sha1" => HashAlgorithm.SHA1,
+                    "sha256" => HashAlgorithm.SHA256,
+                    _ => (HashAlgorithm?)null,
+                };
+
+                if (parsedAlg.HasValue)
+                {
+                    algorithms.Add(parsedAlg.Value);
+                }
+            }
+        }
+
+        return new HashConfig
+        {
+            Mode = mode,
+            Algorithms = algorithms,
         };
     }
 

--- a/src/Config/HashConfig.cs
+++ b/src/Config/HashConfig.cs
@@ -1,0 +1,24 @@
+namespace Zipper.Config;
+
+public enum HashMode
+{
+    None,
+    Actual,
+    Simulated,
+}
+
+public enum HashAlgorithm
+{
+    MD5,
+    SHA1,
+    SHA256,
+}
+
+public record HashConfig
+{
+    public HashMode Mode { get; init; } = HashMode.None;
+
+    public IReadOnlySet<HashAlgorithm> Algorithms { get; init; } = new HashSet<HashAlgorithm>();
+
+    public bool IsEnabled => this.Mode != HashMode.None && this.Algorithms.Count > 0;
+}

--- a/src/Config/HashUtility.cs
+++ b/src/Config/HashUtility.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+
+namespace Zipper.Config;
+
+internal static class HashUtility
+{
+    internal static string ComputeHashHex(ReadOnlySpan<byte> data, HashAlgorithm algo)
+    {
+#pragma warning disable S4790 // Cryptographic algorithms should be robust
+#pragma warning disable S4426 // Weak cryptographic algorithm
+#pragma warning disable CA5350 // Weak cryptographic algorithm is used for e-discovery compat
+        var hashBytes = algo switch
+        {
+            HashAlgorithm.MD5 => MD5.HashData(data),
+            HashAlgorithm.SHA1 => SHA1.HashData(data),
+            HashAlgorithm.SHA256 => SHA256.HashData(data),
+            _ => throw new ArgumentOutOfRangeException(nameof(algo)),
+        };
+#pragma warning restore CA5350
+#pragma warning restore S4426
+#pragma warning restore S4790
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    internal static Random CreateSeededRandom(FileGenerationRequest request, long workItemIndex)
+    {
+#pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
+        var seed = request.Metadata.Seed.HasValue
+            ? unchecked((int)(request.Metadata.Seed.Value + workItemIndex))
+            : (int)workItemIndex;
+        return new Random(seed);
+#pragma warning restore S2245
+    }
+
+    internal static string GenerateSimulatedHash(HashAlgorithm algo, Random rng)
+    {
+        const string chars = "0123456789abcdef";
+        var length = algo switch
+        {
+            HashAlgorithm.MD5 => 32,
+            HashAlgorithm.SHA1 => 40,
+            HashAlgorithm.SHA256 => 64,
+            _ => 32,
+        };
+        Span<char> buffer = stackalloc char[length];
+        for (int i = 0; i < length; i++)
+            buffer[i] = chars[rng.Next(chars.Length)];
+        return new string(buffer);
+    }
+}

--- a/src/DiskBackedFileDataList.cs
+++ b/src/DiskBackedFileDataList.cs
@@ -95,6 +95,21 @@ internal static class FileDataSerializer
         writer.Write(data.PageCount);
         writer.Write(data.Hash ?? string.Empty);
 
+        if (data.Hashes is not null)
+        {
+            writer.Write(true);
+            writer.Write(data.Hashes.Count);
+            foreach (var kvp in data.Hashes)
+            {
+                writer.Write((int)kvp.Key);
+                writer.Write(kvp.Value);
+            }
+        }
+        else
+        {
+            writer.Write(false);
+        }
+
         writer.Write(data.Attachment.HasValue);
         if (data.Attachment.HasValue)
         {
@@ -121,6 +136,21 @@ internal static class FileDataSerializer
         var dataLength = reader.ReadInt32();
         var pageCount = reader.ReadInt32();
         var hash = reader.ReadString();
+
+        IReadOnlyDictionary<Config.HashAlgorithm, string>? hashes = null;
+        if (reader.ReadBoolean())
+        {
+            var count = reader.ReadInt32();
+            var dict = new Dictionary<Config.HashAlgorithm, string>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var algo = (Config.HashAlgorithm)reader.ReadInt32();
+                var value = reader.ReadString();
+                dict[algo] = value;
+            }
+
+            hashes = dict;
+        }
 
         (string filename, byte[] content)? attachment = null;
         if (reader.ReadBoolean())
@@ -158,6 +188,7 @@ internal static class FileDataSerializer
             DataLength = dataLength,
             PageCount = pageCount,
             Hash = hash,
+            Hashes = hashes,
             Attachment = attachment,
             Email = email
         };

--- a/src/FileGenerationRequest.cs
+++ b/src/FileGenerationRequest.cs
@@ -20,6 +20,8 @@ public class FileGenerationRequest
 
     public ProductionConfig Production { get; set; } = new();
 
+    public HashConfig Hash { get; set; } = new();
+
     public bool LoadfileOnly { get; set; }
 
     public FileGenerationRequest Clone()
@@ -37,6 +39,7 @@ public class FileGenerationRequest
             Tiff = this.Tiff,
             Chaos = this.Chaos,
             Production = this.Production,
+            Hash = this.Hash,
             LoadfileOnly = this.LoadfileOnly,
         };
     }

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -249,7 +249,7 @@ internal sealed class DatComposer : ILoadFileComposer
                         val = this.request.Output.WithText ? this.StandardTextPath(fileData, ctx) : string.Empty;
                         break;
                     default:
-                        val = profileValues.TryGetValue(n, out var x) ? x : string.Empty;
+                        val = ResolveHashColumn(upper, fileData) ?? (profileValues.TryGetValue(n, out var x) ? x : string.Empty);
                         break;
                 }
                 result.Add(val);
@@ -447,6 +447,7 @@ internal sealed class DatComposer : ILoadFileComposer
 #pragma warning restore S2245
 
         var fileTypeLower = this.request.Output.FileTypeLower;
+        var hashConfig = this.request.Hash;
 
         for (long i = 1; i <= this.request.Output.FileCount; i++)
         {
@@ -463,12 +464,34 @@ internal sealed class DatComposer : ILoadFileComposer
                 WorkItem = workItem,
                 DataLength = rowRandom.Next(1024, 10_485_760),
                 PageCount = rowRandom.Next(1, 11),
+                Hashes = hashConfig.Mode == Config.HashMode.Simulated ? GenerateSimulatedHashes(workItem) : null,
             };
 
             var values = generator.GenerateRow(workItem, fileData);
-            var ordered = columnNames.Select(n => values.TryGetValue(n, out var x) ? x : string.Empty).ToList();
+            var ordered = columnNames.Select(n =>
+            {
+                var hv = values.TryGetValue(n, out var x) ? x : string.Empty;
+                var hashVal = ResolveHashColumn(n.ToUpperInvariant(), fileData);
+                return hashVal ?? hv;
+            }).ToList();
             yield return this.MakeRecord($"DOC{i:D8}", ordered);
         }
+    }
+
+    private IReadOnlyDictionary<Config.HashAlgorithm, string>? GenerateSimulatedHashes(FileWorkItem workItem)
+    {
+        var hashConfig = this.request.Hash;
+        if (!hashConfig.IsEnabled)
+        {
+            return null;
+        }
+
+        var dict = new Dictionary<Config.HashAlgorithm, string>(hashConfig.Algorithms.Count);
+        var rng = Config.HashUtility.CreateSeededRandom(this.request, workItem.Index);
+        foreach (var algo in hashConfig.Algorithms)
+            dict[algo] = Config.HashUtility.GenerateSimulatedHash(algo, rng);
+
+        return dict;
     }
 
     private (string ParentId, string ChildId, bool HasAttachment) GetFamilyIdentifiers(FileData fileData, FileGenerationRequest request)
@@ -479,6 +502,29 @@ internal sealed class DatComposer : ILoadFileComposer
             : $"DOC{fileData.WorkItem.Index:D8}";
         string childId = hasAttachment ? $"{parentId}_A001" : parentId;
         return (parentId, childId, hasAttachment);
+    }
+
+    private static string? ResolveHashColumn(string upperColumnName, FileData fileData)
+    {
+        if (fileData.Hashes is null)
+        {
+            return null;
+        }
+
+        var algo = upperColumnName switch
+        {
+            "MD5HASH" or "MD5_HASH" or "MD5 HASH" => Config.HashAlgorithm.MD5,
+            "SHA1HASH" or "SHA1_HASH" or "SHA1 HASH" => Config.HashAlgorithm.SHA1,
+            "SHA256HASH" or "SHA256_HASH" or "SHA256 HASH" => Config.HashAlgorithm.SHA256,
+            _ => (Config.HashAlgorithm?)null,
+        };
+
+        if (algo.HasValue && fileData.Hashes.TryGetValue(algo.Value, out var hashValue))
+        {
+            return hashValue;
+        }
+
+        return null;
     }
 
     private static DataGenerator? GetEffectiveProfileGenerator(FileGenerationRequest request, DateTime now)

--- a/src/LoadFiles/StandardRowComposer.cs
+++ b/src/LoadFiles/StandardRowComposer.cs
@@ -21,6 +21,24 @@ internal abstract class StandardRowComposer : ILoadFileComposer
         this.batesSequence = request.Bates != null ? BatesSequence.FromConfig(request.Bates) : null;
     }
 
+    /// <summary>Gets the hash column keys to emit based on request configuration.</summary>
+    protected static IReadOnlyList<string> GetHashColumnKeys(FileGenerationRequest request)
+    {
+        if (!request.Hash.IsEnabled)
+        {
+            return Array.Empty<string>();
+        }
+
+        var keys = new List<string>(request.Hash.Algorithms.Count);
+        if (request.Hash.Algorithms.Contains(Config.HashAlgorithm.MD5))
+            keys.Add("MD5HASH");
+        if (request.Hash.Algorithms.Contains(Config.HashAlgorithm.SHA1))
+            keys.Add("SHA1HASH");
+        if (request.Hash.Algorithms.Contains(Config.HashAlgorithm.SHA256))
+            keys.Add("SHA256HASH");
+        return keys;
+    }
+
     public IReadOnlyList<string> HeaderColumns => this.headerColumns;
 
     /// <summary>Gets a value indicating whether leading BEGATTY/ENDATTY columns are emitted.</summary>
@@ -89,6 +107,11 @@ internal abstract class StandardRowComposer : ILoadFileComposer
             keys.Add("TEXT");
         }
 
+        if (this.request.Hash.IsEnabled)
+        {
+            keys.AddRange(GetHashColumnKeys(this.request));
+        }
+
         return keys;
     }
 
@@ -118,6 +141,14 @@ internal abstract class StandardRowComposer : ILoadFileComposer
             // Whole-string Replace (not extension-only) preserves byte-for-byte parity with the
             // legacy writers; FilePathInZip folder segments never contain ".{FileType}" in practice.
             "TEXT" => wi.FilePathInZip.Replace($".{this.request.Output.FileType}", ".txt", StringComparison.Ordinal),
+            "MD5HASH" => ResolveHashFromFileData(fileData, Config.HashAlgorithm.MD5),
+            "SHA1HASH" => ResolveHashFromFileData(fileData, Config.HashAlgorithm.SHA1),
+            "SHA256HASH" => ResolveHashFromFileData(fileData, Config.HashAlgorithm.SHA256),
             _ => string.Empty,
         };
+
+    private static string ResolveHashFromFileData(FileData fileData, Config.HashAlgorithm algorithm)
+        => fileData.Hashes is not null && fileData.Hashes.TryGetValue(algorithm, out var hash)
+            ? hash
+            : string.Empty;
 }

--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -101,15 +101,36 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
         var filesElement = new XElement("Files");
 
         // Native file reference
-        var nativeFile = new XElement(
-            "File",
-            new XAttribute("FileType", "Native"),
-            new XElement(
-                "ExternalFile",
-                new XAttribute("FilePath", workItem.FilePathInZip),
-                new XAttribute("FileName", workItem.FileName),
-                new XAttribute("FileSize", fileData.DataLength),
-                new XAttribute("Hash", fileData.Hash)));
+        var nativeExternalFile = new XElement(
+            "ExternalFile",
+            new XAttribute("FilePath", workItem.FilePathInZip),
+            new XAttribute("FileName", workItem.FileName),
+            new XAttribute("FileSize", fileData.DataLength),
+            new XAttribute("Hash", fileData.Hash));
+
+        // Add algorithm-specific hash attributes when multiple algorithms exist
+        if (fileData.Hashes is not null)
+        {
+            foreach (var kvp in fileData.Hashes)
+            {
+                if (kvp.Key == Config.HashAlgorithm.MD5)
+                    continue; // Already written as "Hash"
+
+                var attrName = kvp.Key switch
+                {
+                    Config.HashAlgorithm.SHA1 => "Sha1Hash",
+                    Config.HashAlgorithm.SHA256 => "Sha256Hash",
+                    _ => null,
+                };
+
+                if (attrName is not null)
+                {
+                    nativeExternalFile.Add(new XAttribute(attrName, kvp.Value));
+                }
+            }
+        }
+
+        var nativeFile = new XElement("File", new XAttribute("FileType", "Native"), nativeExternalFile);
         filesElement.Add(nativeFile);
 
         // Extracted Text file reference if applicable

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Threading.Channels;
+using Zipper.Config;
 using Zipper.Emails;
 
 namespace Zipper;
@@ -320,6 +321,7 @@ public class ParallelFileGenerator
             var hashBytes = MD5.HashData(data);
 #pragma warning restore S4790
             var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+            var hashes = ComputeHashes(data, workItem, request);
 
             return new FileData
             {
@@ -330,6 +332,7 @@ public class ParallelFileGenerator
                 PageCount = pageCount,
                 Email = email,
                 Hash = hash,
+                Hashes = hashes,
             };
         }
 
@@ -357,6 +360,7 @@ public class ParallelFileGenerator
             var finalHashBytes = MD5.HashData(finalMemory.Span);
 #pragma warning restore S4790
             var finalHash = Convert.ToHexString(finalHashBytes).ToLowerInvariant();
+            var hashes = ComputeHashes(finalMemory.Span, workItem, request);
 
             return new FileData
             {
@@ -368,6 +372,7 @@ public class ParallelFileGenerator
                 PageCount = pageCount,
                 Email = email,
                 Hash = finalHash,
+                Hashes = hashes,
             };
         }
         catch
@@ -375,6 +380,39 @@ public class ParallelFileGenerator
             memoryOwner.Dispose();
             throw;
         }
+    }
+
+    private static IReadOnlyDictionary<Config.HashAlgorithm, string>? ComputeHashes(
+        ReadOnlySpan<byte> data, FileWorkItem workItem, FileGenerationRequest request)
+    {
+        var hashConfig = request.Hash;
+        if (!hashConfig.IsEnabled)
+        {
+            return null;
+        }
+
+        if (hashConfig.Mode == HashMode.Simulated)
+        {
+            return ComputeSimulatedHashes(workItem, request);
+        }
+
+        var dict = new Dictionary<Config.HashAlgorithm, string>(hashConfig.Algorithms.Count);
+        foreach (var algo in hashConfig.Algorithms)
+            dict[algo] = HashUtility.ComputeHashHex(data, algo);
+
+        return dict;
+    }
+
+    private static IReadOnlyDictionary<Config.HashAlgorithm, string> ComputeSimulatedHashes(
+        FileWorkItem workItem, FileGenerationRequest request)
+    {
+        var hashConfig = request.Hash;
+        var dict = new Dictionary<Config.HashAlgorithm, string>(hashConfig.Algorithms.Count);
+        var rng = HashUtility.CreateSeededRandom(request, workItem.Index);
+        foreach (var algo in hashConfig.Algorithms)
+            dict[algo] = HashUtility.GenerateSimulatedHash(algo, rng);
+
+        return dict;
     }
 
     internal long CalculatePaddingPerFile(long targetSize, int baseSize, long fileCount, bool withText)
@@ -474,4 +512,6 @@ internal record FileData
     public Email? Email { get; init; }
 
     public string Hash { get; init; } = string.Empty;
+
+    public IReadOnlyDictionary<Config.HashAlgorithm, string>? Hashes { get; init; }
 }

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using Zipper.Config;
 using Zipper.Profiles.Data;
 
 
@@ -53,6 +54,51 @@ internal static class ProductionSetGenerator
         }
     }
 
+    private static IReadOnlyDictionary<Config.HashAlgorithm, string> ComputeActualHashes(
+        byte[] content, HashConfig hashConfig)
+    {
+        var dict = new Dictionary<Config.HashAlgorithm, string>(hashConfig.Algorithms.Count);
+        foreach (var algo in hashConfig.Algorithms)
+            dict[algo] = HashUtility.ComputeHashHex(content, algo);
+
+        return dict;
+    }
+
+    private static IReadOnlyDictionary<Config.HashAlgorithm, string> ComputeSimulatedHashes(
+        FileWorkItem workItem, HashConfig hashConfig, FileGenerationRequest request)
+    {
+        var dict = new Dictionary<Config.HashAlgorithm, string>(hashConfig.Algorithms.Count);
+
+#pragma warning disable S2245
+        var seed = request.Metadata.Seed.HasValue
+            ? unchecked((int)(request.Metadata.Seed.Value + workItem.Index))
+            : (int)workItem.Index;
+        var rng = new Random(seed);
+#pragma warning restore S2245
+
+        const string chars = "0123456789abcdef";
+        Span<char> buffer = stackalloc char[64];
+        foreach (var algo in hashConfig.Algorithms)
+        {
+            var length = algo switch
+            {
+                Config.HashAlgorithm.MD5 => 32,
+                Config.HashAlgorithm.SHA1 => 40,
+                Config.HashAlgorithm.SHA256 => 64,
+                _ => 32,
+            };
+
+            for (int i = 0; i < length; i++)
+            {
+                buffer[i] = chars[rng.Next(chars.Length)];
+            }
+
+            dict[algo] = new string(buffer[..length]);
+        }
+
+        return dict;
+    }
+
     private static async Task<ProductionSetResult> GenerateCoreAsync(
         FileGenerationRequest request, string productionPath, string productionName, Stopwatch stopwatch, CancellationToken cancellationToken)
     {
@@ -91,6 +137,7 @@ internal static class ProductionSetGenerator
 
         // Generate files using the plan
         var fileDataList = new List<FileData>();
+        var hashConfig = request.Hash;
 
         foreach (var plan in plans)
         {
@@ -130,6 +177,28 @@ internal static class ProductionSetGenerator
                 await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
             }
 
+            var fileDataHash = string.Empty;
+            IReadOnlyDictionary<Config.HashAlgorithm, string>? fileDataHashes = null;
+            if (hashConfig.IsEnabled)
+            {
+                if (hashConfig.Mode == HashMode.Actual)
+                {
+                    fileDataHashes = ComputeActualHashes(nativeContent, hashConfig);
+                    if (fileDataHashes.TryGetValue(Config.HashAlgorithm.MD5, out var md5))
+                    {
+                        fileDataHash = md5;
+                    }
+                }
+                else if (hashConfig.Mode == HashMode.Simulated)
+                {
+                    fileDataHashes = ComputeSimulatedHashes(workItem, hashConfig, request);
+                    if (fileDataHashes.TryGetValue(Config.HashAlgorithm.MD5, out var md5))
+                    {
+                        fileDataHash = md5;
+                    }
+                }
+            }
+
             fileDataList.Add(new FileData
             {
                 WorkItem = workItem,
@@ -137,6 +206,8 @@ internal static class ProductionSetGenerator
                 Attachment = generated.Attachment,
                 PageCount = generated.PageCount,
                 Email = generated.Email,
+                Hash = fileDataHash,
+                Hashes = fileDataHashes,
             });
 
             if (request.Metadata.WithFamilies && request.Output.IsEml && generated.Attachment.HasValue)

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -32,9 +32,9 @@ public class CliParserTests
             "--folders", "--encoding", "--distribution", "--attachment-rate", "--target-zip-size",
             "--load-file-format", "--bates-prefix", "--bates-start", "--bates-digits", "--tiff-pages",
             "--column-profile", "--seed", "--date-format", "--empty-percentage", "--custodian-count",
-            "--load-file-formats", "--dat-delimiters", "--loadfile-format", "--eol", "--col-delim",
+                "--load-file-formats", "--dat-delimiters", "--loadfile-format", "--eol", "--col-delim",
             "--quote-delim", "--newline-delim", "--multi-delim", "--nested-delim", "--chaos-amount",
-            "--chaos-types", "--chaos-scenario", "--volume-size"
+            "--chaos-types", "--chaos-scenario", "--volume-size", "--hash-mode", "--hash-algorithms"
         };
 
         foreach (var flag in flags)
@@ -115,6 +115,33 @@ public class CliParserTests
         Assert.Equal(100, result.BatesStart);
         Assert.Equal(6, result.BatesDigits);
         Assert.Equal(1000, result.VolumeSize);
+    }
+
+    [Fact]
+    public void Parse_HashModeArgs_ParsesCorrectly()
+    {
+        var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--hash-mode", "actual", "--hash-algorithms", "md5,sha256" });
+        Assert.NotNull(result);
+        Assert.Equal("actual", result!.HashMode);
+        Assert.Equal("md5,sha256", result.HashAlgorithms);
+    }
+
+    [Fact]
+    public void Parse_HashModeOnly_ParsesCorrectly()
+    {
+        var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--hash-mode", "simulated" });
+        Assert.NotNull(result);
+        Assert.Equal("simulated", result!.HashMode);
+        Assert.Null(result.HashAlgorithms);
+    }
+
+    [Fact]
+    public void Parse_InvalidHashMode_IsParsedAsString()
+    {
+        // Invalid hash mode is accepted by parser; validation happens at request building
+        var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--hash-mode", "invalid" });
+        Assert.NotNull(result);
+        Assert.Equal("invalid", result!.HashMode);
     }
 
     [Fact]

--- a/src/Zipper.Tests/DiskBackedFileDataListTests.cs
+++ b/src/Zipper.Tests/DiskBackedFileDataListTests.cs
@@ -107,6 +107,66 @@ public class DiskBackedFileDataListTests
     }
 
     [Fact]
+    public void RoundTrip_WithHashes_PreservesHashDictionary()
+    {
+        using var list = new DiskBackedFileDataList();
+
+        var originalData = new FileData
+        {
+            WorkItem = new FileWorkItem
+            {
+                Index = 1,
+                FolderNumber = 1,
+                FolderName = "folder_001",
+                FileName = "doc1.pdf",
+                FilePathInZip = "folder_001/doc1.pdf"
+            },
+            DataLength = 100,
+            PageCount = 1,
+            Hash = "md5hashvalue",
+            Hashes = new Dictionary<Config.HashAlgorithm, string>
+            {
+                [Config.HashAlgorithm.MD5] = "md5hashvalue",
+                [Config.HashAlgorithm.SHA1] = "sha1hashvalue",
+                [Config.HashAlgorithm.SHA256] = "sha256hashvalue",
+            },
+        };
+
+        list.Add(originalData);
+
+        var resultList = list.ToList();
+        var deserializedData = Assert.Single(resultList);
+
+        Assert.Equal(originalData.Hash, deserializedData.Hash);
+        Assert.NotNull(deserializedData.Hashes);
+        Assert.Equal(3, deserializedData.Hashes!.Count);
+        Assert.Equal("md5hashvalue", deserializedData.Hashes[Config.HashAlgorithm.MD5]);
+        Assert.Equal("sha1hashvalue", deserializedData.Hashes[Config.HashAlgorithm.SHA1]);
+        Assert.Equal("sha256hashvalue", deserializedData.Hashes[Config.HashAlgorithm.SHA256]);
+    }
+
+    [Fact]
+    public void RoundTrip_WithoutHashes_HashesIsNull()
+    {
+        using var list = new DiskBackedFileDataList();
+
+        var originalData = new FileData
+        {
+            WorkItem = new FileWorkItem { Index = 1 },
+            DataLength = 100,
+            Hash = "somehash",
+        };
+
+        list.Add(originalData);
+
+        var resultList = list.ToList();
+        var deserializedData = Assert.Single(resultList);
+
+        Assert.Equal("somehash", deserializedData.Hash);
+        Assert.Null(deserializedData.Hashes);
+    }
+
+    [Fact]
     public void Dispose_RemovesTempFile()
     {
         var list = new DiskBackedFileDataList();

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -93,6 +93,114 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
     }
 
     [Fact]
+#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
+    public async Task WriteAsync_WithHashModeActual_WritesAlgorithmSpecificHashAttributes()
+    {
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig { OutputPath = this.TempDir, FileCount = 1, FileType = "pdf" },
+            LoadFile = new LoadFileConfig { Encoding = "UTF-8" },
+            Metadata = new MetadataConfig { WithMetadata = false },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Actual,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5, Config.HashAlgorithm.SHA1, Config.HashAlgorithm.SHA256 },
+            },
+        };
+
+        var contentBytes = "test content"u8.ToArray();
+#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
+#pragma warning disable CA5350 // Weak cryptographic algorithm is used for e-discovery compat
+        var sha1Hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(contentBytes)).ToLowerInvariant();
+#pragma warning restore CA5350
+#pragma warning restore S4426
+        var sha256Hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(contentBytes)).ToLowerInvariant();
+
+        var files = new List<FileData>
+        {
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderNumber = 1,
+                    FileName = "doc1.pdf",
+                    FilePathInZip = "folder/doc1.pdf"
+                },
+                Data = contentBytes,
+                DataLength = contentBytes.Length,
+                Hash = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(contentBytes)).ToLowerInvariant(),
+                Hashes = new Dictionary<Config.HashAlgorithm, string>
+                {
+                    [Config.HashAlgorithm.MD5] = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(contentBytes)).ToLowerInvariant(),
+                    [Config.HashAlgorithm.SHA1] = sha1Hash,
+                    [Config.HashAlgorithm.SHA256] = sha256Hash,
+                },
+            }
+        };
+
+        var writer = new XmlLoadFileWriter();
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, request, files);
+
+        stream.Position = 0;
+        var doc = XDocument.Load(stream);
+        var nativeFile = doc.Root!.Element("Batch")!.Element("Document")!.Element("Files")!.Element("File")!.Element("ExternalFile");
+        Assert.NotNull(nativeFile);
+
+        Assert.Equal(sha1Hash, nativeFile.Attribute("Sha1Hash")?.Value);
+        Assert.Equal(sha256Hash, nativeFile.Attribute("Sha256Hash")?.Value);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WithHashModeMD5Only_DoesNotWriteExtraHashAttributes()
+    {
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig { OutputPath = this.TempDir, FileCount = 1, FileType = "pdf" },
+            LoadFile = new LoadFileConfig { Encoding = "UTF-8" },
+            Metadata = new MetadataConfig { WithMetadata = false },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Actual,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5 },
+            },
+        };
+
+        var files = new List<FileData>
+        {
+            new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = 1,
+                    FolderNumber = 1,
+                    FileName = "doc1.pdf",
+                    FilePathInZip = "folder/doc1.pdf"
+                },
+                DataLength = 500,
+                Hash = "abcdef1234567890",
+                Hashes = new Dictionary<Config.HashAlgorithm, string>
+                {
+                    [Config.HashAlgorithm.MD5] = "abcdef1234567890",
+                },
+            }
+        };
+
+        var writer = new XmlLoadFileWriter();
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, request, files);
+
+        stream.Position = 0;
+        var doc = XDocument.Load(stream);
+        var nativeFile = doc.Root!.Element("Batch")!.Element("Document")!.Element("Files")!.Element("File")!.Element("ExternalFile");
+        Assert.NotNull(nativeFile);
+
+        Assert.Null(nativeFile.Attribute("Sha1Hash"));
+        Assert.Null(nativeFile.Attribute("Sha256Hash"));
+    }
+
+    [Fact]
     public async Task XmlLoadFileWriter_WhenOperationCanceledException_Rethrows()
     {
         var request = this.CreateTestRequest();

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -641,6 +641,148 @@ public class ParallelFileGeneratorTests
     }
 
     [Fact]
+#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
+    public void GenerateFileData_WithHashModeActual_ComputesAllConfiguredHashes()
+    {
+        var generator = new ParallelFileGenerator();
+        var workItem = new FileWorkItem { Index = 1 };
+        const int paddingPerFile = 0;
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig
+            {
+                OutputPath = "dummy",
+                FileType = "docx",
+                FileCount = 1,
+            },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Actual,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5, Config.HashAlgorithm.SHA1, Config.HashAlgorithm.SHA256 },
+            },
+        };
+        var fileGenerator = new OfficeFileGenerator("docx");
+
+        var fileData = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+
+        try
+        {
+            Assert.NotNull(fileData.Hashes);
+            Assert.Equal(3, fileData.Hashes!.Count);
+            Assert.True(fileData.Hashes.ContainsKey(Config.HashAlgorithm.MD5));
+            Assert.True(fileData.Hashes.ContainsKey(Config.HashAlgorithm.SHA1));
+            Assert.True(fileData.Hashes.ContainsKey(Config.HashAlgorithm.SHA256));
+
+            // Verify each hash is a valid lowercase hex string of correct length
+            Assert.Equal(32, fileData.Hashes[Config.HashAlgorithm.MD5].Length);
+            Assert.Equal(40, fileData.Hashes[Config.HashAlgorithm.SHA1].Length);
+            Assert.Equal(64, fileData.Hashes[Config.HashAlgorithm.SHA256].Length);
+
+            // Verify MD5 is also set on the Hash property (backward compat)
+            Assert.Equal(fileData.Hashes[Config.HashAlgorithm.MD5], fileData.Hash);
+
+            // Verify hashes are actual hashes of the content bytes
+            var contentSpan = fileData.Data.Span;
+            var expectedMd5 = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(contentSpan)).ToLowerInvariant();
+#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
+#pragma warning disable CA5350 // Weak cryptographic algorithm is used for e-discovery compat
+            var expectedSha1 = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(contentSpan)).ToLowerInvariant();
+#pragma warning restore CA5350
+#pragma warning restore S4426
+            var expectedSha256 = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(contentSpan)).ToLowerInvariant();
+            Assert.Equal(expectedMd5, fileData.Hashes[Config.HashAlgorithm.MD5]);
+            Assert.Equal(expectedSha1, fileData.Hashes[Config.HashAlgorithm.SHA1]);
+            Assert.Equal(expectedSha256, fileData.Hashes[Config.HashAlgorithm.SHA256]);
+        }
+        finally
+        {
+            fileData.MemoryOwner?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GenerateFileData_WithHashModeNone_HashesIsNull()
+    {
+        var generator = new ParallelFileGenerator();
+        var workItem = new FileWorkItem { Index = 1 };
+        const int paddingPerFile = 0;
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig
+            {
+                OutputPath = "dummy",
+                FileType = "docx",
+                FileCount = 1,
+            },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.None,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5 },
+            },
+        };
+        var fileGenerator = new OfficeFileGenerator("docx");
+
+        var fileData = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+
+        try
+        {
+            Assert.Null(fileData.Hashes);
+            Assert.NotEmpty(fileData.Hash); // MD5 is still computed internally
+        }
+        finally
+        {
+            fileData.MemoryOwner?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GenerateFileData_WithHashModeSimulated_GeneratesDeterministicSimulatedHashes()
+    {
+        var generator = new ParallelFileGenerator();
+        var workItem = new FileWorkItem { Index = 1 };
+        const int paddingPerFile = 0;
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig
+            {
+                OutputPath = "dummy",
+                FileType = "docx",
+                FileCount = 1,
+            },
+            Metadata = new MetadataConfig { Seed = 42 },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Simulated,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5, Config.HashAlgorithm.SHA256 },
+            },
+        };
+        var fileGenerator = new OfficeFileGenerator("docx");
+
+        var fileData1 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+        var fileData2 = generator.GenerateFileData(workItem, paddingPerFile, request, fileGenerator);
+
+        try
+        {
+            Assert.NotNull(fileData1.Hashes);
+            Assert.NotNull(fileData2.Hashes);
+            Assert.Equal(fileData1.Hashes![Config.HashAlgorithm.MD5], fileData2.Hashes![Config.HashAlgorithm.MD5]);
+            Assert.Equal(fileData1.Hashes[Config.HashAlgorithm.SHA256], fileData2.Hashes[Config.HashAlgorithm.SHA256]);
+            Assert.Equal(32, fileData1.Hashes[Config.HashAlgorithm.MD5].Length);
+            Assert.Equal(64, fileData1.Hashes[Config.HashAlgorithm.SHA256].Length);
+
+            // Simulated hashes should NOT match actual content hashes
+            var contentSpan = fileData1.Data.Span;
+            var actualMd5 = Convert.ToHexString(System.Security.Cryptography.MD5.HashData(contentSpan)).ToLowerInvariant();
+            Assert.NotEqual(actualMd5, fileData1.Hashes[Config.HashAlgorithm.MD5]);
+        }
+        finally
+        {
+            fileData1.MemoryOwner?.Dispose();
+            fileData2.MemoryOwner?.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task GenerateFilesAsync_WithChaosModeAndNoLoadfileOnly_ThrowsInvalidOperationException()
     {
         var tempDir = Directory.GetCurrentDirectory();

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -641,9 +641,9 @@ public class ParallelFileGeneratorTests
     }
 
     [Fact]
-#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
     public void GenerateFileData_WithHashModeActual_ComputesAllConfiguredHashes()
     {
+#pragma warning disable S4426 // Weak cryptographic algorithms are tested for correctness
         var generator = new ParallelFileGenerator();
         var workItem = new FileWorkItem { Index = 1 };
         const int paddingPerFile = 0;
@@ -698,6 +698,7 @@ public class ParallelFileGeneratorTests
         {
             fileData.MemoryOwner?.Dispose();
         }
+#pragma warning restore S4426
     }
 
     [Fact]

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -387,4 +387,16 @@ public class RequestBuilderTests
         Assert.Equal(Config.HashMode.None, config.Mode);
         Assert.Empty(config.Algorithms);
     }
+
+    [Fact]
+    public void Build_LoadfileOnlyWithActualHashMode_ReturnsNull()
+    {
+        var parsed = CreateParsedArgs();
+        parsed.LoadfileOnly = true;
+        parsed.HashMode = "actual";
+        parsed.HashAlgorithms = "md5";
+
+        var result = RequestBuilder.Build(parsed);
+        Assert.Null(result);
+    }
 }

--- a/src/Zipper.Tests/RequestBuilderTests.cs
+++ b/src/Zipper.Tests/RequestBuilderTests.cs
@@ -293,4 +293,98 @@ public class RequestBuilderTests
     {
         Assert.Throws<ArgumentException>(() => RequestBuilder.ParseStrictDelimiter("20"));
     }
+
+    [Fact]
+    public void Build_HashModeActualAndAlgorithms_SetsHashConfig()
+    {
+        var parsed = CreateParsedArgs();
+        parsed.HashMode = "actual";
+        parsed.HashAlgorithms = "md5,sha256";
+
+        var result = RequestBuilder.Build(parsed);
+        Assert.NotNull(result);
+
+        var hash = result!.Hash;
+        Assert.Equal(Config.HashMode.Actual, hash.Mode);
+        Assert.Contains(Config.HashAlgorithm.MD5, hash.Algorithms);
+        Assert.Contains(Config.HashAlgorithm.SHA256, hash.Algorithms);
+        Assert.DoesNotContain(Config.HashAlgorithm.SHA1, hash.Algorithms);
+        Assert.True(hash.IsEnabled);
+    }
+
+    [Fact]
+    public void Build_HashModeSimulated_SetsSimulatedMode()
+    {
+        var parsed = CreateParsedArgs();
+        parsed.HashMode = "simulated";
+        parsed.HashAlgorithms = "sha1";
+
+        var result = RequestBuilder.Build(parsed);
+        Assert.NotNull(result);
+
+        var hash = result!.Hash;
+        Assert.Equal(Config.HashMode.Simulated, hash.Mode);
+        Assert.Contains(Config.HashAlgorithm.SHA1, hash.Algorithms);
+        Assert.True(hash.IsEnabled);
+    }
+
+    [Fact]
+    public void Build_HashModeNone_DefaultsToDisabled()
+    {
+        var parsed = CreateParsedArgs();
+
+        var result = RequestBuilder.Build(parsed);
+        Assert.NotNull(result);
+
+        var hash = result!.Hash;
+        Assert.Equal(Config.HashMode.None, hash.Mode);
+        Assert.Empty(hash.Algorithms);
+        Assert.False(hash.IsEnabled);
+    }
+
+    [Fact]
+    public void ParseHashConfig_ActualMode_ReturnsCorrectConfig()
+    {
+        var parsed = new ParsedArguments
+        {
+            HashMode = "actual",
+            HashAlgorithms = "md5,sha1,sha256",
+        };
+
+        var config = RequestBuilder.ParseHashConfig(parsed);
+        Assert.Equal(Config.HashMode.Actual, config.Mode);
+        Assert.Equal(3, config.Algorithms.Count);
+        Assert.Contains(Config.HashAlgorithm.MD5, config.Algorithms);
+        Assert.Contains(Config.HashAlgorithm.SHA1, config.Algorithms);
+        Assert.Contains(Config.HashAlgorithm.SHA256, config.Algorithms);
+    }
+
+    [Fact]
+    public void ParseHashConfig_SimulatedMode_ReturnsSimulatedMode()
+    {
+        var parsed = new ParsedArguments { HashMode = "simulated" };
+
+        var config = RequestBuilder.ParseHashConfig(parsed);
+        Assert.Equal(Config.HashMode.Simulated, config.Mode);
+        Assert.Empty(config.Algorithms);
+    }
+
+    [Fact]
+    public void ParseHashConfig_InvalidMode_DefaultsToNone()
+    {
+        var parsed = new ParsedArguments { HashMode = "invalid" };
+
+        var config = RequestBuilder.ParseHashConfig(parsed);
+        Assert.Equal(Config.HashMode.None, config.Mode);
+    }
+
+    [Fact]
+    public void ParseHashConfig_Default_NoneModeEmptyAlgorithms()
+    {
+        var parsed = new ParsedArguments();
+
+        var config = RequestBuilder.ParseHashConfig(parsed);
+        Assert.Equal(Config.HashMode.None, config.Mode);
+        Assert.Empty(config.Algorithms);
+    }
 }


### PR DESCRIPTION
## Description

Add `--hash-mode` (None/Actual/Simulated) and `--hash-algorithms` CLI flags to produce hash columns in load files and XML attributes. Actual hashes use stdlib crypto (MD5/SHA1/SHA256). Simulated hashes use seeded Random for Load File-Only mode.

Hash fields are only emitted when explicitly enabled — default is None, fully backward compatible.

## Changes

- **CLI:** Added `--hash-mode`, `--hash-algorithms` flags (src/Cli/CliParser.cs, ParsedArguments.cs, RequestBuilder.cs)
- **Config:** New `HashConfig` record + `HashMode`/HashAlgorithm enums (src/Config/HashConfig.cs)
- **File Data:** New optional `Hashes` dictionary on FileData record, serialized by DiskBackedFileDataList
- **Standard Mode (ParallelFileGenerator):** Computes actual hashes from file bytes (ReadOnlySpan`1); simulated mode uses seeded Random
- **Production Set Mode (ProductionSetGenerator):** Computes actual hashes from byte content
- **Load File-Only Mode (DatComposer):** Simulated hashes via seeded Random; skipped for Actual mode (no file bytes available)
- **Load File Writers:** DAT/OPT/CSV/Concordance (StandardRowComposer, DatComposer) emit MD5HASH/SHA1HASH/SHA256HASH columns when enabled; EDRM-XML (XmlLoadFileWriter) emits Sha1Hash/Sha256Hash attributes
- **Tests:** 17 new tests across CLI parsing, config parsing, hash computation, XML output, and serialization round-trip (1226 total, all passing)

## Verifications

- Build: 0 errors, 0 warnings
- Format: clean
- Unit tests: 1226 passed
- E2E: 6/6 basic smoke tests passed
- Goldens: 13/13 regression scenarios passed

## Architecture

- Minimum code per Ponytail principle: stdlib `MD5.HashData`/`SHA1.HashData`/`SHA256.HashData` for actual computation
- Seeded Random for deterministic simulated hashes (compatible with existing seed-based generation)
- Backward compatible: no output changes when `--hash-mode` not specified

Closes #570

## Release Notes

Added configurable hash generation for native files. Two new CLI flags — `--hash-mode` (None, Actual, Simulated) and `--hash-algorithms` (comma-separated md5, sha1, sha256) — produce hash columns in load file formats and hash attributes in EDRM-XML output. Simulated mode uses a seeded random generator for Load File-Only scenarios where actual file bytes are not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable hashing from the command line, including choosing hash mode and one or more hash algorithms.
  * Generated output can now include multiple hash values, with support for both real and simulated hashes.
  * XML output now includes additional hash attributes when available.

* **Bug Fixes**
  * Improved validation for hash-related command-line options, with clear errors when required values are missing.
  * Preserved hash data during save/load round trips and request cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->