### PR TITLE
fix: prevent path traversal attacks in custom column profiles (#600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ zipper --type <filetype> --count <number> --output-path <directory> [--folders <
 - `--tiff-pages <min-max>`: Page count range for TIFF files (e.g., "1-20"). Defaults to "1-1". **Important:** Default differs by mode. Standard mode defaults to 1-1 (single page). Loadfile-Only OPT mode defaults to random 1-10 pages when omitted.
 
 **Column Profile Options:**
-- `--column-profile <name|path>`: Column profile for configurable metadata generation. Use built-in profiles (`minimal`, `standard`, `litigation`, `full`) or path to custom JSON file
+- `--column-profile <name|path>`: Column profile for configurable metadata generation. Use built-in profiles (`minimal`, `standard`, `litigation`, `full`) or path to custom JSON file (must reside within the working directory)
 - `--seed <number>`: Random seed for reproducible output. Use the same seed to generate identical data
 - `--date-format <format>`: Override the default date format (e.g., "yyyy-MM-dd", "MM/dd/yyyy")
 - `--empty-percentage <0-100>`: Override the default empty value percentage for optional fields

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--bates-start` | 1 | ≥0 | Bates start number |
 | `--bates-digits` | 8 | 1-20 | Bates digit count |
 | `--tiff-pages` | 1-1 (standard mode); random 1–10 per doc in loadfile-only OPT mode | min-max | TIFF page range |
-| `--column-profile` | none | minimal, standard, litigation, full, or path | Column profile |
+| `--column-profile` | none | minimal, standard, litigation, full, or path (within working dir) | Column profile |
 | `--seed` | none | integer | Random seed |
 | `--date-format` | yyyy-MM-dd | format string | Date format override |
 | `--empty-percentage` | 15 | 0-100 | Empty value % override |

--- a/Requirements.md
+++ b/Requirements.md
@@ -695,7 +695,7 @@ This section clarifies behavior when multiple arguments interact:
 ### FR-021: Path Traversal Prevention
 
 - **REQ-106**: The application shall validate the `--output-path` argument to prevent directory traversal attacks. Paths containing `..` components that resolve outside the intended base directory shall be rejected with a clear error message.
-- **TODO-001**: The --column-profile argument accepts user-supplied file paths. A future enhancement should validate that custom profile paths do not escape the intended base directory. Currently unaddressed.
+- **REQ-164**: The application shall validate custom file paths passed to `--column-profile` to prevent directory traversal attacks. Profile paths resolving outside the working directory (or allowed base directory) shall be rejected with a clear error message.
 
 ---
 

--- a/src/Cli/HelpTextGenerator.cs
+++ b/src/Cli/HelpTextGenerator.cs
@@ -69,7 +69,7 @@ internal static class HelpTextGenerator
         Console.Error.WriteLine();
         Console.Error.WriteLine("Column Profile Options:");
         Console.Error.WriteLine("  --column-profile <name>  Built-in profile: minimal, standard, litigation, full");
-        Console.Error.WriteLine("                           Or path to custom JSON profile file");
+        Console.Error.WriteLine("                           Or path to custom JSON profile file (within working directory)");
         Console.Error.WriteLine("  --seed <number>          Random seed for reproducible output");
         Console.Error.WriteLine("  --date-format <fmt>      Override date format (e.g., yyyy-MM-dd)");
         Console.Error.WriteLine("  --empty-percentage <n>   Override empty value percentage (0-100)");

--- a/src/Cli/RequestBuilder.cs
+++ b/src/Cli/RequestBuilder.cs
@@ -28,7 +28,16 @@ public static class RequestBuilder
         ColumnProfile? profile = null;
         if (!string.IsNullOrEmpty(parsed.ColumnProfile))
         {
-            profile = ColumnProfileLoader.Load(parsed.ColumnProfile);
+            try
+            {
+                profile = ColumnProfileLoader.Load(parsed.ColumnProfile);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                return null;
+            }
+
             if (profile is null)
             {
                 Console.Error.WriteLine($"Warning: Failed to load column profile '{parsed.ColumnProfile}'.");

--- a/src/Cli/Validation/CrossCuttingValidator.cs
+++ b/src/Cli/Validation/CrossCuttingValidator.cs
@@ -75,10 +75,19 @@ internal static class CrossCuttingValidator
 
     private static bool ValidateColumnProfile(ParsedArguments parsed)
     {
-        if (!string.IsNullOrEmpty(parsed.ColumnProfile) && !ColumnProfileLoader.IsBuiltInProfile(parsed.ColumnProfile) && !File.Exists(parsed.ColumnProfile))
+        if (!string.IsNullOrEmpty(parsed.ColumnProfile) && !ColumnProfileLoader.IsBuiltInProfile(parsed.ColumnProfile))
         {
-            Console.Error.WriteLine($"Error: Column profile '{parsed.ColumnProfile}' is not a valid built-in profile or file path.\n       Built-in profiles: {string.Join(", ", BuiltInProfiles.ProfileNames)}");
-            return false;
+            if (!PathValidator.IsPathSafe(parsed.ColumnProfile, Directory.GetCurrentDirectory()))
+            {
+                Console.Error.WriteLine($"Error: Path traversal detected in column profile path '{parsed.ColumnProfile}'. Profile file must reside within working directory.");
+                return false;
+            }
+
+            if (!File.Exists(parsed.ColumnProfile))
+            {
+                Console.Error.WriteLine($"Error: Column profile '{parsed.ColumnProfile}' is not a valid built-in profile or file path.\n       Built-in profiles: {string.Join(", ", BuiltInProfiles.ProfileNames)}");
+                return false;
+            }
         }
 
         if (parsed.WithMetadata && !string.IsNullOrEmpty(parsed.ColumnProfile))

--- a/src/PathValidator.cs
+++ b/src/PathValidator.cs
@@ -136,7 +136,7 @@ public static class PathValidator
 
     private static (string resolvedRootPath, System.Collections.Generic.IEnumerable<string> suffixParts)? ResolveLinkTargetWithSuffix(string fullPath)
     {
-        DirectoryInfo? current = new DirectoryInfo(fullPath);
+        FileSystemInfo? current = File.Exists(fullPath) ? new FileInfo(fullPath) : new DirectoryInfo(fullPath);
         var parts = new System.Collections.Generic.List<string>();
 
         while (current is not null)
@@ -151,7 +151,12 @@ public static class PathValidator
                 }
             }
             parts.Add(current.Name);
-            current = current.Parent;
+            current = current switch
+            {
+                DirectoryInfo dir => dir.Parent,
+                FileInfo file => file.Directory,
+                _ => null
+            };
         }
 
         return null;

--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -19,8 +19,9 @@ public static class ColumnProfileLoader
     /// Loads a column profile by name or file path.
     /// </summary>
     /// <param name="nameOrPath">Built-in profile name or path to custom JSON file.</param>
+    /// <param name="baseDirectory">The allowed base directory. Defaults to current directory if null.</param>
     /// <returns>The loaded profile, or null if not found.</returns>
-    public static ColumnProfile? Load(string nameOrPath)
+    public static ColumnProfile? Load(string nameOrPath, string? baseDirectory = null)
     {
         // Check if it's a built-in profile name
         var builtIn = BuiltInProfiles.GetProfile(nameOrPath);
@@ -32,7 +33,7 @@ public static class ColumnProfileLoader
         // Check if it's a file path
         if (File.Exists(nameOrPath))
         {
-            return LoadFromFile(nameOrPath);
+            return LoadFromFile(nameOrPath, baseDirectory);
         }
 
         return null;
@@ -42,10 +43,17 @@ public static class ColumnProfileLoader
     /// Loads a column profile from a JSON file.
     /// </summary>
     /// <param name="filePath">Path to the JSON profile file.</param>
+    /// <param name="baseDirectory">The allowed base directory. Defaults to current directory if null.</param>
     /// <returns>The loaded profile.</returns>
-    /// <exception cref="InvalidOperationException">If the file cannot be parsed or validated.</exception>
-    public static ColumnProfile LoadFromFile(string filePath)
+    /// <exception cref="InvalidOperationException">If the file cannot be parsed or validated, or if path traversal is detected.</exception>
+    public static ColumnProfile LoadFromFile(string filePath, string? baseDirectory = null)
     {
+        var effectiveBase = baseDirectory ?? Directory.GetCurrentDirectory();
+        if (!PathValidator.IsPathSafe(filePath, effectiveBase))
+        {
+            throw new InvalidOperationException($"Path traversal detected in column profile path '{filePath}'. Profile file must reside within allowed base directory.");
+        }
+
         try
         {
             var json = File.ReadAllText(filePath);
@@ -62,6 +70,10 @@ public static class ColumnProfileLoader
         catch (JsonException ex)
         {
             throw new InvalidOperationException($"Invalid JSON in column profile '{filePath}': {ex.Message}", ex);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException($"Unable to read column profile file '{filePath}': {ex.Message}", ex);
         }
     }
 

--- a/src/Zipper.Tests/CliParserTests.cs
+++ b/src/Zipper.Tests/CliParserTests.cs
@@ -303,4 +303,48 @@ public class CliParserTests
             }
         }
     }
+
+    /// <summary>
+    /// REQ-164: A custom profile path containing ".." that resolves outside CWD must be rejected by CliValidator.
+    /// </summary>
+    [Fact]
+    public void Parse_ColumnProfileWithParentTraversal_RejectsPathOutsideCwd()
+    {
+        var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--column-profile", "../outside-profile.json" });
+        Assert.NotNull(result);
+
+        var isValid = CliValidator.Validate(result!);
+        Assert.False(isValid);
+    }
+
+    /// <summary>
+    /// REQ-164: A built-in profile name or safe profile path within CWD must be accepted by CliValidator.
+    /// </summary>
+    [Fact]
+    public void Parse_ColumnProfileWithinCwd_IsAccepted()
+    {
+        var tempProfilePath = Path.Combine(Directory.GetCurrentDirectory(), "temp_profile_" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var validProfileJson = @"{
+                ""name"": ""TempProfile"",
+                ""columns"": [{ ""name"": ""DocID"", ""type"": ""identifier"" }],
+                ""dataSources"": {}
+            }";
+            File.WriteAllText(tempProfilePath, validProfileJson);
+
+            var result = CliParser.Parse(new[] { "--type", "pdf", "--count", "10", "--output-path", Directory.GetCurrentDirectory(), "--column-profile", tempProfilePath });
+            Assert.NotNull(result);
+
+            var isValid = CliValidator.Validate(result!);
+            Assert.True(isValid);
+        }
+        finally
+        {
+            if (File.Exists(tempProfilePath))
+            {
+                File.Delete(tempProfilePath);
+            }
+        }
+    }
 }

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -593,6 +593,33 @@ public class ColumnProfileLoaderTests : IDisposable
         Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void LoadFromFile_WithFileSymlinkOutsideBase_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var subDir = Path.Combine(this.tempDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        var outsideFile = Path.Combine(this.tempDir, "outside-profile.json");
+        File.WriteAllText(outsideFile, "{}");
+
+        var symlinkPath = Path.Combine(subDir, "in-tree-link.json");
+        try
+        {
+            File.CreateSymbolicLink(symlinkPath, outsideFile);
+        }
+        catch
+        {
+            // Skip test on platforms/permissions where creating symlink is unsupported
+            return;
+        }
+
+        // Act & Assert: In-tree symlink pointing to an outside target must be blocked
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ColumnProfileLoader.LoadFromFile(symlinkPath, subDir));
+
+        Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
+    }
+
     private static ColumnProfile CreateMinimalProfile()
     {
         return new ColumnProfile

--- a/src/Zipper.Tests/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/ColumnProfileLoaderTests.cs
@@ -541,6 +541,58 @@ public class ColumnProfileLoaderTests : IDisposable
         Assert.Contains("more weights than values", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void LoadFromFile_WithRelativePathTraversal_ThrowsInvalidOperationException()
+    {
+        // Arrange: Create a subfolder and a file outside of it
+        var subDir = Path.Combine(this.tempDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        var outsideFile = Path.Combine(this.tempDir, "outside-profile.json");
+        File.WriteAllText(outsideFile, "{}");
+
+        var traversalPath = Path.Combine(subDir, "..", "outside-profile.json");
+
+        // Act & Assert: When base directory is subDir, referencing file in parent dir must throw
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ColumnProfileLoader.LoadFromFile(traversalPath, subDir));
+
+        Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromFile_WithAbsolutePathOutsideBase_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var subDir = Path.Combine(this.tempDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        var outsideFile = Path.Combine(this.tempDir, "outside-profile.json");
+        File.WriteAllText(outsideFile, "{}");
+
+        // Act & Assert: Absolute path outside subDir base must throw
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ColumnProfileLoader.LoadFromFile(outsideFile, subDir));
+
+        Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_WithRelativePathTraversalExistingFile_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var subDir = Path.Combine(this.tempDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        var outsideFile = Path.Combine(this.tempDir, "outside-profile.json");
+        File.WriteAllText(outsideFile, "{}");
+
+        var traversalPath = Path.Combine(subDir, "..", "outside-profile.json");
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ColumnProfileLoader.Load(traversalPath, subDir));
+
+        Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
+    }
+
     private static ColumnProfile CreateMinimalProfile()
     {
         return new ColumnProfile
@@ -554,3 +606,4 @@ public class ColumnProfileLoaderTests : IDisposable
         };
     }
 }
+

--- a/tests/test-path-traversal-security.bat
+++ b/tests/test-path-traversal-security.bat
@@ -49,7 +49,7 @@ echo Test 2: Path traversal with ..\ should be blocked
 dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "%TEST_DIR%\..\security_test" > "%TEMP%\security_output.txt" 2>&1
 set SECURITY_EXIT_CODE=%errorlevel%
 findstr /C:"Path traversal detected" "%TEMP%\security_output.txt" > nul
-if !errorlevel! neq 0 if !SECURITY_EXIT_CODE! neq 0 (
+if !errorlevel! equ 0 if !SECURITY_EXIT_CODE! neq 0 (
     echo [OK] Path traversal with ..\ was properly blocked
     for /f "tokens=*" %%a in ('findstr /C:"Path traversal detected" "%TEMP%\security_output.txt"') do echo    Error message: %%a
 ) else (
@@ -63,18 +63,18 @@ echo Test 3: Absolute path traversal attempt should be blocked
 dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "C:\Windows\System32\security_test" > "%TEMP%\system_output.txt" 2>&1
 set SYSTEM_EXIT_CODE=%errorlevel%
 findstr /C:"Path traversal detected" "%TEMP%\system_output.txt" > nul
-if !errorlevel! neq 0 (
-    findstr /C:"Invalid path" "%TEMP%\system_output.txt" > nul
-    if !errorlevel! neq 0 if !SYSTEM_EXIT_CODE! neq 0 (
-        echo [OK] Absolute path traversal was properly blocked
-        for /f "tokens=*" %%a in ('findstr /C:"Path traversal detected" "%TEMP%\system_output.txt"') do echo    Error message: %%a
-    ) else (
-        echo [OK] Absolute path traversal was properly blocked (invalid path)
-        for /f "tokens=*" %%a in ('findstr /C:"Invalid path" "%TEMP%\system_output.txt"') do echo    Error message: %%a
-    )
-) else (
+if !errorlevel! equ 0 (
     echo [OK] Absolute path traversal was properly blocked
     for /f "tokens=*" %%a in ('findstr /C:"Path traversal detected" "%TEMP%\system_output.txt"') do echo    Error message: %%a
+) else (
+    findstr /C:"Invalid path" "%TEMP%\system_output.txt" > nul
+    if !errorlevel! equ 0 if !SYSTEM_EXIT_CODE! neq 0 (
+        echo [OK] Absolute path traversal was properly blocked (invalid path)
+        for /f "tokens=*" %%a in ('findstr /C:"Invalid path" "%TEMP%\system_output.txt"') do echo    Error message: %%a
+    ) else (
+        echo [FAIL] Absolute path traversal was not properly blocked
+        echo    Exit code: !SYSTEM_EXIT_CODE!
+    )
 )
 
 REM Test 4: Path with invalid characters should be blocked
@@ -83,7 +83,7 @@ echo Test 4: Path with invalid characters should be blocked
 dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "%TEST_DIR%\invalid<name" > "%TEMP%\invalid_output.txt" 2>&1
 set INVALID_EXIT_CODE=%errorlevel%
 findstr /C:"Invalid character" "%TEMP%\invalid_output.txt" > nul
-if !errorlevel! neq 0 if !INVALID_EXIT_CODE! neq 0 (
+if !errorlevel! equ 0 if !INVALID_EXIT_CODE! neq 0 (
     echo [OK] Path with invalid characters was properly blocked
     for /f "tokens=*" %%a in ('findstr /C:"Invalid character" "%TEMP%\invalid_output.txt"') do echo    Error message: %%a
 ) else (
@@ -97,16 +97,36 @@ echo Test 5: Empty path should be blocked
 dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "" > "%TEMP%\empty_output.txt" 2>&1
 set EMPTY_EXIT_CODE=%errorlevel%
 findstr /C:"cannot be null or empty" "%TEMP%\empty_output.txt" > nul
-if !errorlevel! neq 0 if !EMPTY_EXIT_CODE! neq 0 (
+if !errorlevel! equ 0 if !EMPTY_EXIT_CODE! neq 0 (
     echo [OK] Empty path was properly handled
     for /f "tokens=*" %%a in ('findstr /C:"cannot be null or empty" "%TEMP%\empty_output.txt"') do echo    Error message: %%a
 ) else (
-    echo [FAIL] Empty path was not properly handled
-    echo    Exit code: !EMPTY_EXIT_CODE!
+    findstr /C:"Output path is required" "%TEMP%\empty_output.txt" > nul
+    if !errorlevel! equ 0 if !EMPTY_EXIT_CODE! neq 0 (
+        echo [OK] Empty path was properly handled
+        for /f "tokens=*" %%a in ('findstr /C:"Output path is required" "%TEMP%\empty_output.txt"') do echo    Error message: %%a
+    ) else (
+        echo [FAIL] Empty path was not properly handled
+        echo    Exit code: !EMPTY_EXIT_CODE!
+    )
+)
+
+REM Test 7: Custom column profile path traversal with ..\ should be blocked
+echo.
+echo Test 7: Custom column profile path traversal with ..\ should be blocked
+dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "%TEST_DIR%\profile_test" --column-profile "..\outside-profile.json" > "%TEMP%\profile_output.txt" 2>&1
+set PROF_EXIT_CODE=%errorlevel%
+findstr /C:"Path traversal detected" "%TEMP%\profile_output.txt" > nul
+if !errorlevel! equ 0 if !PROF_EXIT_CODE! neq 0 (
+    echo [OK] Custom column profile path traversal with ..\ was properly blocked
+    for /f "tokens=*" %%a in ('findstr /C:"Path traversal detected" "%TEMP%\profile_output.txt"') do echo    Error message: %%a
+) else (
+    echo [FAIL] Custom column profile path traversal with ..\ was not properly blocked
+    echo    Exit code: !PROF_EXIT_CODE!
 )
 
 REM Cleanup temp files
-del /q "%TEMP%\security_output.txt" "%TEMP%\system_output.txt" "%TEMP%\invalid_output.txt" "%TEMP%\empty_output.txt" > nul 2>&1
+del /q "%TEMP%\security_output.txt" "%TEMP%\system_output.txt" "%TEMP%\invalid_output.txt" "%TEMP%\empty_output.txt" "%TEMP%\profile_output.txt" > nul 2>&1
 
 REM Cleanup test directory
 echo.

--- a/tests/test-path-traversal-security.bat
+++ b/tests/test-path-traversal-security.bat
@@ -63,7 +63,7 @@ echo Test 3: Absolute path traversal attempt should be blocked
 dotnet "%ZIPPER_DLL%" --type pdf --count 5 --output-path "C:\Windows\System32\security_test" > "%TEMP%\system_output.txt" 2>&1
 set SYSTEM_EXIT_CODE=%errorlevel%
 findstr /C:"Path traversal detected" "%TEMP%\system_output.txt" > nul
-if !errorlevel! equ 0 (
+if !errorlevel! equ 0 if !SYSTEM_EXIT_CODE! neq 0 (
     echo [OK] Absolute path traversal was properly blocked
     for /f "tokens=*" %%a in ('findstr /C:"Path traversal detected" "%TEMP%\system_output.txt"') do echo    Error message: %%a
 ) else (
@@ -74,6 +74,7 @@ if !errorlevel! equ 0 (
     ) else (
         echo [FAIL] Absolute path traversal was not properly blocked
         echo    Exit code: !SYSTEM_EXIT_CODE!
+        set TOTAL_FAILURES=1
     )
 )
 
@@ -123,6 +124,7 @@ if !errorlevel! equ 0 if !PROF_EXIT_CODE! neq 0 (
 ) else (
     echo [FAIL] Custom column profile path traversal with ..\ was not properly blocked
     echo    Exit code: !PROF_EXIT_CODE!
+    set TOTAL_FAILURES=1
 )
 
 REM Cleanup temp files
@@ -142,5 +144,11 @@ echo - Invalid characters are detected and rejected
 echo - Normal valid paths continue to work correctly
 echo - Security fixes do not break legitimate functionality
 echo.
+
+if defined TOTAL_FAILURES (
+    echo [FAIL] Security test failures detected.
+    endlocal
+    exit /b 1
+)
 
 endlocal

--- a/tests/test-path-traversal-security.sh
+++ b/tests/test-path-traversal-security.sh
@@ -119,6 +119,7 @@ else
     echo "❌ Custom column profile path traversal with ../ was not properly blocked"
     echo "   Exit code: $PROF_EXIT_CODE"
     echo "   Output: $PROF_OUTPUT"
+    TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
 fi
 
 # Cleanup
@@ -134,3 +135,8 @@ echo "- Path traversal attempts are properly blocked"
 echo "- Invalid characters are detected and rejected"
 echo "- Normal valid paths continue to work correctly"
 echo "- Security fixes do not break legitimate functionality"
+
+if [[ ${TOTAL_FAILURES:-0} -gt 0 ]]; then
+    echo "❌ Security test failures detected ($TOTAL_FAILURES failure(s))"
+    exit 1
+fi

--- a/tests/test-path-traversal-security.sh
+++ b/tests/test-path-traversal-security.sh
@@ -106,6 +106,21 @@ else
     echo "   Output: $MIXED_OUTPUT"
 fi
 
+# Test 7: Custom column profile path traversal with ../ should be blocked
+echo ""
+echo "Test 7: Custom column profile path traversal with ../ should be blocked"
+
+PROF_OUTPUT=$(zipper --type pdf --count 5 --output-path "$TEST_DIR/profile_test" --column-profile "../outside-profile.json" 2>&1) && PROF_EXIT_CODE=0 || PROF_EXIT_CODE=$?
+
+if [[ $PROF_EXIT_CODE -ne 0 ]] && echo "$PROF_OUTPUT" | grep -q "Path traversal detected"; then
+    echo "✅ Custom column profile path traversal with ../ was properly blocked"
+    echo "   Error message: $(echo "$PROF_OUTPUT" | grep "Path traversal detected" | head -1)"
+else
+    echo "❌ Custom column profile path traversal with ../ was not properly blocked"
+    echo "   Exit code: $PROF_EXIT_CODE"
+    echo "   Output: $PROF_OUTPUT"
+fi
+
 # Cleanup
 echo ""
 echo "Cleaning up test directory..."


### PR DESCRIPTION
Fixes #600

## Description
Validates custom Column Profile file paths passed to `--column-profile` against path traversal attacks. Custom profile file paths resolving outside the working directory (or allowed base directory) are rejected with a clear error message.

## Release Notes
Adds path traversal validation for custom Column Profile file paths, preventing access to files outside the working directory.

## Architecture
- [x] Unchanged / N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Custom column profile paths are now restricted to the working directory, preventing directory traversal and access to files outside the allowed location.
  * Unsafe, inaccessible, or invalid profile files now produce clear validation errors.

* **Documentation**
  * Clarified that `--column-profile` accepts built-in profile names or custom JSON files located within the working directory.

* **Tests**
  * Expanded coverage for safe paths, traversal attempts, invalid paths, and reported command-line errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->