### PR TITLE
fix: complete post-generation load file validation

### DIFF
--- a/src/LoadFileOnlyMode.cs
+++ b/src/LoadFileOnlyMode.cs
@@ -90,7 +90,15 @@ internal class LoadFileOnlyMode : IGenerationMode
                 _ => null
             };
             var runner = new ValidatorRunner();
-            var vr = runner.ValidateLoadFile(fileForFormat, formatName, null, eol);
+            var vr = runner.ValidateLoadFile(
+                fileForFormat,
+                formatName,
+                null,
+                eol,
+                bates: request.Bates,
+                encoding: EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding),
+                columnDelimiter: request.Delimiters.GetColumnChar(),
+                quoteDelimiter: request.Delimiters.GetQuoteChar());
             if (vr.HasErrors || vr.HasWarnings)
             {
                 Console.Error.WriteLine(vr.GetSummary());

--- a/src/ProductionSetMode.cs
+++ b/src/ProductionSetMode.cs
@@ -57,7 +57,15 @@ internal class ProductionSetMode : IGenerationMode
         if (!string.IsNullOrEmpty(result.DatFilePath) && File.Exists(result.DatFilePath))
         {
             var runner = new ValidatorRunner();
-            var vr = runner.ValidateLoadFile(result.DatFilePath, "concordance", null, eol);
+            var vr = runner.ValidateLoadFile(
+                result.DatFilePath,
+                "concordance",
+                null,
+                eol,
+                bates: request.Bates,
+                encoding: EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding),
+                columnDelimiter: request.Delimiters.GetColumnChar(),
+                quoteDelimiter: request.Delimiters.GetQuoteChar());
             if (vr.HasErrors || vr.HasWarnings)
             {
                 Console.Error.WriteLine(vr.GetSummary());
@@ -69,7 +77,12 @@ internal class ProductionSetMode : IGenerationMode
         if (!string.IsNullOrEmpty(result.OptFilePath) && File.Exists(result.OptFilePath))
         {
             var runner = new ValidatorRunner();
-            var vr = runner.ValidateLoadFile(result.OptFilePath, "opt", null, eol);
+            var vr = runner.ValidateLoadFile(
+                result.OptFilePath,
+                "opt",
+                null,
+                eol,
+                encoding: EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding));
             if (vr.HasErrors || vr.HasWarnings)
             {
                 Console.Error.WriteLine(vr.GetSummary());

--- a/src/StandardMode.cs
+++ b/src/StandardMode.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Zipper.Validation;
 
 namespace Zipper;
@@ -86,30 +87,70 @@ internal class StandardMode : IGenerationMode
 
         if (!string.IsNullOrEmpty(result.LoadFilePath))
         {
-            ValidateGeneratedLoadFile(result.LoadFilePath, request);
+            ValidateGeneratedLoadFile(result, request);
         }
     }
 
-    private static void ValidateGeneratedLoadFile(string loadFilePath, FileGenerationRequest request)
+    private static void ValidateGeneratedLoadFile(FileGenerationResult result, FileGenerationRequest request)
     {
-        if (!File.Exists(loadFilePath)) return;
-        var format = request.LoadFile.Formats.Count > 0 ? request.LoadFile.Formats[0] : LoadFileFormat.Dat;
-        var formatName = format switch
-        {
-            LoadFileFormat.Opt => "opt",
-            LoadFileFormat.Csv => "csv",
-            LoadFileFormat.Concordance => "concordance",
-            _ => "dat"
-        };
         // ponytail: StandardMode uses Environment.NewLine regardless of --eol config,
         // so skip EOL validation here. Only LoadFileOnlyMode/ProductionSetMode respect --eol.
         var runner = new ValidatorRunner();
-        var vr = runner.ValidateLoadFile(loadFilePath, formatName, null, null);
-        if (vr.HasErrors || vr.HasWarnings)
+        using var archive = ZipFile.OpenRead(result.ZipFilePath);
+        var entryPaths = archive.Entries.Select(entry => entry.FullName).ToArray();
+        var validation = new ValidationResult();
+        var baseName = Path.GetFileNameWithoutExtension(result.LoadFilePath);
+        var directory = Path.GetDirectoryName(result.LoadFilePath) ?? string.Empty;
+
+        foreach (var format in GetDistinctFormats(request.LoadFile.Formats))
         {
-            Console.Error.WriteLine(vr.GetSummary());
-            if (vr.HasErrors)
+            if (format == LoadFileFormat.EdrmXml)
+                continue;
+
+            var fileName = baseName + GetExtension(format);
+            ValidationResult current;
+            if (request.Output.IncludeLoadFile)
+            {
+                var entry = archive.GetEntry(fileName)
+                    ?? throw new InvalidOperationException($"Generated load file '{fileName}' is missing from the Archive.");
+                using var reader = new StreamReader(entry.Open(), EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding), detectEncodingFromByteOrderMarks: true);
+                current = runner.ValidateLoadFile(reader, entry.FullName, GetFormatName(format), null, entryPaths, request.Bates, request.Delimiters.GetColumnChar(), request.Delimiters.GetQuoteChar());
+            }
+            else
+            {
+                var loadFilePath = Path.Combine(directory, fileName);
+                current = runner.ValidateLoadFile(loadFilePath, GetFormatName(format), null, null, entryPaths, request.Bates, EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding), request.Delimiters.GetColumnChar(), request.Delimiters.GetQuoteChar());
+            }
+
+            validation.AddRange(current.Findings);
+        }
+
+        if (validation.HasErrors || validation.HasWarnings)
+        {
+            Console.Error.WriteLine(validation.GetSummary());
+            if (validation.HasErrors)
                 throw new InvalidOperationException("Post-generation validation failed.");
         }
     }
