### PR TITLE
feat: add redacted Production mode with withheld Native File handling (#575)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--rolling-bates-mode` | continuous | `continuous` or `restart` | Bates numbering mode across rolling production sets |
 | `--production-zip` | false | flag | Wrap production set output in an Archive |
 | `--volume-size` | 5000 | number | Max files per volume subfolder |
-| `--redacted-production` | false | flag | Enable redacted Production mode with REDACTED/IMAGES and REDACTED/TEXT directories |
+| `--redacted-production` | false | flag | Enable redacted Production mode with REDACTED/IMAGES and REDACTED/TEXT directories. Text placeholders require `--with-text`. |
 | `--withheld-native-policy` | keep-native | `keep-native`, `omit-native-path`, `replace-with-placeholder` | How to handle withheld Native File paths in redacted mode |
 | `--supplemental-production` | false | flag | Enable supplemental production set generation mode |
 | `--prior-manifest` | none | paths | Comma-separated list of paths to prior production manifest files |
@@ -276,7 +276,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
 | `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
-| `--redacted-production` | Requires `--production-set`; conflicts with `--loadfile-only` |
+| `--redacted-production` | Requires `--production-set`; conflicts with `--loadfile-only`. Redacted text files are only written when `--with-text` is enabled; without it, `REDACTED_TEXT_PATH` is empty in the Load File. |
 | `--withheld-native-policy` | Requires `--redacted-production` |
 | `--production-set` + `--load-file-format / --load-file-formats` | Ignored. Production Set always generates DAT+OPT regardless. |
 | `--production-zip`, `--volume-size` | Require `--production-set` |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Zipper is a .NET command-line tool for generating large Archives containing Nati
 - Real-time performance monitoring with progress tracking, throughput metrics, and ETA calculations
 - **Loadfile-Only mode**: Generate standalone Load Files (DAT/OPT) without Archives or Native Files
 - **Chaos Engine**: Inject deliberate structural anomalies into Load Files for ingestion resilience testing
+- **Redacted Production Mode**: Generate redacted image/text placeholders with configurable Native File withholding
 
 ## Requirements
 
@@ -44,7 +45,7 @@ After building the project, you can run the executable directly. The examples be
 ### Basic Usage
 
 ```bash
-zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>] [--chaos-scenario <name>] [--production-set] [--production-zip] [--volume-size <number>] [--supplemental-production] [--prior-manifest <paths>] [--supplemental-gap-policy <reject|allow>] [--benchmark] [--chaos-list] [--compare-production-manifests <paths>] [--comparison-mode <mode>] [--comparison-output <path>]
+zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>] [--chaos-scenario <name>] [--production-set] [--production-zip] [--volume-size <number>] [--redacted-production] [--withheld-native-policy <keep-native|omit-native-path|replace-with-placeholder>] [--supplemental-production] [--prior-manifest <paths>] [--supplemental-gap-policy <reject|allow>] [--benchmark] [--chaos-list] [--compare-production-manifests <paths>] [--comparison-mode <mode>] [--comparison-output <path>]
 ```
 
 ### Arguments
@@ -237,6 +238,8 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--rolling-bates-mode` | continuous | `continuous` or `restart` | Bates numbering mode across rolling production sets |
 | `--production-zip` | false | flag | Wrap production set output in an Archive |
 | `--volume-size` | 5000 | number | Max files per volume subfolder |
+| `--redacted-production` | false | flag | Enable redacted Production mode with REDACTED/IMAGES and REDACTED/TEXT directories |
+| `--withheld-native-policy` | keep-native | `keep-native`, `omit-native-path`, `replace-with-placeholder` | How to handle withheld Native File paths in redacted mode |
 | `--supplemental-production` | false | flag | Enable supplemental production set generation mode |
 | `--prior-manifest` | none | paths | Comma-separated list of paths to prior production manifest files |
 | `--supplemental-gap-policy` | reject | reject, allow | Gap policy for supplemental mode: reject or allow |
