### PR TITLE
fix(e2e): quiet unzip and increase file count for 4.5GB Zip64 test (#662)

### DIFF
--- a/tests/test-zip64-boundary.sh
+++ b/tests/test-zip64-boundary.sh
@@ -55,7 +55,7 @@ else
 fi
 
 # 2. Structural validity by a second tool
-if unzip -t "$ZIP_FILE" ; then
+if unzip -t -q "$ZIP_FILE" ; then
     print_info "Assertion OK: unzip -t exited 0 (structurally valid)"
     PASSED=$((PASSED + 1))
 else
@@ -97,7 +97,7 @@ if [[ "${RUN_4GB_CASE:-false}" == "true" ]]; then
     OUT_4GB="$TEST_OUTPUT_DIR/4gb"
     mkdir -p "$OUT_4GB"
     
-    zipper --type pdf --count 10 --target-zip-size 4500MB --output-path "$OUT_4GB" --seed 42 
+    zipper --type pdf --count 50 --target-zip-size 4500MB --output-path "$OUT_4GB" --seed 42 
     
     ZIP_4GB=$(find "$OUT_4GB" -name "*.zip" -print | head -n 1 || true)
     if [[ -z "$ZIP_4GB" ]]; then
@@ -109,7 +109,7 @@ if [[ "${RUN_4GB_CASE:-false}" == "true" ]]; then
             print_info "Assertion OK: 4GB archive generated successfully ($SIZE bytes)"
             PASSED=$((PASSED + 1))
             
-            if unzip -t "$ZIP_4GB" ; then
+            if unzip -t -q "$ZIP_4GB" ; then
                 print_info "Assertion OK: unzip -t exited 0 on 4GB archive"
                 PASSED=$((PASSED + 1))
             else


### PR DESCRIPTION
## Summary
Fixes #662 where the Zip64 boundary test failed in nightly CI.

## Root Cause & Fix
1. In [44m[ INFO ][0m Generating archive with 70000 files to cross 65,535 boundary...
Starting parallel file generation...
  File Type: jpg
  Count: 70,000
  Output Path: /home/dom/Downloads/repos/zipper/results/zip64-boundary
  Folders: 1
  Encoding: UTF-8
  Distribution: Proportional
Progress: 1,000 / 70,000 files (1.4%) - 4274.2 files/sec - ETA: 00:00:16          Progress: 7,000 / 70,000 files (10.0%) - 20463.2 files/sec - ETA: 00:00:03          Progress: 13,000 / 70,000 files (18.6%) - 28321.0 files/sec - ETA: 00:00:02          Progress: 19,000 / 70,000 files (27.1%) - 33805.4 files/sec - ETA: 00:00:01          Progress: 25,000 / 70,000 files (35.7%) - 36574.0 files/sec - ETA: 00:00:01          Progress: 31,000 / 70,000 files (44.3%) - 37785.5 files/sec - ETA: 00:00:01          Progress: 37,000 / 70,000 files (52.9%) - 39139.1 files/sec - ETA: 00:00:00          Progress: 43,000 / 70,000 files (61.4%) - 40301.9 files/sec - ETA: 00:00:00          Progress: 49,000 / 70,000 files (70.0%) - 39301.1 files/sec - ETA: 00:00:00          Progress: 55,000 / 70,000 files (78.6%) - 39323.0 files/sec - ETA: 00:00:00          Progress: 61,000 / 70,000 files (87.1%) - 39611.1 files/sec - ETA: 00:00:00          


Generation complete in 2.5 seconds.
  Archive created: /home/dom/Downloads/repos/zipper/results/zip64-boundary/archive_20260723_194249.zip
  Performance: 28331.6 files/second
  Load file created: /home/dom/Downloads/repos/zipper/results/zip64-boundary/archive_20260723_194249.opt
[44m[ INFO ][0m Found generated archive: ./results/zip64-boundary/archive_20260723_194249.zip
[44m[ INFO ][0m Assertion OK: unzip -Z1 found 70000 jpg files
[44m[ INFO ][0m Assertion OK: unzip -Z1 found 70000 total entries
No errors detected in compressed data of ./results/zip64-boundary/archive_20260723_194249.zip.
[44m[ INFO ][0m Assertion OK: unzip -t exited 0 (structurally valid)
[44m[ INFO ][0m Assertion OK: Python zipfile parser found 70000 entries (Zip64 format engaged properly)
[44m[ INFO ][0m Assertion OK: Load file (.opt) has 70000 lines

[42m[ SUCCESS ][0m All Zip64 boundary tests passed! (5/5),  was called with . Because file generators cap individual file size at 100MB max per file, 10 files produced at most 1000MB (~1GB), causing the 4.5GB archive size assertion to fail. Increased  to 50 files so 50 files * 90MB = 4.5GB.
2. Added  (quiet) flag to UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.

Usage: unzip [-Z] [-opts[modifiers]] file[.zip] [list] [-x xlist] [-d exdir]
  Default action is to extract files in list, except those in xlist, to exdir;
  file[.zip] may be a wildcard.  -Z => ZipInfo mode ("unzip -Z" for usage).

  -p  extract files to pipe, no messages     -l  list files (short format)
  -f  freshen existing files, create none    -t  test compressed archive data
  -u  update files, create if necessary      -z  display archive comment only
  -v  list verbosely/show version info       -T  timestamp archive to latest
  -x  exclude files that follow (in xlist)   -d  extract files into exdir
modifiers:
  -n  never overwrite existing files         -q  quiet mode (-qq => quieter)
  -o  overwrite files WITHOUT prompting      -a  auto-convert any text files
  -j  junk paths (do not make directories)   -aa treat ALL files as text
  -U  use escapes for all non-ASCII Unicode  -UU ignore any Unicode fields
  -C  match filenames case-insensitively     -L  make (some) names lowercase
  -X  restore UID/GID info                   -V  retain VMS version numbers
  -K  keep setuid/setgid/tacky permissions   -M  pipe through "more" pager
  -O CHARSET  specify a character encoding for DOS, Windows and OS/2 archives
  -I CHARSET  specify a character encoding for UNIX and other archives

See "unzip -hh" or unzip.txt for more help.  Examples:
  unzip data1 -x joe   => extract all files except joe from zipfile data1.zip
  unzip -p foo | more  => send contents of foo.zip via pipe into program more
  unzip -fo foo ReadMe => quietly replace existing ReadMe if archive file newer checks in [44m[ INFO ][0m Generating archive with 70000 files to cross 65,535 boundary...
Starting parallel file generation...
  File Type: jpg
  Count: 70,000
  Output Path: /home/dom/Downloads/repos/zipper/results/zip64-boundary
  Folders: 1
  Encoding: UTF-8
  Distribution: Proportional
Progress: 1,000 / 70,000 files (1.4%) - 3734.4 files/sec - ETA: 00:00:18          Progress: 7,000 / 70,000 files (10.0%) - 17595.6 files/sec - ETA: 00:00:03          Progress: 13,000 / 70,000 files (18.6%) - 22814.4 files/sec - ETA: 00:00:02          Progress: 19,000 / 70,000 files (27.1%) - 26886.9 files/sec - ETA: 00:00:01          Progress: 25,000 / 70,000 files (35.7%) - 29436.0 files/sec - ETA: 00:00:01          Progress: 31,000 / 70,000 files (44.3%) - 31058.4 files/sec - ETA: 00:00:01          Progress: 37,000 / 70,000 files (52.9%) - 32759.9 files/sec - ETA: 00:00:01          Progress: 43,000 / 70,000 files (61.4%) - 33222.7 files/sec - ETA: 00:00:00          Progress: 49,000 / 70,000 files (70.0%) - 32582.6 files/sec - ETA: 00:00:00          Progress: 55,000 / 70,000 files (78.6%) - 32439.2 files/sec - ETA: 00:00:00          Progress: 61,000 / 70,000 files (87.1%) - 32636.0 files/sec - ETA: 00:00:00          Progress: 66,659 / 70,000 files (95.2%) - 33435.4 files/sec - ETA: 00:00:00          


Generation complete in 2.8 seconds.
  Archive created: /home/dom/Downloads/repos/zipper/results/zip64-boundary/archive_20260723_194256.zip
  Performance: 24628.1 files/second
  Load file created: /home/dom/Downloads/repos/zipper/results/zip64-boundary/archive_20260723_194256.opt
[44m[ INFO ][0m Found generated archive: ./results/zip64-boundary/archive_20260723_194256.zip
[44m[ INFO ][0m Assertion OK: unzip -Z1 found 70000 jpg files
[44m[ INFO ][0m Assertion OK: unzip -Z1 found 70000 total entries
No errors detected in compressed data of ./results/zip64-boundary/archive_20260723_194256.zip.
[44m[ INFO ][0m Assertion OK: unzip -t exited 0 (structurally valid)
[44m[ INFO ][0m Assertion OK: Python zipfile parser found 70000 entries (Zip64 format engaged properly)
[44m[ INFO ][0m Assertion OK: Load file (.opt) has 70000 lines

[42m[ SUCCESS ][0m All Zip64 boundary tests passed! (5/5) to suppress printing 70,000 file entries to stdout, preventing I/O bottlenecks and timeouts during nightly CI execution.

## Release Notes
Fixed Zip64 boundary E2E test by adding quiet flag to unzip structural validation and increasing test file count to 50 files for 4.5GB target size verification, ensuring tests complete reliably within CI timeout limits.