### PR TITLE
feat: add --with-collection-metadata for custodian metadata columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After building the project, you can run the executable directly. The examples be
 ### Basic Usage
 
 ```bash
-zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>] [--chaos-scenario <name>] [--production-set] [--production-zip] [--volume-size <number>] [--redacted-production] [--withheld-native-policy <keep-native|omit-native-path|replace-with-placeholder>] [--supplemental-production] [--prior-manifest <paths>] [--supplemental-gap-policy <reject|allow>] [--benchmark] [--chaos-list] [--compare-production-manifests <paths>] [--comparison-mode <mode>] [--comparison-output <path>]
+zipper --type <filetype> --count <number> --output-path <directory> [--folders <number>] [--encoding <UTF-8|UTF-16|ANSI>] [--distribution <proportional|gaussian|exponential>] [--with-metadata] [--with-collection-metadata] [--with-text] [--attachment-rate <number>] [--target-zip-size <size>] [--include-load-file] [--load-file-format <format>] [--bates-prefix <prefix>] [--bates-start <number>] [--bates-digits <number>] [--tiff-pages <min-max>] [--loadfile-only] [--eol <CRLF|LF|CR>] [--col-delim <ascii:N|char:C>] [--quote-delim <ascii:N|char:C|none>] [--newline-delim <ascii:N|char:C>] [--multi-delim <ascii:N|char:C>] [--nested-delim <ascii:N|char:C>] [--chaos-mode] [--chaos-amount <N|N%>] [--chaos-types <type1,type2,...>] [--chaos-scenario <name>] [--production-set] [--production-zip] [--volume-size <number>] [--redacted-production] [--withheld-native-policy <keep-native|omit-native-path|replace-with-placeholder>] [--supplemental-production] [--prior-manifest <paths>] [--supplemental-gap-policy <reject|allow>] [--benchmark] [--chaos-list] [--compare-production-manifests <paths>] [--comparison-mode <mode>] [--comparison-output <path>]
 ```
 
 ### Arguments
@@ -63,6 +63,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
   - `gaussian`: Bell curve distribution with most files in middle folders
   - `exponential`: Exponential decay with most files in first folders
 - `--with-metadata`: Generates a Load File with additional metadata columns (Custodian, Date Sent, Author, File Size). Supported for all file types including `eml`
+- `--with-collection-metadata`: Generates a Load File with collection metadata columns (Data Source, Collection Date, De-Nisted, Dedupe Group ID, Processing Status). Supported in Standard, Loadfile-Only, and Production Set modes
 - `--with-text`: Generates a corresponding extracted text file for each document and adds the path to the Load File. Supported for all file types including `eml`
 - `--attachment-rate <number>`: When type is `eml`, specifies the percentage of Emails (0-100) that will receive a placeholder Native File (jpg/tiff/pdf from the internal pool) as a random Attachment. Defaults to 0
 - `--target-zip-size <size>`: Specifies a target size for the final Archive (e.g., 500MB, 10GB). This feature works by padding each of the `--count` Native Files with uncompressible data to meet the target size. This significantly reduces the overall Compression Ratio and is intended for specific network or storage performance testing scenarios. Requires `--count`