@@ -273,6 +276,8 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
 | `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
+| `--redacted-production` | Requires `--production-set`; conflicts with `--loadfile-only` |
+| `--withheld-native-policy` | Requires `--redacted-production` |
 | `--production-set` + `--load-file-format / --load-file-formats` | Ignored. Production Set always generates DAT+OPT regardless. |
 | `--production-zip`, `--volume-size` | Require `--production-set` |
 | `--supplemental-production` | Requires `--production-set` and `--prior-manifest` |

--- a/Requirements.md
+++ b/Requirements.md
@@ -627,6 +627,8 @@ This section clarifies behavior when multiple arguments interact:
 | `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` |
 | `--benchmark` | **Early exit**: bypasses all file generation and argument validation; runs benchmarks and exits |
 | `--chaos-list` | **Early exit**: bypasses all file generation and argument validation; prints scenarios and exits |
+| `--redacted-production` | Requires `--production-set`; conflicts with `--loadfile-only` |
+| `--withheld-native-policy` | Requires `--redacted-production`; values: `keep-native`, `omit-native-path`, `replace-with-placeholder` |
 
 ---
 
@@ -748,6 +750,13 @@ This section clarifies behavior when multiple arguments interact:
 - **REQ-139**: Supplemental Production Manifests shall record references to all prior Production Manifests used for validation.
 - **REQ-140**: Supplemental validation shall report duplicate ranges, skipped ranges, expected next Bates Number, and actual starting Bates Number.
 - **REQ-141**: Supplemental validation shall fail before writing output when prior Production Manifest input is missing, malformed, or incompatible with current Bates Prefix and Bates Digits.
+- **REQ-142**: Zipper shall support redacted Production mode for Production Set generation via `--redacted-production`.
+- **REQ-143**: Redacted Production mode shall generate redacted image paths in the Load File under `REDACTED/IMAGES/`.
+- **REQ-144**: Redacted Production mode shall generate redacted Text Paths in the Load File under `REDACTED/TEXT/` when Extracted Text is enabled.
+- **REQ-145**: Redacted Production mode shall support withheld Native File handling via `--withheld-native-policy` with values `keep-native`, `omit-native-path`, or `replace-with-placeholder`.
+- **REQ-146**: Redacted Production mode shall add redaction reason Metadata to the Load File via `REDACTION_REASON` column.
+- **REQ-147**: Redacted Production mode shall record redaction counts, withheld Native File counts, and reason distributions in the Production Manifest.
+- **REQ-148**: Post-generation validation shall verify that redacted image and text references point to existing files on disk, and that `NATIVE_WITHHELD` values are `YES` or `NO`.
 - **REQ-157**: Zipper shall support comparing two or more Production Manifests.
 - **REQ-158**: Comparison reports shall support replacement workflows.
 - **REQ-159**: Comparison reports shall support supplemental workflows.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -122,6 +122,11 @@ The delimited **Load File Formats** (DAT, OPT, CSV, Concordance) are produced by
 | **Production Set** | A structured directory hierarchy (`--production-set`) containing **Native Files** organized into `DATA`, `IMAGES`, `NATIVES`, `TEXT` subdirectories with accompanying **Load Files**. | Production, deliverable, structured output |
 | **Production Manifest** | The `_manifest.json` file at the root of a **Production Set**, documenting **Volume** structure, document counts, and **Bates Number** ranges. | Manifest, metadata file |
 | **Production Zip** | An **Archive** containing the entire **Production Set** directory structure, created when `--production-zip` is specified with `--production-set`. | Production archive, wrapped delivery |
+| **Redacted Production** | A Production Set mode (`--redacted-production`) that generates redacted image/text placeholders under `REDACTED/IMAGES/` and `REDACTED/TEXT/`, and optionally withholds Native Files. | Redacted mode, redaction mode |
+| **Redacted Image** | A placeholder TIFF file in `REDACTED/IMAGES/` representing a redacted version of a **Native File**'s visual content. | Redacted visual, redacted page |
+| **Withheld Native File** | A **Native File** whose path in the **Load File** is omitted, emptied, or replaced with a placeholder path according to `--withheld-native-policy`. | Withheld native, suppressed native |
+| **Withheld Native Policy** | The strategy for handling withheld **Native File** paths: `keep-native` (retain original path), `omit-native-path` (empty the path column), or `replace-with-placeholder` (synthetic path). | Native policy, withholding policy |
+| **Redaction Reason** | A Metadata value in the `REDACTION_REASON` column indicating why a **Native File** was redacted (e.g., Privileged, Attorney Work Product). Cycled deterministically by **Seed**. | Reason code, redaction justification |
 
 ---
 
@@ -161,6 +166,7 @@ The delimited **Load File Formats** (DAT, OPT, CSV, Concordance) are produced by
 - The **Chaos Engine** injects **Anomalies** into **Load File** records in **Loadfile-Only Mode**
 - An **Audit File** (`_properties.json`) records all **Anomalies** injected by the **Chaos Engine**
 - A **Production Manifest** (`_manifest.json`) documents the **Volume** structure and **Bates Number** ranges of a **Production Set**
+- **Redacted Production** adds `REDACTED/IMAGES/` and `REDACTED/TEXT/` subdirectories alongside the standard `DATA`, `IMAGES`, `NATIVES`, `TEXT` tree
 
 ## Example Dialogue
 

--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -735,6 +735,22 @@ public static class CliParser
                     }
 
                     break;
+                case "--redacted-production":
+                    parsed.RedactedProduction = true;
+                    break;
+                case "--withheld-native-policy":
+                    if (TryGetValue(args, i, out var withheldVal))
+                    {
+                        parsed.WithheldNativePolicy = withheldVal;
+                        i++;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Error: --withheld-native-policy requires a value.");
+                        return null;
+                    }
+
+                    break;
                 default:
                     Console.Error.WriteLine($"Error: Unknown argument or unconsumed value '{args[i]}'");
                     return null;

--- a/src/Cli/ParsedArguments.cs
+++ b/src/Cli/ParsedArguments.cs
@@ -117,4 +117,8 @@ public class ParsedArguments
     public string? ComparisonMode { get; set; }
 
     public string? ComparisonOutput { get; set; }
+
+    public bool RedactedProduction { get; set; }
+
+    public string? WithheldNativePolicy { get; set; }
 }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -203,7 +203,7 @@ public static class RequestBuilder
                     _ => RollingBatesMode.Continuous,
                 },
                 RedactedProduction = parsed.RedactedProduction,
-                WithheldNativePolicy = parsed.WithheldNativePolicy ?? "keep-native",
+                WithheldNativePolicy = parsed.WithheldNativePolicy?.ToLowerInvariant() ?? "keep-native",
             },
             LoadfileOnly = parsed.LoadfileOnly,
             Hash = hashConfig,

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -202,6 +202,8 @@ public static class RequestBuilder
                     "restart" => RollingBatesMode.Restart,
                     _ => RollingBatesMode.Continuous,
                 },
+                RedactedProduction = parsed.RedactedProduction,
+                WithheldNativePolicy = parsed.WithheldNativePolicy ?? "keep-native",
             },
             LoadfileOnly = parsed.LoadfileOnly,
             Hash = hashConfig,

--- a/src/Cli/Validation/ProductionSetValidator.cs
+++ b/src/Cli/Validation/ProductionSetValidator.cs
@@ -30,6 +30,12 @@ internal static class ProductionSetValidator
             }
         }
 
+        if (parsed.RedactedProduction && parsed.LoadfileOnly)
+        {
+            Console.Error.WriteLine("Error: --redacted-production conflicts with --loadfile-only.");
+            return false;
+        }
+
         if (parsed.ProductionZip && !parsed.ProductionSet)
         {
             Console.Error.WriteLine("Error: --production-zip requires --production-set.");
@@ -75,6 +81,28 @@ internal static class ProductionSetValidator
                 !string.Equals(parsed.SupplementalGapPolicy, "allow", StringComparison.OrdinalIgnoreCase))
             {
                 Console.Error.WriteLine("Error: --supplemental-gap-policy must be 'reject' or 'allow'.");
+                return false;
+            }
+        }
+
+        if (parsed.RedactedProduction && !parsed.ProductionSet)
+        {
+            Console.Error.WriteLine("Error: --redacted-production requires --production-set.");
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(parsed.WithheldNativePolicy))
+        {
+            if (!parsed.RedactedProduction)
+            {
+                Console.Error.WriteLine("Error: --withheld-native-policy requires --redacted-production.");
+                return false;
+            }
+
+            var policy = parsed.WithheldNativePolicy.ToLowerInvariant();
+            if (policy != "keep-native" && policy != "omit-native-path" && policy != "replace-with-placeholder")
+            {
+                Console.Error.WriteLine("Error: --withheld-native-policy must be 'keep-native', 'omit-native-path', or 'replace-with-placeholder'.");
                 return false;
             }
         }

--- a/src/Config/ProductionConfig.cs
+++ b/src/Config/ProductionConfig.cs
@@ -22,6 +22,10 @@ public record ProductionConfig
     public int RollingCount { get; init; } = 1;
 
     public RollingBatesMode RollingBatesMode { get; init; } = RollingBatesMode.Continuous;
+
+    public bool RedactedProduction { get; init; }
+
+    public string WithheldNativePolicy { get; init; } = "keep-native";
 }
 
 

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -384,10 +384,11 @@ internal sealed class DatComposer : ILoadFileComposer
                         BegAttach = parentId,
                         EndAttach = childId,
                         ParentDocId = parentId,
+                        RedactedImageRelPathOverride = childRedactedImageRelPath,
+                        RedactedTextRelPathOverride = childRedactedTextRelPath,
+                        NativeWithheldOverride = "NO",
+                        RedactionReasonOverride = fileData.RedactionReason,
                     }));
-
-                // Override redacted fields on the child record after ProductionRowValues
-                // ponytail: child redacted paths set via FileData fields on parent; child records inherit via RowCtx
             }
         }
     }
@@ -434,12 +435,12 @@ internal sealed class DatComposer : ILoadFileComposer
 
         if (this.request.Production.RedactedProduction)
         {
-            var redactedImagePath = fileData.RedactedImageRelPath?.Replace('/', '\\') ?? string.Empty;
+            var redactedImagePath = (ctx.RedactedImageRelPathOverride ?? fileData.RedactedImageRelPath)?.Replace('/', '\\') ?? string.Empty;
             // Only populate REDACTED_TEXT_PATH when text output is enabled; otherwise the file
             // on disk is not written and post-generation validation would flag the dangling reference.
-            var redactedTextPath = (this.request.Output.WithText ? fileData.RedactedTextRelPath : null)?.Replace('/', '\\') ?? string.Empty;
-            var nativeWithheld = fileData.NativePathOverride is not null ? "YES" : "NO";
-            var redactionReason = fileData.RedactionReason ?? string.Empty;
+            var redactedTextPath = (this.request.Output.WithText ? (ctx.RedactedTextRelPathOverride ?? fileData.RedactedTextRelPath) : null)?.Replace('/', '\\') ?? string.Empty;
+            var nativeWithheld = ctx.NativeWithheldOverride ?? (fileData.NativePathOverride is not null ? "YES" : "NO");
+            var redactionReason = ctx.RedactionReasonOverride ?? fileData.RedactionReason ?? string.Empty;
             v.Add(redactedImagePath);
             v.Add(redactedTextPath);
             v.Add(nativeWithheld);
@@ -667,5 +668,13 @@ internal sealed class DatComposer : ILoadFileComposer
         public string EndAttach { get; init; } = string.Empty;
 
         public string ParentDocId { get; init; } = string.Empty;
+
+        public string? RedactedImageRelPathOverride { get; init; }
+
+        public string? RedactedTextRelPathOverride { get; init; }
+
+        public string? NativeWithheldOverride { get; init; }
+
+        public string? RedactionReasonOverride { get; init; }
     }
 }

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -78,6 +78,11 @@ internal sealed class DatComposer : ILoadFileComposer
         if (this.mode == WriterMode.ProductionSet)
         {
             var headers = new List<string> { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
+            if (this.request.Production.RedactedProduction)
+            {
+                headers.AddRange(new[] { "REDACTED_IMAGE_PATH", "REDACTED_TEXT_PATH", "NATIVE_WITHHELD", "REDACTION_REASON" });
+            }
+
             if (this.request.Metadata.WithFamilies)
             {
                 headers.AddRange(new[] { "BEGATTACH", "ENDATTACH", "PARENTDOCID" });
@@ -359,6 +364,13 @@ internal sealed class DatComposer : ILoadFileComposer
                 var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\');
                 var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\');
 
+                var childRedactedImageRelPath = this.request.Production.RedactedProduction
+                    ? Path.Combine("REDACTED", "IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\')
+                    : null;
+                var childRedactedTextRelPath = this.request.Production.RedactedProduction && this.request.Output.WithText
+                    ? Path.Combine("REDACTED", "TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\')
+                    : null;
+
                 yield return this.MakeRecord(
                     childId,
                     this.ProductionRowValues(fileData, new RowCtx
@@ -373,6 +385,9 @@ internal sealed class DatComposer : ILoadFileComposer
                         EndAttach = childId,
                         ParentDocId = parentId,
                     }));
+
+                // Override redacted fields on the child record after ProductionRowValues
+                // ponytail: child redacted paths set via FileData fields on parent; child records inherit via RowCtx
             }
         }
     }
@@ -385,8 +400,11 @@ internal sealed class DatComposer : ILoadFileComposer
             .Replace(Path.GetExtension(wi.FilePathInZip), ".tif", StringComparison.Ordinal);
         // FilePathInZip always uses forward slashes (ZIP spec); replace '/' directly so the
         // backslash normalization also works on Windows (where DirectorySeparatorChar is '\').
-        var nativePath = ctx.NativePathOverride ?? wi.FilePathInZip.Replace('/', '\\');
-        var textPath = ctx.TextPathOverride ?? (nativePath.StartsWith("NATIVES\\", StringComparison.OrdinalIgnoreCase) ? "TEXT\\" + nativePath.Substring(8) : nativePath).Replace($".{this.request.Output.FileType}", ".txt", StringComparison.Ordinal);
+        var nativePath = ctx.NativePathOverride ?? fileData.NativePathOverride ?? wi.FilePathInZip.Replace('/', '\\');
+        // Derive text path from the original FilePathInZip (not the overridden nativePath) so
+        // replace-with-placeholder policy doesn't produce wrong text paths in the DAT.
+        var originalNativePath = wi.FilePathInZip.Replace('/', '\\');
+        var textPath = ctx.TextPathOverride ?? (originalNativePath.StartsWith("NATIVES\\", StringComparison.OrdinalIgnoreCase) ? "TEXT\\" + originalNativePath.Substring(8) : originalNativePath).Replace($".{this.request.Output.FileType}", ".txt", StringComparison.Ordinal);
         var imagesPath = imagePath.Replace('/', '\\');
 
 #pragma warning disable S2245
@@ -413,6 +431,20 @@ internal sealed class DatComposer : ILoadFileComposer
             fileSize,
             fileType,
         };
+
+        if (this.request.Production.RedactedProduction)
+        {
+            var redactedImagePath = fileData.RedactedImageRelPath?.Replace('/', '\\') ?? string.Empty;
+            // Only populate REDACTED_TEXT_PATH when text output is enabled; otherwise the file
+            // on disk is not written and post-generation validation would flag the dangling reference.
+            var redactedTextPath = (this.request.Output.WithText ? fileData.RedactedTextRelPath : null)?.Replace('/', '\\') ?? string.Empty;
+            var nativeWithheld = fileData.NativePathOverride is not null ? "YES" : "NO";
+            var redactionReason = fileData.RedactionReason ?? string.Empty;
+            v.Add(redactedImagePath);
+            v.Add(redactedTextPath);
+            v.Add(nativeWithheld);
+            v.Add(redactionReason);
+        }
 
         if (this.request.Metadata.WithFamilies)
         {

--- a/src/ParallelFileGenerator.cs
+++ b/src/ParallelFileGenerator.cs
@@ -512,4 +512,12 @@ internal record FileData
     public string Hash { get; init; } = string.Empty;
 
     public IReadOnlyDictionary<Config.HashAlgorithm, string>? Hashes { get; init; }
+
+    public string? RedactedImageRelPath { get; init; }
+
+    public string? RedactedTextRelPath { get; init; }
+
+    public string? NativePathOverride { get; init; }
+
+    public string? RedactionReason { get; init; }
 }

--- a/src/ProductionManifestWriter.cs
+++ b/src/ProductionManifestWriter.cs
@@ -108,10 +108,16 @@ internal static class ProductionManifestWriter
             {
                 if (f.RedactionReason is not null)
                 {
+                    // Each parent with an attachment has one redacted child (in redacted mode)
+                    long increment = f.Attachment.HasValue ? 2 : 1;
                     reasonCounts.TryGetValue(f.RedactionReason, out var count);
-                    reasonCounts[f.RedactionReason] = count + 1;
+                    reasonCounts[f.RedactionReason] = count + increment;
                 }
             }
+
+            // Children are also redacted: one child per parent with attachment
+            int childCount = fileDataList.Count(f => f.Attachment.HasValue);
+            redactedCount += childCount;
 
             manifest.RedactedFileCount = redactedCount;
             manifest.WithheldNativeFileCount = withheldCount > 0 ? withheldCount : null;

--- a/src/ProductionManifestWriter.cs
+++ b/src/ProductionManifestWriter.cs
@@ -77,6 +77,7 @@ internal static class ProductionManifestWriter
                 Natives = "NATIVES",
                 Text = "TEXT",
                 Images = "IMAGES",
+                Redacted = request.Production.RedactedProduction ? "REDACTED" : null,
             },
             LoadFiles = new ProductionLoadFiles
             {
@@ -96,6 +97,26 @@ internal static class ProductionManifestWriter
             PriorManifests = priorManifests is { Count: > 0 } ? priorManifests : null,
             SupplementalValidation = supplementalValidation,
         };
+
+        // Redaction stats
+        if (request.Production.RedactedProduction && fileDataList.Count > 0)
+        {
+            long redactedCount = fileDataList.Count(f => f.RedactedImageRelPath is not null);
+            long withheldCount = fileDataList.Count(f => f.NativePathOverride is not null);
+            var reasonCounts = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+            foreach (var f in fileDataList)
+            {
+                if (f.RedactionReason is not null)
+                {
+                    reasonCounts.TryGetValue(f.RedactionReason, out var count);
+                    reasonCounts[f.RedactionReason] = count + 1;
+                }
+            }
+
+            manifest.RedactedFileCount = redactedCount;
+            manifest.WithheldNativeFileCount = withheldCount > 0 ? withheldCount : null;
+            manifest.RedactionReasons = reasonCounts.Count > 0 ? reasonCounts : null;
+        }
 
         var json = JsonSerializer.Serialize(manifest, ManifestSerializerOptions);
         await File.WriteAllTextAsync(manifestPath, json).ConfigureAwait(false);
@@ -180,6 +201,15 @@ internal class ProductionManifest
 
     [JsonPropertyName("supplementalValidation")]
     public Validation.SupplementalValidationReport? SupplementalValidation { get; set; }
+
+    [JsonPropertyName("redactedFileCount")]
+    public long? RedactedFileCount { get; set; }
+
+    [JsonPropertyName("withheldNativeFileCount")]
+    public long? WithheldNativeFileCount { get; set; }
+
+    [JsonPropertyName("redactionReasons")]
+    public System.Collections.Generic.IReadOnlyDictionary<string, long>? RedactionReasons { get; set; }
 }
 
 internal class BatesRange
@@ -210,6 +240,9 @@ internal class ProductionDirectories
 
     [JsonPropertyName("images")]
     public string Images { get; set; } = string.Empty;
+
+    [JsonPropertyName("redacted")]
+    public string? Redacted { get; set; }
 }
 
 internal class ProductionLoadFiles

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -212,6 +212,17 @@ internal static class ProductionSetGenerator
         Directory.CreateDirectory(textDir);
         Directory.CreateDirectory(imagesDir);
 
+        bool isRedacted = request.Production.RedactedProduction;
+        string? redactedImagesDir = null;
+        string? redactedTextDir = null;
+        if (isRedacted)
+        {
+            redactedImagesDir = Path.Combine(productionPath, "REDACTED", "IMAGES");
+            redactedTextDir = Path.Combine(productionPath, "REDACTED", "TEXT");
+            Directory.CreateDirectory(redactedImagesDir);
+            Directory.CreateDirectory(redactedTextDir);
+        }
+
 #pragma warning disable S2245 // Pseudo-randomness is safe for mock metadata generation
         var random = request.Metadata.Seed.HasValue ? new Random(request.Metadata.Seed.Value) : new Random();
 #pragma warning restore S2245
@@ -224,6 +235,11 @@ internal static class ProductionSetGenerator
             Directory.CreateDirectory(Path.Combine(nativesDir, volName));
             Directory.CreateDirectory(Path.Combine(textDir, volName));
             Directory.CreateDirectory(Path.Combine(imagesDir, volName));
+            if (isRedacted && redactedImagesDir is not null && redactedTextDir is not null)
+            {
+                Directory.CreateDirectory(Path.Combine(redactedImagesDir, volName));
+                Directory.CreateDirectory(Path.Combine(redactedTextDir, volName));
+            }
         }
 
         var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile.Encoding);
@@ -234,6 +250,12 @@ internal static class ProductionSetGenerator
         // Generate files using the plan
         var fileDataList = new List<FileData>();
         var hashConfig = request.Hash;
+
+        // Redaction reasons cycle for deterministic redacted-mode generation
+        string[] redactionReasons = ["Privileged", "Attorney Work Product", "Settlement Communication", "Trade Secret", "Personal Privacy"];
+        string withheldPolicy = request.Production.WithheldNativePolicy;
+        int redactedCount = 0;
+        int withheldCount = 0;
 
         foreach (var plan in plans)
         {
@@ -273,6 +295,38 @@ internal static class ProductionSetGenerator
                 await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.ImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
             }
 
+            // Write redacted image/text files when redacted mode is on
+            string? nativePathOverride = null;
+            string? redactionReason = null;
+            if (isRedacted)
+            {
+                redactionReason = redactionReasons[plan.Index % redactionReasons.Length];
+                Interlocked.Increment(ref redactedCount);
+
+                if (plan.RedactedImageRelPath is not null)
+                {
+                    await File.WriteAllBytesAsync(Path.Combine(productionPath, plan.RedactedImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+                }
+
+                if (plan.RedactedTextRelPath is not null && request.Output.WithText)
+                {
+                    var redactedText = $"Redacted text for document {plan.BatesNumber}. {LoremIpsum.GetParagraph(random)}";
+                    await File.WriteAllTextAsync(Path.Combine(productionPath, plan.RedactedTextRelPath), redactedText, encoding).ConfigureAwait(false);
+                }
+
+                // Apply withheld native policy
+                nativePathOverride = withheldPolicy switch
+                {
+                    "omit-native-path" => string.Empty,
+                    "replace-with-placeholder" => $"PLACEHOLDER/{plan.VolumeName}/{plan.BatesNumber}.{request.Output.FileTypeLower}",
+                    _ => null,
+                };
+                if (nativePathOverride is not null)
+                {
+                    Interlocked.Increment(ref withheldCount);
+                }
+            }
+
             var fileDataHash = string.Empty;
             IReadOnlyDictionary<Config.HashAlgorithm, string>? fileDataHashes = null;
             if (hashConfig.IsEnabled)
@@ -304,6 +358,10 @@ internal static class ProductionSetGenerator
                 Email = generated.Email,
                 Hash = fileDataHash,
                 Hashes = fileDataHashes,
+                RedactedImageRelPath = plan.RedactedImageRelPath,
+                RedactedTextRelPath = plan.RedactedTextRelPath,
+                NativePathOverride = nativePathOverride,
+                RedactionReason = redactionReason,
             });
 
             if (request.Metadata.WithFamilies && request.Output.IsEml && generated.Attachment.HasValue)
@@ -322,6 +380,20 @@ internal static class ProductionSetGenerator
                 await File.WriteAllTextAsync(Path.Combine(productionPath, childTextRelPath), childTextContent, encoding).ConfigureAwait(false);
 
                 await File.WriteAllBytesAsync(Path.Combine(productionPath, childImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+
+                // Write redacted child files when redacted mode is on
+                if (isRedacted)
+                {
+                    var childRedactedImageRelPath = Path.Combine("REDACTED", "IMAGES", plan.VolumeName, $"{childBates}.tif");
+                    await File.WriteAllBytesAsync(Path.Combine(productionPath, childRedactedImageRelPath), PlaceholderFiles.GetContent("tiff")).ConfigureAwait(false);
+
+                    if (request.Output.WithText)
+                    {
+                        var childRedactedTextRelPath = Path.Combine("REDACTED", "TEXT", plan.VolumeName, $"{childBates}.txt");
+                        var childRedactedText = $"Redacted text for attachment {childBates}.";
+                        await File.WriteAllTextAsync(Path.Combine(productionPath, childRedactedTextRelPath), childRedactedText, encoding).ConfigureAwait(false);
+                    }
+                }
             }
 
             // Progress reporting

--- a/src/ProductionSetPlanner.cs
+++ b/src/ProductionSetPlanner.cs
@@ -19,6 +19,10 @@ internal sealed record ProductionNativeFilePlan
     public required string TextRelPath { get; init; }
 
     public required string ImageRelPath { get; init; }
+
+    public string? RedactedImageRelPath { get; init; }
+
+    public string? RedactedTextRelPath { get; init; }
 }
 
 /// <summary>
@@ -84,6 +88,8 @@ internal static class ProductionSetPlanner
 
         var batesSequence = BatesSequence.FromConfig(setBatesConfig);
 
+        bool isRedacted = request.Production.RedactedProduction;
+
         for (long i = 0; i < request.Output.FileCount; i++)
         {
             int volumeIndex = (int)(i / request.Production.VolumeSize) + 1;
@@ -99,6 +105,8 @@ internal static class ProductionSetPlanner
                 NativeRelPath = Path.Combine("NATIVES", volName, $"{batesNumber}.{nativeExt}"),
                 TextRelPath = Path.Combine("TEXT", volName, $"{batesNumber}.txt"),
                 ImageRelPath = Path.Combine("IMAGES", volName, $"{batesNumber}.tif"),
+                RedactedImageRelPath = isRedacted ? Path.Combine("REDACTED", "IMAGES", volName, $"{batesNumber}.tif") : null,
+                RedactedTextRelPath = isRedacted ? Path.Combine("REDACTED", "TEXT", volName, $"{batesNumber}.txt") : null,
             });
         }
 

--- a/src/Validation/ProductionSetPostValidator.cs
+++ b/src/Validation/ProductionSetPostValidator.cs
@@ -82,6 +82,7 @@ internal sealed class ProductionSetPostValidator
         {
             var encoding = EncodingHelper.GetEncodingOrDefault(request.LoadFile?.Encoding);
             var datLines = File.ReadLines(datPath, encoding);
+            var skipNativePathValidation = string.Equals(request.Production.WithheldNativePolicy, "replace-with-placeholder", StringComparison.OrdinalIgnoreCase);
 
             using (var enumerator = datLines.GetEnumerator())
             {
@@ -99,6 +100,9 @@ internal sealed class ProductionSetPostValidator
                     int textIdx = headers.FindIndex(h => string.Equals(h, "TEXT_PATH", StringComparison.OrdinalIgnoreCase) || string.Equals(h, "TEXT", StringComparison.OrdinalIgnoreCase));
                     int imageIdx = headers.FindIndex(h => string.Equals(h, "IMAGE_PATH", StringComparison.OrdinalIgnoreCase) || string.Equals(h, "IMAGE", StringComparison.OrdinalIgnoreCase));
                     int parentIdIdx = headers.FindIndex(h => string.Equals(h, "PARENTDOCID", StringComparison.OrdinalIgnoreCase));
+                    int redactedImageIdx = headers.FindIndex(h => string.Equals(h, "REDACTED_IMAGE_PATH", StringComparison.OrdinalIgnoreCase));
+                    int redactedTextIdx = headers.FindIndex(h => string.Equals(h, "REDACTED_TEXT_PATH", StringComparison.OrdinalIgnoreCase));
+                    int nativeWithheldIdx = headers.FindIndex(h => string.Equals(h, "NATIVE_WITHHELD", StringComparison.OrdinalIgnoreCase));
 
                     int i = 0;
                     while (enumerator.MoveNext())
@@ -189,7 +193,7 @@ internal sealed class ProductionSetPostValidator
                         }
 
                         // Native path existence
-                        if (nativeIdx >= 0 && nativeIdx < fields.Count)
+                        if (nativeIdx >= 0 && nativeIdx < fields.Count && !skipNativePathValidation)
                         {
                             var nativePath = fields[nativeIdx];
                             if (!string.IsNullOrEmpty(nativePath))
@@ -259,6 +263,67 @@ internal sealed class ProductionSetPostValidator
                                         });
                                     }
                                 }
+                            }
+                        }
+
+                        // Redacted image path existence
+                        if (redactedImageIdx >= 0 && redactedImageIdx < fields.Count)
+                        {
+                            var redactedImagePath = fields[redactedImageIdx];
+                            if (!string.IsNullOrEmpty(redactedImagePath))
+                            {
+                                var fullRedactedImagePath = Path.Combine(productionPath, redactedImagePath.Replace('\\', '/'));
+                                if (!File.Exists(fullRedactedImagePath))
+                                {
+                                    findings.Add(new ValidationReportFinding
+                                    {
+                                        Code = "PathExistence",
+                                        Severity = "error",
+                                        Path = datRelPath,
+                                        Line = i + 1,
+                                        Message = $"Referenced redacted image file '{redactedImagePath}' does not exist."
+                                    });
+                                }
+                            }
+                        }
+
+                        // Redacted text path existence
+                        if (redactedTextIdx >= 0 && redactedTextIdx < fields.Count)
+                        {
+                            var redactedTextPath = fields[redactedTextIdx];
+                            if (!string.IsNullOrEmpty(redactedTextPath))
+                            {
+                                var fullRedactedTextPath = Path.Combine(productionPath, redactedTextPath.Replace('\\', '/'));
+                                if (!File.Exists(fullRedactedTextPath))
+                                {
+                                    findings.Add(new ValidationReportFinding
+                                    {
+                                        Code = "PathExistence",
+                                        Severity = "error",
+                                        Path = datRelPath,
+                                        Line = i + 1,
+                                        Message = $"Referenced redacted text file '{redactedTextPath}' does not exist."
+                                    });
+                                }
+                            }
+                        }
+
+                        // NATIVE_WITHHELD value validation
+                        if (nativeWithheldIdx >= 0 && nativeWithheldIdx < fields.Count)
+                        {
+                            var withheldVal = fields[nativeWithheldIdx];
+                            if (!string.IsNullOrEmpty(withheldVal) &&
+                                !string.Equals(withheldVal, "YES", StringComparison.OrdinalIgnoreCase) &&
+                                !string.Equals(withheldVal, "NO", StringComparison.OrdinalIgnoreCase))
+                            {
+                                findings.Add(new ValidationReportFinding
+                                {
+                                    Code = "InvalidValue",
+                                    Severity = "error",
+                                    Path = datRelPath,
+                                    Line = i + 1,
+                                    Message = $"NATIVE_WITHHELD must be 'YES' or 'NO', got '{withheldVal}'"
+                                });
                             }
                         }
                     }

--- a/src/Validation/ProductionSetPostValidator.cs
+++ b/src/Validation/ProductionSetPostValidator.cs
@@ -312,9 +312,9 @@ internal sealed class ProductionSetPostValidator
                         if (nativeWithheldIdx >= 0 && nativeWithheldIdx < fields.Count)
                         {
                             var withheldVal = fields[nativeWithheldIdx];
-                            if (!string.IsNullOrEmpty(withheldVal) &&
-                                !string.Equals(withheldVal, "YES", StringComparison.OrdinalIgnoreCase) &&
-                                !string.Equals(withheldVal, "NO", StringComparison.OrdinalIgnoreCase))
+                            if (string.IsNullOrEmpty(withheldVal) ||
+                                (!string.Equals(withheldVal, "YES", StringComparison.OrdinalIgnoreCase) &&
+                                 !string.Equals(withheldVal, "NO", StringComparison.OrdinalIgnoreCase)))
                             {
                                 findings.Add(new ValidationReportFinding
                                 {

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -900,6 +900,197 @@ public class ProductionSetTests : IDisposable
         Assert.Equal("PROD00000001", doc2.RootElement.GetProperty("batesNumberStart").GetString());
         Assert.Equal("PROD00000005", doc2.RootElement.GetProperty("batesNumberEnd").GetString());
     }
+
+    // === Redacted Production Tests ===
+
+    [Fact]
+    public void RedactedProduction_RequiresProductionSet()
+    {
+        var args = new[] { "--redacted-production", "--count", "10", "--output-path", this.testOutputPath, "--bates-prefix", "TEST" };
+        var request = Cli.Pipeline.Build(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void RedactedProduction_ConflictsWithLoadfileOnly()
+    {
+        var args = new[] { "--redacted-production", "--production-set", "--loadfile-only", "--count", "10", "--output-path", this.testOutputPath, "--bates-prefix", "TEST" };
+        var request = Cli.Pipeline.Build(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void RedactedProduction_WithInvalidPolicy_FailsValidation()
+    {
+        var args = new[] { "--redacted-production", "--production-set", "--withheld-native-policy", "invalid", "--count", "10", "--output-path", this.testOutputPath, "--bates-prefix", "TEST" };
+        var request = Cli.Pipeline.Build(args);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void RedactedProduction_ValidArgs_ParsesCorrectly()
+    {
+        var args = new[]
+        {
+            "--production-set", "--redacted-production", "--count", "10", "--output-path", this.testOutputPath,
+            "--bates-prefix", "PROD", "--withheld-native-policy", "omit-native-path",
+        };
+        var request = Cli.Pipeline.Build(args);
+
+        Assert.NotNull(request);
+        Assert.True(request.Production.RedactedProduction);
+        Assert.Equal("omit-native-path", request.Production.WithheldNativePolicy);
+    }
+
+    [Fact]
+    public async Task RedactedProduction_CreatesRedactedDirectories()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "REDACTED")));
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "REDACTED", "IMAGES")));
+        Assert.True(Directory.Exists(Path.Combine(result.ProductionPath, "REDACTED", "TEXT")));
+    }
+
+    [Fact]
+    public async Task RedactedProduction_CreatesRedactedImageFiles()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var redactedImages = Directory.GetFiles(Path.Combine(result.ProductionPath, "REDACTED", "IMAGES"), "*.tif", SearchOption.AllDirectories);
+        Assert.Equal(3, redactedImages.Length);
+
+        foreach (var file in redactedImages)
+        {
+            Assert.True(new FileInfo(file).Length > 0);
+        }
+    }
+
+    [Fact]
+    public async Task RedactedProduction_DatHeader_IncludesRedactedColumns()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath);
+        var headerLine = datContent.Split('\n')[0];
+        Assert.Contains("REDACTED_IMAGE_PATH", headerLine, StringComparison.Ordinal);
+        Assert.Contains("REDACTED_TEXT_PATH", headerLine, StringComparison.Ordinal);
+        Assert.Contains("NATIVE_WITHHELD", headerLine, StringComparison.Ordinal);
+        Assert.Contains("REDACTION_REASON", headerLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RedactedProduction_WithWithheldPolicy_OmitsNativePath()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true, WithheldNativePolicy = "omit-native-path" };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath);
+        var lines = datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        // Skip header line
+        foreach (var line in lines.Skip(1))
+        {
+            var fields = Validation.ProductionSetPostValidator.ParseDatLine(line.TrimEnd('\r'), '\x14', '\xfe');
+            // NATIVE_PATH is column index 3
+            Assert.Equal(string.Empty, fields[3]);
+            // NATIVE_WITHHELD is column index 12
+            Assert.Equal("YES", fields[12]);
+        }
+    }
+
+    [Fact]
+    public async Task RedactedProduction_WithKeepNative_KeepsNativePath()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true, WithheldNativePolicy = "keep-native" };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath);
+        var lines = datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines.Skip(1))
+        {
+            var fields = Validation.ProductionSetPostValidator.ParseDatLine(line.TrimEnd('\r'), '\x14', '\xfe');
+            // NATIVE_PATH should not be empty
+            Assert.False(string.IsNullOrEmpty(fields[3]));
+            // NATIVE_WITHHELD is column index 12
+            Assert.Equal("NO", fields[12]);
+        }
+    }
+
+    [Fact]
+    public async Task RedactedProduction_WithWithText_CreatesRedactedTextFiles()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true };
+        request.Output = request.Output with { WithText = true };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var redactedTexts = Directory.GetFiles(Path.Combine(result.ProductionPath, "REDACTED", "TEXT"), "*.txt", SearchOption.AllDirectories);
+        Assert.Equal(3, redactedTexts.Length);
+
+        foreach (var file in redactedTexts)
+        {
+            var content = await File.ReadAllTextAsync(file);
+            Assert.Contains("Redacted text", content, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task RedactedProduction_Manifest_IncludesRedactionStats()
+    {
+        var request = this.CreateTestRequest(count: 5);
+        request.Production = request.Production with { RedactedProduction = true, WithheldNativePolicy = "omit-native-path" };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var manifestPath = Path.Combine(result.ProductionPath, "_manifest.json");
+        var json = await File.ReadAllTextAsync(manifestPath);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Equal(5, doc.RootElement.GetProperty("redactedFileCount").GetInt64());
+        Assert.Equal(5, doc.RootElement.GetProperty("withheldNativeFileCount").GetInt64());
+        Assert.Equal("REDACTED", doc.RootElement.GetProperty("directories").GetProperty("redacted").GetString());
+
+        var reasons = doc.RootElement.GetProperty("redactionReasons");
+        Assert.True(reasons.EnumerateObject().Any());
+    }
+
+    [Fact]
+    public async Task RedactedProduction_WithoutRedactedMode_NoRedactedColumns()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath);
+        var headerLine = datContent.Split('\n')[0];
+        Assert.DoesNotContain("REDACTED_IMAGE_PATH", headerLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("NATIVE_WITHHELD", headerLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RedactedProduction_WithReplacePlaceholder_ShowsPlaceholderPath()
+    {
+        var request = this.CreateTestRequest(count: 3);
+        request.Production = request.Production with { RedactedProduction = true, WithheldNativePolicy = "replace-with-placeholder" };
+        var result = await ProductionSetGenerator.GenerateAsync(request);
+
+        var datContent = await File.ReadAllTextAsync(result.DatFilePath);
+        var lines = datContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines.Skip(1))
+        {
+            var fields = Validation.ProductionSetPostValidator.ParseDatLine(line.TrimEnd('\r'), '\x14', '\xfe');
+            // NATIVE_PATH should contain PLACEHOLDER
+            Assert.Contains("PLACEHOLDER", fields[3], StringComparison.Ordinal);
+            // NATIVE_WITHHELD is column index 12
+            Assert.Equal("YES", fields[12]);
+        }
+    }
 }
 
 

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
## Release Notes

Adds redacted Production mode for generating redacted image/text placeholders with configurable Native File withholding. New flags `--redacted-production` and `--withheld-native-policy` (keep-native|omit-native-path|replace-with-placeholder). DAT Load File includes REDACTED_IMAGE_PATH, REDACTED_TEXT_PATH, NATIVE_WITHHELD, and REDACTION_REASON columns. Production Manifest tracks redaction counts and reason distributions. Post-generation validation verifies redacted path integrity and NATIVE_WITHHELD values.

## Architecture

No changes to architecture diagrams. The redacted production feature extends existing Production Set pipeline components (ProductionSetPlanner, ProductionSetGenerator, DatComposer) without altering the load-file `composer → serializer → emitter` seam.

## Acceptance Criteria

- [x] Redacted Production mode creates valid Production Set output
- [x] Load File includes redacted path and redaction reason Metadata
- [x] Withheld Native File behavior is explicit and validated
- [x] Production Manifest summarizes redaction behavior
- [x] Non-redacted Production Set output remains unchanged
- [x] REQ-142 through REQ-148 added to Requirements.md
- [x] UBIQUITOUS_LANGUAGE.md updated with redacted production terms
- [x] README.md updated with new CLI flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Redacted Production** mode to generate `REDACTED/IMAGES/` and (optionally) `REDACTED/TEXT/` placeholder outputs.
  * Added `--withheld-native-policy` to control how native paths are kept, omitted, or replaced with placeholders.
  * Extended output DAT headers and `_manifest.json` with redaction/withheld statistics and reason distributions.
* **Documentation**
  * Documented new CLI flags, argument rules, and redaction/withholding behavior.
* **Tests**
  * Added end-to-end and validation tests covering redacted output structure, columns, policies, and manifest stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->