+
+    private static IEnumerable<LoadFileFormat> GetDistinctFormats(IReadOnlyList<LoadFileFormat> formats)
+        => (formats.Count > 0 ? formats : [LoadFileFormat.Dat])
+            .GroupBy(GetExtension)
+            .Select(group => group.Last());
+
+    private static string GetFormatName(LoadFileFormat format) => format switch
+    {
+        LoadFileFormat.Opt => "opt",
+        LoadFileFormat.Csv => "csv",
+        LoadFileFormat.Concordance => "concordance",
+        _ => "dat",
+    };
+
+    private static string GetExtension(LoadFileFormat format) => format switch
+    {
+        LoadFileFormat.Opt => ".opt",
+        LoadFileFormat.Csv => ".csv",
+        LoadFileFormat.EdrmXml => ".xml",
+        _ => ".dat",
+    };
 }

--- a/src/Validation/ValidatorRunner.cs
+++ b/src/Validation/ValidatorRunner.cs
@@ -106,6 +106,16 @@ public sealed class ValidatorRunner
             ValidateRecord(columns, fields, ids, expectedPathSet, expectedSidecarSet, bates, ref previousBates, loadFilePath, lineNumber, result);
         }
 
+        if (normalizedFormat == "csv" && csvRecord.Length > 0)
+        {
+            result.Add(new ValidationFinding(
+                ValidationSeverity.Error,
+                "MalformedCsv",
+                "Unclosed quote at the end of the CSV file.",
+                loadFilePath,
+                lineNumber));
+        }
+
         return result;
     }
 
@@ -206,9 +216,9 @@ public sealed class ValidatorRunner
             !long.TryParse(value[bates.Prefix.Length..], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var current))
             return;
 
-        if (previousBates.HasValue && current != previousBates.Value + 1)
+        if (previousBates.HasValue && current != previousBates.Value + bates.Increment)
         {
-            var expected = bates.Prefix + (previousBates.Value + 1).ToString($"D{bates.Digits}", System.Globalization.CultureInfo.InvariantCulture);
+            var expected = bates.Prefix + (previousBates.Value + bates.Increment).ToString($"D{bates.Digits}", System.Globalization.CultureInfo.InvariantCulture);
             result.Add(new ValidationFinding(ValidationSeverity.Error, "BatesContinuity", $"Expected Bates number {expected}, got '{value}'", loadFilePath, lineNumber));
         }
 