@@ -199,6 +200,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--encoding` | UTF-8 | UTF-8, UTF-16, ANSI | Load File encoding |
 | `--distribution` | proportional | proportional, gaussian, exponential | File distribution |
 | `--with-metadata` | false | flag | Include metadata columns |
+| `--with-collection-metadata` | false | flag | Include collection metadata columns (Data Source, Collection Date, De-Nisted, Dedupe Group ID, Processing Status) |
 | `--with-text` | false | flag | Generate text files |
 | `--attachment-rate` | 0 | 0-100 | Email Attachment % |
 | `--target-zip-size` | none | KB/MB/GB (e.g., 500MB) | Target ZIP size |
@@ -257,6 +259,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | Interaction | Behavior |
 |-------------|----------|
 | `--column-profile` + `--with-metadata` | Column profile takes precedence; `--with-metadata` is ignored with a warning |
+| `--column-profile` + `--with-collection-metadata` | Collection metadata columns are merged into the profile |
 | `--target-zip-size` | Requires `--count` to be specified |
 | `--attachment-rate` | Only meaningful when `--type eml` (Email File Type) |
 | `--with-families` | Only meaningful when `--type eml` and `--attachment-rate > 0` (emits a soft warning to stderr otherwise) |

--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -24,6 +24,7 @@ internal static class CliOptions
         "--version",
         "--with-families",
         "--with-metadata",
+        "--with-collection-metadata",
         "--with-text",
     };
 }

--- a/src/Cli/CliParser.cs
+++ b/src/Cli/CliParser.cs
@@ -111,6 +111,9 @@ public static class CliParser
                 case "--with-metadata":
                     parsed.WithMetadata = true;
                     break;
+                case "--with-collection-metadata":
+                    parsed.WithCollectionMetadata = true;
+                    break;
                 case "--with-text":
                     parsed.WithText = true;
                     break;

--- a/src/Cli/HelpTextGenerator.cs
+++ b/src/Cli/HelpTextGenerator.cs
@@ -20,6 +20,7 @@ internal static class HelpTextGenerator
         Console.Error.WriteLine("  --encoding <string>      Encoding: UTF-8, UTF-16, ANSI (default: UTF-8)");
         Console.Error.WriteLine("  --distribution <string>  Distribution: proportional, gaussian, exponential");
         Console.Error.WriteLine("  --with-metadata          Include metadata columns in load file");
+        Console.Error.WriteLine("  --with-collection-metadata Include collection metadata columns in load file");
         Console.Error.WriteLine("  --with-text              Generate extracted text files");
         Console.Error.WriteLine("  --attachment-rate <n>    EML attachment percentage (0-100, default: 0)");
         Console.Error.WriteLine("  --target-zip-size <size> Target ZIP size (e.g., 500MB, 10GB)");

--- a/src/Cli/ParsedArguments.cs
+++ b/src/Cli/ParsedArguments.cs
@@ -21,6 +21,8 @@ public class ParsedArguments
 
     public bool WithMetadata { get; set; }
 
+    public bool WithCollectionMetadata { get; set; }
+
     public bool WithText { get; set; }
 
     public int AttachmentRate { get; set; }

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -33,6 +33,10 @@ public static class RequestBuilder
             {
                 Console.Error.WriteLine($"Warning: Failed to load column profile '{parsed.ColumnProfile}'.");
             }
+            else if (parsed.WithCollectionMetadata)
+            {
+                profile = BuiltInProfiles.MergeWithCollectionMetadata(profile);
+            }
         }
 
         List<LoadFileFormat>? multiFormats = null;
@@ -147,6 +151,7 @@ public static class RequestBuilder
                 EmptyPercentageOverride = parsed.EmptyPercentage,
                 CustodianCountOverride = parsed.CustodianCount,
                 WithFamilies = parsed.WithFamilies,
+                WithCollectionMetadata = parsed.WithCollectionMetadata,
             },
             LoadFile = new LoadFileConfig
             {

--- a/src/Config/MetadataConfig.cs
+++ b/src/Config/MetadataConfig.cs
@@ -18,7 +18,11 @@ public record MetadataConfig
 
     public bool WithFamilies { get; init; }
 
+    public bool WithCollectionMetadata { get; init; }
+
     internal bool ShouldIncludeEmlColumns(OutputConfig output) => output.IsEml;
 
     internal bool ShouldIncludeMetadataColumns(OutputConfig output) => this.WithMetadata || output.IsEml;
+
+    internal bool ShouldIncludeCollectionMetadataColumns() => this.WithCollectionMetadata;
 }

--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -117,6 +117,11 @@ internal sealed class DatComposer : ILoadFileComposer
             cols.AddRange(new[] { "To", "From", "Subject", "Sent Date", "Attachment" });
         }
 
+        if (this.request.Metadata.ShouldIncludeCollectionMetadataColumns())
+        {
+            cols.AddRange(new[] { "Data Source", "Collection Date", "De-Nisted", "Dedupe Group ID", "Processing Status" });
+        }
+
         if (this.request.Bates != null)
         {
             cols.Add("Bates Number");
@@ -290,6 +295,17 @@ internal sealed class DatComposer : ILoadFileComposer
             v.Add(ctx.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSUBJECT") ?? $"Email Subject {wi.Index}"));
             v.Add(ctx.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILSENTDATE") ?? string.Empty));
             v.Add(ctx.IsChild ? string.Empty : (profileValues?.GetValueOrDefault("EMAILATTACHMENT") ?? string.Empty));
+        }
+
+        if (this.request.Metadata.ShouldIncludeCollectionMetadataColumns())
+        {
+            var colRandom = this.request.Metadata.Seed.HasValue ? new Random(unchecked((int)(this.request.Metadata.Seed.Value + wi.Index))) : Random.Shared;
+            var now = this.EffectiveNow();
+            v.Add(profileValues?.GetValueOrDefault("DATA_SOURCE") ?? CollectionMetadataValues.DataSources[colRandom.Next(CollectionMetadataValues.DataSources.Length)]);
+            v.Add(profileValues?.GetValueOrDefault("COLLECTION_DATE") ?? now.AddDays(-colRandom.Next(1, 30)).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
+            v.Add(profileValues?.GetValueOrDefault("DENISTED") ?? (colRandom.Next(100) < 85 ? "YES" : "NO"));
+            v.Add(profileValues?.GetValueOrDefault("DEDUPE_GROUP_ID") ?? $"GRP{colRandom.Next(1, 1000):D6}");
+            v.Add(profileValues?.GetValueOrDefault("PROCESSING_STATUS") ?? CollectionMetadataValues.ProcessingStatuses[colRandom.Next(CollectionMetadataValues.ProcessingStatuses.Length)]);
         }
 
         if (this.request.Bates != null)
@@ -677,4 +693,10 @@ internal sealed class DatComposer : ILoadFileComposer
 
         public string? RedactionReasonOverride { get; init; }
     }
+}
+
+internal static class CollectionMetadataValues
+{
+    public static readonly string[] DataSources = ["Email Server", "Network Share", "Cloud Storage", "Mobile Device", "Laptop", "Desktop", "Server", "External Media"];
+    public static readonly string[] ProcessingStatuses = ["Processed", "Pending Review", "Approved", "Privileged", "Redacted", "Produced"];
 }

--- a/src/LoadFiles/StandardRowComposer.cs
+++ b/src/LoadFiles/StandardRowComposer.cs
@@ -56,6 +56,7 @@ internal abstract class StandardRowComposer : ILoadFileComposer
 
         bool includeMeta = this.request.Metadata.ShouldIncludeMetadataColumns(this.request.Output);
         bool includeEml = this.request.Metadata.ShouldIncludeEmlColumns(this.request.Output);
+        bool includeCollectionMeta = this.request.Metadata.ShouldIncludeCollectionMetadataColumns();
 
         foreach (var fileData in processedFiles)
         {
@@ -64,6 +65,7 @@ internal abstract class StandardRowComposer : ILoadFileComposer
             // Draw order must stay metadata-then-email to match historical output.
             var meta = includeMeta ? SyntheticRowValues.Metadata(wi, fileData, random, now) : default;
             var eml = includeEml ? SyntheticRowValues.Eml(wi, fileData, random, now) : default;
+            var colMeta = includeCollectionMeta ? SyntheticRowValues.CollectionMetadata(wi, random, now) : default;
 
             bool hasAttachment = this.request.Metadata.WithFamilies && this.request.Output.IsEml && fileData.Attachment.HasValue;
             string parentId = this.batesSequence is not null
@@ -79,7 +81,7 @@ internal abstract class StandardRowComposer : ILoadFileComposer
                 ParentDocId = string.Empty
             };
 
-            var values = this.orderedKeys.Select(k => this.Resolve(k, wi, fileData, meta, eml, parentCtx)).ToList();
+            var values = this.orderedKeys.Select(k => this.Resolve(k, wi, fileData, meta, eml, colMeta, parentCtx)).ToList();
             yield return LoadFileRecordBuilder.Build(this.headerColumns, values, parentId);
 
             if (hasAttachment)
@@ -98,7 +100,7 @@ internal abstract class StandardRowComposer : ILoadFileComposer
                     EndAttach = childId,
                     ParentDocId = parentId,
                 };
-                var childValues = this.orderedKeys.Select(k => this.Resolve(k, wi, fileData, meta, eml, childCtx)).ToList();
+                var childValues = this.orderedKeys.Select(k => this.Resolve(k, wi, fileData, meta, eml, colMeta, childCtx)).ToList();
                 yield return LoadFileRecordBuilder.Build(this.headerColumns, childValues, childId);
             }
         }
@@ -122,6 +124,11 @@ internal abstract class StandardRowComposer : ILoadFileComposer
         if (this.request.Metadata.ShouldIncludeEmlColumns(this.request.Output))
         {
             keys.AddRange(new[] { "TO", "FROM", "SUBJECT", "SENTDATE", "ATTACHMENT" });
+        }
+
+        if (this.request.Metadata.ShouldIncludeCollectionMetadataColumns())
+        {
+            keys.AddRange(new[] { "DATA_SOURCE", "COLLECTION_DATE", "DENISTED", "DEDUPE_GROUP_ID", "PROCESSING_STATUS" });
         }
 
         if (this.batesSequence is not null)
@@ -158,6 +165,7 @@ internal abstract class StandardRowComposer : ILoadFileComposer
         FileData fileData,
         (string Custodian, string DateSent, string Author, string FileSize) meta,
         (string To, string From, string Subject, string SentDate, string Attachment) eml,
+        (string DataSource, string CollectionDate, string DeNisted, string DedupeGroupId, string ProcessingStatus) colMeta,
         RowCtx ctx)
         => key switch
         {
@@ -174,6 +182,11 @@ internal abstract class StandardRowComposer : ILoadFileComposer
             "SUBJECT" => ctx.IsChild ? string.Empty : eml.Subject,
             "SENTDATE" => ctx.IsChild ? string.Empty : eml.SentDate,
             "ATTACHMENT" => ctx.IsChild ? string.Empty : eml.Attachment,
+            "DATA_SOURCE" => colMeta.DataSource,
+            "COLLECTION_DATE" => colMeta.CollectionDate,
+            "DENISTED" => colMeta.DeNisted,
+            "DEDUPE_GROUP_ID" => colMeta.DedupeGroupId,
+            "PROCESSING_STATUS" => colMeta.ProcessingStatus,
             "BATES" => ctx.IdOverride ?? this.batesSequence!.Format(wi.Index - 1).ToString(),
             "PAGECOUNT" => (ctx.IsChild ? 1 : fileData.PageCount).ToString(System.Globalization.CultureInfo.InvariantCulture),
             // Whole-string Replace (not extension-only) preserves byte-for-byte parity with the

--- a/src/LoadFiles/SyntheticRowValues.cs
+++ b/src/LoadFiles/SyntheticRowValues.cs
@@ -34,4 +34,17 @@ internal static class SyntheticRowValues
         var attachment = fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty;
         return (to, from, subject, sentDate, attachment);
     }
+
+    internal static (string DataSource, string CollectionDate, string DeNisted, string DedupeGroupId, string ProcessingStatus) CollectionMetadata(
+        FileWorkItem workItem,
+        Random random,
+        DateTime now)
+    {
+        var dataSource = CollectionMetadataValues.DataSources[random.Next(CollectionMetadataValues.DataSources.Length)];
+        var collectionDate = now.AddDays(-random.Next(1, 30)).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+        var deNisted = random.Next(100) < 85 ? "YES" : "NO";
+        var dedupeGroupId = $"GRP{random.Next(1, 1000):D6}";
+        var processingStatus = CollectionMetadataValues.ProcessingStatuses[random.Next(CollectionMetadataValues.ProcessingStatuses.Length)];
+        return (dataSource, collectionDate, deNisted, dedupeGroupId, processingStatus);
+    }
 }

--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -228,6 +228,40 @@ public static class BuiltInProfiles
         },
     };
 
+    /// <summary>
+    /// Gets the collection metadata profile activated by --with-collection-metadata.
+    /// Five columns: DATA_SOURCE, COLLECTION_DATE, DENISTED, DEDUPE_GROUP_ID, PROCESSING_STATUS.
+    /// </summary>
+    public static ColumnProfile LegacyWithCollectionMetadata { get; } = new()
+    {
+        Name = "legacyWithCollectionMetadata",
+        Description = "Legacy --with-collection-metadata pseudo-profile",
+        Version = "1.0",
+        FieldNamingConvention = null,
+        Settings = new ProfileSettings { EmptyValuePercentage = 0 },
+        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal)
+        {
+            ["datasource"] = new DataSourceConfig
+            {
+                Values = ["Email Server", "Network Share", "Cloud Storage", "Mobile Device", "Laptop", "Desktop", "Server", "External Media"],
+                Weights = [25, 20, 15, 10, 10, 8, 7, 5],
+            },
+            ["processingstatus"] = new DataSourceConfig
+            {
+                Values = ["Processed", "Pending Review", "Approved", "Privileged", "Redacted", "Produced"],
+                Weights = [40, 20, 15, 10, 10, 5],
+            },
+        },
+        Columns = new List<ColumnDefinition>
+        {
+            new() { Name = "DATA_SOURCE", Type = "coded", DataSource = "datasource", Required = true, EmptyPercentage = 0 },
+            new() { Name = "COLLECTION_DATE", Type = "date", Required = true, EmptyPercentage = 0 },
+            new() { Name = "DENISTED", Type = "boolean", Required = true, EmptyPercentage = 0 },
+            new() { Name = "DEDUPE_GROUP_ID", Type = "identifier", Required = true, EmptyPercentage = 0 },
+            new() { Name = "PROCESSING_STATUS", Type = "coded", DataSource = "processingstatus", Required = true, EmptyPercentage = 0 },
+        },
+    };
+
     private static List<ColumnDefinition> CreateLitigationColumns()
     {
         var columns = new List<ColumnDefinition>
@@ -400,5 +434,42 @@ public static class BuiltInProfiles
 
         columns.AddRange(extraColumns);
         return columns;
+    }
+
+    /// <summary>
+    /// Creates a merged profile combining the base profile's columns with additional columns.
+    /// Data sources from the additional profile are merged into the base.
+    /// </summary>
+    public static ColumnProfile MergeWithCollectionMetadata(ColumnProfile baseProfile)
+    {
+        ArgumentNullException.ThrowIfNull(baseProfile);
+        var merged = new ColumnProfile
+        {
+            Name = baseProfile.Name,
+            Description = baseProfile.Description,
+            Version = baseProfile.Version,
+            FieldNamingConvention = baseProfile.FieldNamingConvention,
+            Settings = baseProfile.Settings,
+            DataSources = new Dictionary<string, DataSourceConfig>(baseProfile.DataSources, StringComparer.Ordinal),
+            Columns = new List<ColumnDefinition>(baseProfile.Columns),
+        };
+
+        foreach (var ds in LegacyWithCollectionMetadata.DataSources)
+        {
+            if (!merged.DataSources.ContainsKey(ds.Key))
+            {
+                merged.DataSources[ds.Key] = ds.Value;
+            }
+        }
+
+        foreach (var col in LegacyWithCollectionMetadata.Columns)
+        {
+            if (!merged.Columns.Any(c => string.Equals(c.Name, col.Name, StringComparison.Ordinal)))
+            {
+                merged.Columns.Add(col);
+            }
+        }
+
+        return merged;
     }
 }

--- a/src/Zipper.Tests/DatComposingWriterTests.cs
+++ b/src/Zipper.Tests/DatComposingWriterTests.cs
@@ -116,6 +116,31 @@ public class DatComposingWriterTests : TempDirectoryTestBase
     }
 
     [Fact]
+    public async Task WriteAsync_WithCollectionMetadata_IncludesCollectionMetadataColumns()
+    {
+        var request = DefaultRequest();
+        request.Metadata = request.Metadata with { WithCollectionMetadata = true };
+        var output = await WriteAndCaptureOutput(request, []);
+        Assert.Contains("Data Source", output, StringComparison.Ordinal);
+        Assert.Contains("Collection Date", output, StringComparison.Ordinal);
+        Assert.Contains("De-Nisted", output, StringComparison.Ordinal);
+        Assert.Contains("Dedupe Group ID", output, StringComparison.Ordinal);
+        Assert.Contains("Processing Status", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WithCollectionMetadata_WritesCollectionMetadataValues()
+    {
+        var request = DefaultRequest();
+        request.Metadata = request.Metadata with { WithCollectionMetadata = true, Seed = 42 };
+        var files = new List<FileData> { MakeFileData(1) };
+
+        var output = await WriteAndCaptureOutput(request, files);
+        Assert.Contains("GRP", output, StringComparison.Ordinal);
+        Assert.Contains("2024-", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task WriteAsync_WithEmailData_WritesEmlColumns()
     {
         var request = DefaultRequest();


### PR DESCRIPTION
## Summary

Adds `--with-collection-metadata` CLI flag that adds 5 collection metadata columns to load file output: Data Source (coded), Collection Date (date), De-Nisted (boolean), Dedupe Group ID (identifier), and Processing Status (coded). Available in Standard, Loadfile-Only, and Production Set modes.

## Changes

- New `--with-collection-metadata` CLI flag and `MetadataConfig.WithCollectionMetadata` property
- `DatComposer`: header columns and row values for collection metadata with seeded randomness
- `StandardRowComposer`: CSV/Concordance path support via `SyntheticRowValues.CollectionMetadata()`
- `BuiltInProfiles`: `LegacyWithCollectionMetadata` profile with data source and processing status value pools
- 2 new unit tests for header and value generation

## Testing

- All 1297 tests pass (1295 + 2 new collection metadata tests)
- Lint clean, 0 warnings
- Pre-push E2E smoke + golden regression all passed

## Release Notes

Adds `--with-collection-metadata` CLI flag that appends 5 collection metadata columns (Data Source, Collection Date, De-Nisted, Dedupe Group ID, Processing Status) to DAT, OPT, CSV, and Concordance load file output in Standard, Loadfile-Only, and Production Set modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--with-collection-metadata` command-line option.
  * Outputs collection metadata columns, including data source, collection date, de-nesting status, deduplication group ID, and processing status.
  * Added support for profile-provided or automatically generated collection metadata values.
  * Added a built-in profile for collection metadata integration.

* **Tests**
  * Added coverage for collection metadata columns and generated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->