### PR TITLE
fix(ci): do not classify text build inputs as docs-only (#631)

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -23,7 +23,7 @@ fi
 # Docs-only = every staged file matches one of the doc patterns.
 # Use a positive filter (count matches) to avoid || true masking genuine failures.
 TOTAL=$(printf '%s\n' "$STAGED" | grep -c .)
-DOCS=$(printf '%s\n' "$STAGED" | grep -c -E '(^|/)(docs/|CHANGELOG\.md$|.*\.(md|txt)$)' || true)
+DOCS=$(printf '%s\n' "$STAGED" | grep -c -E '(^|/)(docs/|CHANGELOG(\.md)?$|.*\.(md|markdown)$)' || true)
 if [[ "$TOTAL" -gt 0 && "$DOCS" -eq "$TOTAL" ]]; then
     echo "✓ Pre-commit: docs-only change, skipping build/test."
     exit 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
           # as docs-only. Count matches explicitly (no `|| true` masking).
           total=$(printf '%s\n' "$files" | grep -c . || true)
           docs=$(printf '%s\n' "$files" \
-              | grep -c -E '(^|/)(docs/|CHANGELOG\.md$|.*\.(md|txt)$)' || true)
+              | grep -c -E '(^|/)(docs/|CHANGELOG(\.md)?$|.*\.(md|markdown)$)' || true)
 
           if [[ "$total" -gt 0 && "$docs" -eq "$total" ]]; then
             echo "Docs-only PR detected ($total files, all docs); skipping build and tests."

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -64,7 +64,7 @@ Version-controlled in [`.github/hooks/`](../.github/hooks/), installed with `./s
 
 | Hook | Trigger | Does |
 |------|---------|------|
-| `pre-commit` | `git commit` | Short-circuits if every staged file is docs (`*.md`, `*.txt`, `docs/`). Else stashes unstaged changes, runs `dotnet format` on staged `*.cs`, runs all unit tests. |
+| `pre-commit` | `git commit` | Short-circuits if every staged file is docs (`*.md`, `docs/`). Else stashes unstaged changes, runs `dotnet format` on staged `*.cs`, runs all unit tests. |
 | `post-commit` | after commit object exists | Writes `pre-commit.ok` marker (timestamp + new HEAD) so pre-push can skip redundant unit tests. |
 | `pre-push` | `git push` | Unit tests (skipped if marker is <10 min old on current HEAD) + basic E2E smoke (`tests/run-e2e-basic.sh` / `.bat`). |
 

--- a/tests/run-tests.bat
+++ b/tests/run-tests.bat
@@ -573,6 +573,15 @@ if errorlevel 1 (
 )
 call :print_success "CLI coverage gap tests passed."
 
+REM Test 14b: CI build props tests
+call :print_info "Running CI build props tests..."
+call .\tests\test-ci-build-props.bat
+if errorlevel 1 (
+    echo [ ERROR ] CI build props tests failed.
+    exit /b 1
+)
+call :print_success "CI build props tests passed."
+
 REM Test 15: Target-zip-size smoke tests
 call :print_info "Running target-zip-size smoke tests..."
 call .\tests\test-target-zip-size.bat

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -641,6 +641,10 @@ print_info "Running CLI coverage gap tests..."
 bash ./tests/test-cli-coverage-gaps.sh || print_error "test-cli-coverage-gaps.sh failed."
 print_success "CLI coverage gap tests passed."
 
+print_info "Running CI build properties and docs-only classification tests..."
+bash ./tests/test-ci-build-props.sh || print_error "test-ci-build-props.sh failed."
+print_success "CI build properties and docs-only classification tests passed."
+
 # FGR guard: FileGenerationRequest must not have flat pass-through properties (see #213).
 print_info "Checking for flat pass-through properties on FileGenerationRequest..."
 if grep -q 'get => this\.[A-Z][a-z]*\.' src/FileGenerationRequest.cs; then

--- a/tests/test-ci-build-props.bat
+++ b/tests/test-ci-build-props.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "SCRIPT_DIR=%~dp0"
+set "PROJECT_PATH=%SCRIPT_DIR%..\src\Zipper.csproj"
+
+echo Testing Deterministic property...
+for /f "usebackq delims=" %%i in (`dotnet msbuild "%PROJECT_PATH%" -getProperty:Deterministic`) do set "DETERMINISTIC=%%i"
+if not "!DETERMINISTIC!"=="true" (
+    echo FAIL: Deterministic is not true. Got '!DETERMINISTIC!'
+    exit /b 1
+)
+
+echo Testing ContinuousIntegrationBuild property (CI=true)...
+set "CI=true"
+for /f "usebackq delims=" %%i in (`dotnet msbuild "%PROJECT_PATH%" -getProperty:ContinuousIntegrationBuild`) do set "CI_BUILD=%%i"
+if not "!CI_BUILD!"=="true" (
+    echo FAIL: ContinuousIntegrationBuild is not true when CI=true. Got '!CI_BUILD!'
+    exit /b 1
+)
+set "CI="
+
+echo Testing ContinuousIntegrationBuild property (GITHUB_ACTIONS=true)...
+set "GITHUB_ACTIONS=true"
+for /f "usebackq delims=" %%i in (`dotnet msbuild "%PROJECT_PATH%" -getProperty:ContinuousIntegrationBuild`) do set "GH_BUILD=%%i"
+if not "!GH_BUILD!"=="true" (
+    echo FAIL: ContinuousIntegrationBuild is not true when GITHUB_ACTIONS=true. Got '!GH_BUILD!'
+    exit /b 1
+)
+set "GITHUB_ACTIONS="
+
+echo PASS: Build properties are correct.
+exit /b 0

--- a/tests/test-ci-build-props.sh
+++ b/tests/test-ci-build-props.sh
@@ -32,4 +32,27 @@ if [[ "$NO_CI_BUILD" == "true" ]]; then
     exit 1
 fi
 
-echo "PASS: Build properties are correct."
+echo "Testing docs-only regex classification..."
+DOCS_REGEX='(^|/)(docs/|CHANGELOG(\.md)?$|.*\.(md|markdown)$)'
+
+is_docs() {
+    echo "$1" | grep -q -E "$DOCS_REGEX"
+}
+
+# Documentation files MUST match:
+for file in "README.md" "AGENTS.md" "Requirements.md" "UBIQUITOUS_LANGUAGE.md" "docs/cicd.md" "docs/architecture.md" "docs/notes.txt" "src/folder/README.md" "CHANGELOG.md"; do
+    if ! is_docs "$file"; then
+        echo "FAIL: '$file' should be classified as documentation"
+        exit 1
+    fi
+done
+
+# Non-documentation files MUST NOT match:
+for file in "BannedSymbols.txt" "tests/fixtures/chaos-anomaly-types.txt" "tests/fixtures/profiles/expected-headers/full.txt" "src/Program.cs" "zipper.sln"; do
+    if is_docs "$file"; then
+        echo "FAIL: '$file' should NOT be classified as documentation"
+        exit 1
+    fi
+done
+
+echo "PASS: Build properties and docs-only classification are correct."


### PR DESCRIPTION
## Release Notes
Fixes docs-only filters in PR workflow and pre-commit hook so text build inputs (such as BannedSymbols.txt and test fixtures) run full build, test, and validation pipelines instead of being misclassified as documentation.

Fixes #631

## Description
Updates the docs-only regex filter in `.github/workflows/pr.yml` and `.github/hooks/pre-commit` from `.*\.(md|txt)$` to `(^|/)(docs/|CHANGELOG(\.md)?$|.*\.(md|markdown)$)`.

## Type of Change
- [x] Bug fix
- [x] CI/Build
- [x] Test coverage

## Testing Done
- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`)
- [x] Classification tests pass (`bash tests/test-ci-build-props.sh`)
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Actionlint clean (`actionlint .github/workflows/pr.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved docs-only change detection for Markdown files, documentation folders, and changelog files.
  * Prevented `.txt` files from being incorrectly classified as documentation-only changes.

* **Documentation**
  * Updated CI documentation to reflect the revised docs-only criteria.

* **Tests**
  * Added validation for documentation and non-documentation file classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->