--- a/src/Validation/ValidatorRunner.cs
+++ b/src/Validation/ValidatorRunner.cs
@@ -1,41 +1,298 @@
+using System.Text;
+using Zipper.Config;
+
 namespace Zipper.Validation;
 
 public sealed class ValidatorRunner
 {
-    public ValidationResult ValidateLoadFile(string loadFilePath, string format, IReadOnlyList<string>? headerColumns, string? expectedEol)
+    public ValidationResult ValidateLoadFile(
+        string loadFilePath,
+        string format,
+        IReadOnlyList<string>? headerColumns,
+        string? expectedEol,
+        IEnumerable<string>? expectedPaths = null,
+        BatesNumberConfig? bates = null,
+        Encoding? encoding = null,
+        char columnDelimiter = '\x14',
+        char quoteDelimiter = '\xfe')
     {
         ArgumentNullException.ThrowIfNull(loadFilePath);
-        ArgumentNullException.ThrowIfNull(format);
-        var result = new ValidationResult();
-        var content = File.ReadAllText(loadFilePath);
-
-        if (format.Equals("opt", StringComparison.OrdinalIgnoreCase))
-        {
-            new OptBoundaryValidator().Validate(content, loadFilePath, result);
-        }
-
-        var colValidator = new ColumnCountValidator();
-        if (format.Equals("concordance", StringComparison.OrdinalIgnoreCase))
-        {
-            colValidator.ValidateConcordance(content, '\x14', loadFilePath, result);
-        }
-        else if (headerColumns is { Count: > 0 })
-        {
-            if (format.Equals("csv", StringComparison.OrdinalIgnoreCase))
-            {
-                colValidator.ValidateCsv(content, headerColumns.Count, loadFilePath, result);
-            }
-            else if (format.Equals("dat", StringComparison.OrdinalIgnoreCase))
-            {
-                colValidator.ValidateDat(content, headerColumns.Count, '\x14', loadFilePath, result);
-            }
-        }
+        var result = ValidateLines(File.ReadLines(loadFilePath, encoding ?? Encoding.UTF8), loadFilePath, format, headerColumns, expectedPaths, bates, columnDelimiter, quoteDelimiter);
 
         if (!string.IsNullOrEmpty(expectedEol))
+            ValidateLineEndings(loadFilePath, expectedEol, encoding ?? Encoding.UTF8, result);
+
+        return result;
+    }
+
+    public ValidationResult ValidateLoadFile(
+        TextReader reader,
+        string displayPath,
+        string format,
+        IReadOnlyList<string>? headerColumns,
+        IEnumerable<string>? expectedPaths = null,
+        BatesNumberConfig? bates = null,
+        char columnDelimiter = '\x14',
+        char quoteDelimiter = '\xfe')
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(displayPath);
+        return ValidateLines(ReadLines(reader), displayPath, format, headerColumns, expectedPaths, bates, columnDelimiter, quoteDelimiter);
+    }
+
+    private static ValidationResult ValidateLines(
+        IEnumerable<string> lines,
+        string loadFilePath,
+        string format,
+        IReadOnlyList<string>? headerColumns,
+        IEnumerable<string>? expectedPaths,
+        BatesNumberConfig? bates,
+        char columnDelimiter,
+        char quoteDelimiter)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        var result = new ValidationResult();
+        var normalizedFormat = format.ToLowerInvariant();
+        var columns = headerColumns;
+        var ids = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var expectedPathSet = expectedPaths is null ? null : new HashSet<string>(expectedPaths, StringComparer.OrdinalIgnoreCase);
+        var expectedSidecarSet = expectedPathSet?.Select(GetSidecarKey).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        long? previousBates = null;
+        long lineNumber = 0;
+        var csvRecord = new StringBuilder();
+
+        foreach (var line in lines)
         {
-            new LineEndingValidator().Validate(content, expectedEol, loadFilePath, result);
+            lineNumber++;
+            var record = line;
+            if (normalizedFormat == "csv")
+            {
+                if (csvRecord.Length > 0)
+                    csvRecord.Append('\n');
+                csvRecord.Append(line);
+                if (HasOpenCsvQuote(csvRecord))
+                    continue;
+                record = csvRecord.ToString();
+                csvRecord.Clear();
+            }
+
+            if (record.Length == 0)
+                continue;
+
+            if (normalizedFormat == "opt")
+            {
+                ValidateOptLine(record, loadFilePath, lineNumber, result);
+                continue;
+            }
+
+            var fields = SplitFields(record, normalizedFormat, columnDelimiter, quoteDelimiter);
+            if (columns is null)
+            {
+                columns = fields;
+                continue;
+            }
+
+            if (fields.Count != columns.Count)
+            {
+                result.Add(new ValidationFinding(
+                    ValidationSeverity.Error,
+                    "ColumnCount",
+                    $"Expected {columns.Count} columns, got {fields.Count} on line {lineNumber}",
+                    loadFilePath,
+                    lineNumber));
+                continue;
+            }
+
+            ValidateRecord(columns, fields, ids, expectedPathSet, expectedSidecarSet, bates, ref previousBates, loadFilePath, lineNumber, result);
         }
 
         return result;
