### PR TITLE
perf(loadfiles): eliminate string and byte array allocations in LoadFileEmitter chaos path (#612)

### DIFF
--- a/src/LoadFiles/LoadFileEmitter.cs
+++ b/src/LoadFiles/LoadFileEmitter.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 
 namespace Zipper.LoadFiles;
@@ -139,7 +140,21 @@ internal static class LoadFileEmitter
             ? chaosEngine.Intercept(lineNumber, originalLine, recordId)
             : originalLine;
 
-        await stream.WriteAsync(encoding.GetBytes(text + eol), cancellationToken).ConfigureAwait(false);
+        int textByteCount = encoding.GetByteCount(text);
+        int eolByteCount = encoding.GetByteCount(eol);
+        int totalByteCount = textByteCount + eolByteCount;
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(totalByteCount);
+        try
+        {
+            int textWritten = encoding.GetBytes(text.AsSpan(), buffer.AsSpan());
+            int eolWritten = encoding.GetBytes(eol.AsSpan(), buffer.AsSpan(textWritten));
+            await stream.WriteAsync(buffer.AsMemory(0, textWritten + eolWritten), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
 
         var anomaly = chaosEngine.GetEncodingAnomaly(lineNumber, lineNumber + 1, encoding);
         if (anomaly is not null)


### PR DESCRIPTION
## Summary
Resolves #612 by eliminating per-row string concatenation () and  allocations in .

## Changes Made
- Used  in .
- Encoded  and  directly into the rented buffer using .
- Written line and EOL in a single  call and returned the buffer to  in a  block.

## Release Notes
Optimized memory efficiency in LoadFileEmitter chaos path by renting byte encoding buffers from ArrayPool<byte>.Shared and eliminating per-row string concatenation and byte array allocations.