### PR TITLE
ci(testing): run Zipper.Analyzers.Tests in automated gates (#632)

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -122,6 +122,17 @@ if ! dotnet test src/Zipper.Tests/Zipper.Tests.csproj --logger "console;verbosit
     exit 1
 fi
 
+ANALYZER_TRIGGER=$(printf '%s\n' "$STAGED" | grep -c -E '(^|/)(src/Zipper\.Analyzers/|src/Zipper\.Analyzers\.Tests/|Directory\.Build\.props$|Directory\.Packages\.props$|\.editorconfig$|zipper\.sln$|global\.json$)' || true)
+if [[ "$ANALYZER_TRIGGER" -gt 0 ]]; then
+    echo "▶ Running analyzer tests..."
+    if ! dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj --logger "console;verbosity=quiet"; then
+        echo "❌ Analyzer unit tests failed. Commit aborted." >&2
+        echo "   Run 'dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj' for full output." >&2
+        echo "   To bypass: git commit --no-verify" >&2
+        exit 1
+    fi
+fi
+
 echo "✓ Pre-commit: format + unit tests passed"
 
 # Success handshake with post-commit:

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -50,6 +50,14 @@ if [[ "$RUN_UNIT_TESTS" == "true" ]]; then
         echo "   To bypass: git push --no-verify"
         exit 1
     fi
+    if ! dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj \
+            --logger "console;verbosity=quiet" --nologo; then
+        echo ""
+        echo "❌ Analyzer unit tests failed. Push aborted."
+        echo "   Run 'dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj' for details."
+        echo "   To bypass: git push --no-verify"
+        exit 1
+    fi
     echo "✓ Unit tests passed"
 fi
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ What does this PR change and why?
 
 ## Testing Done
 
-- [ ] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`)
+- [ ] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`)
 - [ ] E2E tests pass (`bash tests/run-tests.sh`)
 - [ ] Lint clean (`dotnet format --verify-no-changes src/`)
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,6 +107,9 @@ jobs:
             --logger "console;verbosity=normal" \
             --collect:"XPlat Code Coverage" \
             --results-directory ./TestResults
+          dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj \
+            -c Release --no-build \
+            --logger "console;verbosity=normal"
 
       - name: Coverage report + 80% gate (Linux)
         if: runner.os == 'Linux'
@@ -114,7 +117,9 @@ jobs:
 
       - name: Unit tests (non-Linux)
         if: runner.os != 'Linux'
-        run: dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
+        run: |
+          dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
+          dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
 
       # Publish self-contained per platform
       - name: Publish self-contained binary

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -141,6 +141,9 @@ jobs:
             --logger "junit;LogFilePath=TestResults/test-results.xml" \
             --collect:"XPlat Code Coverage" \
             --results-directory ./TestResults
+          dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj \
+            -c Release --no-build \
+            --logger "console;verbosity=normal"
 
       - name: Check for deprecated/vulnerable NuGet packages (Linux)
         if: matrix.coverage == true
@@ -188,7 +191,9 @@ jobs:
 
       - name: Unit tests (non-Linux)
         if: matrix.coverage != true
-        run: dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
+        run: |
+          dotnet test src/Zipper.Tests/Zipper.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
+          dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"
 
       - name: Run full E2E suite (same as main CI)
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj          # 
 dotnet format --verify-no-changes src/   # Format check (run after every code change)
 
 # Build + lint + test combo (run after every change)
-dotnet build zipper.sln && dotnet format --verify-no-changes src/ && dotnet test src/Zipper.Tests/Zipper.Tests.csproj
+dotnet build zipper.sln && dotnet format --verify-no-changes src/ && dotnet test src/Zipper.Tests/Zipper.Tests.csproj && dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj
 
 # E2E (must pass before push)
 # The pre-push hook runs the basic E2E smoke against src/bin/Release — build Release first.
@@ -128,7 +128,7 @@ Verify behavior changes against Requirements.md before committing. Run `grep -n 
    - If the newest substantive comment contradicts the body, follow the comment and say so in the PR.
    - If the issue itself is stale (the code it describes no longer exists, or another change already resolved it), do not implement it as written — comment on the issue with evidence and a recommendation (close or retarget), then stop.
 5. Write a failing test first (TDD), then implement the fix
-6. Run `dotnet format --verify-no-changes src/` and `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` after every change
+6. Run `dotnet format --verify-no-changes src/` and `dotnet test src/Zipper.Tests/Zipper.Tests.csproj && dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj` after every change
 7. Run autoreview before creating PR (see Adversarial Review section below). *Required for any change touching logic, error handling, or public contracts. For docs-only, version-bump, or single-line fixes, a self-review suffices — note the exemption in the PR.*
 8. Commit and create PR — include `## Release Notes` per the [Release Notes Mandate](#release-notes-mandate) below
 9. Monitor CI until all checks pass; fix failures before requesting review. Reproduce each gate locally first — see the [docs/cicd.md](docs/cicd.md#quick-reference-for-agents) gate-to-command table so you fail fast instead of waiting on CI minutes. If a CI failure appears flaky (same test passes locally, or failure is in an unrelated component), re-run once. If it fails again, document the flake in the PR and proceed to request review. Push fixes via `git commit --amend --no-edit && git push --force-with-lease`.

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -123,7 +123,7 @@ Reproduce each CI gate locally **before** pushing — CI minutes are slow feedba
 |---------|------------------|
 | lint (format) | `dotnet format --verify-no-changes src/` |
 | build | `dotnet build zipper.sln -c Release` |
-| unit tests + coverage gate | `dotnet test src/Zipper.Tests/Zipper.Tests.csproj` |
+| unit tests + coverage gate | `dotnet test src/Zipper.Tests/Zipper.Tests.csproj && dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj` |
 | full E2E | `dotnet build -c Release && ./tests/run-tests.sh` (Unix) / `dotnet build -c Release && tests\run-tests.bat` (Windows) |
 | basic E2E smoke (pre-push) | `./tests/run-e2e-basic.sh` (Unix) / `tests\run-e2e-basic.bat` (Windows) |
 | goldens | `dotnet publish src/Zipper.csproj -c Release -o ./publish-bin && ZIPPER_CLI=$(pwd)/publish-bin/Zipper bash tests/goldens/run-goldens.sh` |


### PR DESCRIPTION
## Release Notes
Configures automated gates (GitHub Actions workflows and local git hooks) to execute Zipper.Analyzers.Tests alongside product unit tests.

Fixes #632

## Description
Ensures `Zipper.Analyzers.Tests` is executed in `pr.yml`, `build-and-test.yml`, `pre-commit`, and `pre-push` gates.

## Type of Change
- [x] CI/Build
- [x] Test coverage

## Testing Done
- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)