+    }
+
+    private static bool HasOpenCsvQuote(StringBuilder record)
+    {
+        bool quoted = false;
+        for (int i = 0; i < record.Length; i++)
+        {
+            if (record[i] != '"')
+                continue;
+
+            if (quoted && i + 1 < record.Length && record[i + 1] == '"')
+            {
+                i++;
+                continue;
+            }
+
+            quoted = !quoted;
+        }
+
+        return quoted;
+    }
+
+    private static IEnumerable<string> ReadLines(TextReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+            yield return line;
+    }
+
+    private static void ValidateRecord(
+        IReadOnlyList<string> columns,
+        IReadOnlyList<string> fields,
+        Dictionary<string, HashSet<string>> ids,
+        HashSet<string>? expectedPathSet,
+        HashSet<string>? expectedSidecarSet,
+        BatesNumberConfig? bates,
+        ref long? previousBates,
+        string loadFilePath,
+        long lineNumber,
+        ValidationResult result)
+    {
+        for (int i = 0; i < columns.Count; i++)
+        {
+            var column = NormalizeColumn(columns[i]);
+            var value = fields[i];
+            if (value.Length == 0)
+                continue;
+
+            if (column is "CONTROLNUMBER" or "DOCID" or "BATESNUMBER" or "BATES")
+            {
+                if (!ids.TryGetValue(column, out var seen))
+                {
+                    seen = new HashSet<string>(StringComparer.Ordinal);
+                    ids[column] = seen;
+                }
+
+                if (!seen.Add(value))
+                {
+                    result.Add(new ValidationFinding(ValidationSeverity.Error, "UniqueId", $"Duplicate {columns[i]}: '{value}'", loadFilePath, lineNumber));
+                }
+
+                if (bates is not null && (column is "BATESNUMBER" or "BATES"))
+                    ValidateBates(value, bates, ref previousBates, loadFilePath, lineNumber, result);
+            }
+
+            if (column is "FILEPATH" or "PATH" or "NATIVEPATH" or "TEXTPATH" or "IMAGEPATH")
+                ValidatePath(value, expectedPathSet, expectedSidecarSet, loadFilePath, lineNumber, result);
+        }
+    }
+
+    private static void ValidatePath(string value, HashSet<string>? expectedPathSet, HashSet<string>? expectedSidecarSet, string loadFilePath, long lineNumber, ValidationResult result)
+    {
+        if (expectedPathSet is null)
+            return;
+
+        var normalized = value.Replace('\\', '/');
+        if (expectedPathSet.Contains(normalized))
+            return;
+
+        if (expectedSidecarSet!.Contains(GetSidecarKey(normalized)))
+            return;
+
+        result.Add(new ValidationFinding(
+            ValidationSeverity.Error,
+            "PathReconciliation",
+            $"Load file path '{value}' does not resolve to any archive entry or sidecar file.",
+            loadFilePath,
+            lineNumber));
+    }
+
+    private static string GetSidecarKey(string path)
+        => $"{Path.GetDirectoryName(path)?.Replace('\\', '/') ?? string.Empty}|{Path.GetFileNameWithoutExtension(path)}";
+
+    private static void ValidateBates(string value, BatesNumberConfig bates, ref long? previousBates, string loadFilePath, long lineNumber, ValidationResult result)
+    {
+        if (!value.StartsWith(bates.Prefix, StringComparison.Ordinal) ||
+            !long.TryParse(value[bates.Prefix.Length..], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var current))
+            return;
+
+        if (previousBates.HasValue && current != previousBates.Value + 1)
+        {
+            var expected = bates.Prefix + (previousBates.Value + 1).ToString($"D{bates.Digits}", System.Globalization.CultureInfo.InvariantCulture);
+            result.Add(new ValidationFinding(ValidationSeverity.Error, "BatesContinuity", $"Expected Bates number {expected}, got '{value}'", loadFilePath, lineNumber));
+        }
+
+        previousBates = current;
+    }
+
+    private static void ValidateOptLine(string line, string loadFilePath, long lineNumber, ValidationResult result)
+    {
+        int count = line.Count(c => c == ',') + 1;
+        if (count != 7)
+            result.Add(new ValidationFinding(ValidationSeverity.Error, "OptBoundary", $"OPT line {lineNumber} has {count} columns, expected 7", loadFilePath, lineNumber));
+    }
+
+    private static IReadOnlyList<string> SplitFields(string line, string format, char columnDelimiter, char quoteDelimiter)
+    {
+        char delimiter = format == "csv" ? ',' : columnDelimiter;
+        char quote = format == "csv" ? '"' : quoteDelimiter;
+        var fields = new List<string>();
+        var field = new StringBuilder();
+        bool quoted = false;
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            var current = line[i];
+            if (current == quote)
+            {
+                if (quoted && i + 1 < line.Length && line[i + 1] == quote)
+                {
+                    field.Append(quote);
+                    i++;
+                }
+                else
+                {
+                    quoted = !quoted;
+                }
+            }
+            else if (current == delimiter && !quoted)
+            {
+                fields.Add(field.ToString());
+                field.Clear();
+            }
+            else
+            {
+                field.Append(current);
+            }
+        }
+
+        fields.Add(field.ToString());
+        return fields;
+    }
+
+    private static string NormalizeColumn(string column)
+        => new string(column.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
+
+    private static void ValidateLineEndings(string loadFilePath, string expectedEol, Encoding encoding, ValidationResult result)
+    {
+        using var reader = new StreamReader(loadFilePath, encoding, detectEncodingFromByteOrderMarks: true);
+        int current;
+        long lineNumber = 1;
+        while ((current = reader.Read()) != -1)
+        {
+            if (current == '\r')
+            {
+                if (reader.Peek() == '\n')
+                {
+                    reader.Read();
+                    if (expectedEol != "\r\n")
+                        break;
+                }
+                else if (expectedEol != "\r")
+                {
+                    break;
+                }
+                lineNumber++;
+            }
+            else if (current == '\n')
+            {
+                if (expectedEol != "\n")
+                    break;
+                lineNumber++;
+            }
+        }
+
+        if (current != -1)
+            result.Add(new ValidationFinding(ValidationSeverity.Error, "LineEnding", $"Inconsistent line ending on or before line {lineNumber}.", loadFilePath, lineNumber));
     }
 }

