### PR TITLE
fix: skip MD5 hash when not requested in output

### DIFF
--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -317,11 +317,10 @@ public class ParallelFileGenerator
                 }
             }
 
-#pragma warning disable S4790 // Cryptographic algorithms should be robust
-            var hashBytes = MD5.HashData(data);
-#pragma warning restore S4790
-            var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
             var hashes = ComputeHashes(data, workItem, request);
+            var hash = hashes is not null && hashes.TryGetValue(Config.HashAlgorithm.MD5, out var md5Hash)
+                ? md5Hash
+                : string.Empty;
 
             return new FileData
             {
@@ -356,11 +355,10 @@ public class ParallelFileGenerator
             }
 
             var finalMemory = memoryOwner.Memory[..(int)totalSize];
-#pragma warning disable S4790 // Cryptographic algorithms should be robust
-            var finalHashBytes = MD5.HashData(finalMemory.Span);
-#pragma warning restore S4790
-            var finalHash = Convert.ToHexString(finalHashBytes).ToLowerInvariant();
             var hashes = ComputeHashes(finalMemory.Span, workItem, request);
+            var finalHash = hashes is not null && hashes.TryGetValue(Config.HashAlgorithm.MD5, out var md5Hash)
+                ? md5Hash
+                : string.Empty;
 
             return new FileData
             {

--- a/src/Zipper.Tests/ParallelFileGeneratorTests.cs
+++ b/src/Zipper.Tests/ParallelFileGeneratorTests.cs
@@ -584,6 +584,11 @@ public class ParallelFileGeneratorTests
                 FileType = "docx",
                 FileCount = 1,
             },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Actual,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5 },
+            },
             Metadata = new MetadataConfig
             {
                 Seed = 42
@@ -618,6 +623,11 @@ public class ParallelFileGeneratorTests
                 OutputPath = "dummy",
                 FileType = "docx",
                 FileCount = 1,
+            },
+            Hash = new HashConfig
+            {
+                Mode = HashMode.Actual,
+                Algorithms = new HashSet<Config.HashAlgorithm> { Config.HashAlgorithm.MD5 },
             },
             Metadata = new MetadataConfig
             {
@@ -728,7 +738,7 @@ public class ParallelFileGeneratorTests
         try
         {
             Assert.Null(fileData.Hashes);
-            Assert.NotEmpty(fileData.Hash); // MD5 is still computed internally
+            Assert.Empty(fileData.Hash); // ponytail: hash skipped when not requested
         }
         finally
         {


### PR DESCRIPTION
## Release Notes

Skip standalone MD5 hash computation when hashes are not requested in output, saving O(file_size) per generated file on the hot path.

## What changed

- Guard MD5.HashData calls with request.Hash.IsEnabled in both pooled and unpooled paths of ParallelFileGenerator.GenerateFileData
- When hash not requested, FileData.Hash is set to string.Empty (safe for DiskBackedFileDataList serialization)
- Update seed+target-zip-size tests to explicitly enable HashConfig so they actually test deterministic hash behavior
- Flip HashModeNone test to assert empty Hash when not requested

## Why

MD5 was computed unconditionally on every generated file regardless of whether hashes appeared in load file output. For workloads with many large files (e.g., 50K PDFs), this added measurable overhead on the hot path.

## Closes #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled hashing now correctly produces an empty hash value instead of calculating an MD5 hash.
  * Hash generation remains consistent across pooled and non-pooled file processing paths.
  * Multi-algorithm hash results continue to be omitted when hashing is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->