--- a/src/Zipper.Tests/PostGenerationValidatorTests.cs
+++ b/src/Zipper.Tests/PostGenerationValidatorTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Zipper.Config;
 using Zipper.Validation;
 
 namespace Zipper.Tests;
@@ -219,6 +220,50 @@ public class PostGenerationValidatorTests
             var result = runner.ValidateLoadFile(loadFilePath, "csv", new[] { "col1", "col2", "col3" }, null);
 
             Assert.NotNull(result);
+        }
+        finally
+        {
+            File.Delete(loadFilePath);
+        }
+    }
+
+    [Fact]
+    public void ValidateLoadFile_WithDuplicateIdentifierAndMissingPath_ReportsBothFindings()
+    {
+        var loadFilePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(loadFilePath, "Control Number,File Path,Bates Number\nDOC001,folder/one.pdf,ABC0001\nDOC001,folder/missing.pdf,ABC0003\n");
+
+            var result = new ValidatorRunner().ValidateLoadFile(
+                loadFilePath,
+                "csv",
+                null,
+                null,
+                new[] { "folder/one.pdf" },
+                new BatesNumberConfig { Prefix = "ABC", Start = 1, Digits = 4 });
+
+            Assert.Contains(result.Findings, finding => finding.Category == "UniqueId");
+            Assert.Contains(result.Findings, finding => finding.Category == "PathReconciliation");
+            Assert.Contains(result.Findings, finding => finding.Category == "BatesContinuity");
+        }
+        finally
+        {
+            File.Delete(loadFilePath);
+        }
+    }
+
+    [Fact]
+    public void ValidateLoadFile_WithQuotedCsvNewline_DoesNotReportColumnCountError()
+    {
+        var loadFilePath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(loadFilePath, "Control Number,Note\nDOC001,\"first line\nsecond line\"\n");
+
+            var result = new ValidatorRunner().ValidateLoadFile(loadFilePath, "csv", null, null);
+
+            Assert.DoesNotContain(result.Findings, finding => finding.Category == "ColumnCount");
         }
         finally
         {


### PR DESCRIPTION
## Summary

Completes the shared post-generation validation path for delimited Load Files. Validation now streams records, checks column counts, duplicate identifiers, Bates continuity, configured delimiters, and Archive path reconciliation across Standard, Loadfile-Only, and Production Set modes.

## Validation

- `dotnet build zipper.sln`
- `dotnet format --verify-no-changes src/`
- `dotnet test src/Zipper.Tests/Zipper.Tests.csproj`
- `dotnet build -c Release zipper.sln`
- `./tests/run-tests.sh` basic smoke and feature suites (terminal session ended before final suite summary)

## Release Notes

Load File validation now streams generated delimited output and detects malformed records, duplicate identifiers, Bates gaps, and unresolved Archive paths before reporting success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced load-file validation for CSV, OPT, and other supported formats.
  * Validates multiple generated formats, including files inside ZIP archives.
  * Supports configured encoding, delimiters, quoted fields, expected paths, and Bates continuity.
  * Reports validation findings across duplicate IDs, missing paths, column counts, and inconsistent line endings.

* **Bug Fixes**
  * Correctly handles CSV fields containing embedded newlines.
  * Detects and reports multiple validation issues in a single load file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->