### PR TITLE
ci(gate): enforce per-file line coverage floor in CI (#604)

### DIFF
--- a/.github/actions/coverage-gate/action.yml
+++ b/.github/actions/coverage-gate/action.yml
@@ -30,6 +30,12 @@ runs:
         COVERAGE=$(grep "Line coverage:" TestResults/coverage-report/Summary.txt | grep -oP '\d+(\.\d+)?%' | head -1 | sed 's/%//')
         echo "Coverage: ${COVERAGE}%"
         awk -v c="$COVERAGE" 'BEGIN { exit (c+0 < 80) ? 1 : 0 }' || {
-          echo "ERROR: coverage ${COVERAGE}% < 80%"
+          echo "ERROR: total coverage ${COVERAGE}% < 80%"
           exit 1
         }
+        echo "==> Enforcing per-file coverage floor (50%)..."
+        python3 .github/actions/coverage-gate/check-per-file-coverage.py \
+          --reports "TestResults/*/coverage.cobertura.xml" \
+          --min-coverage 50 \
+          --min-lines 20
+

--- a/.github/actions/coverage-gate/check-per-file-coverage.py
+++ b/.github/actions/coverage-gate/check-per-file-coverage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import sys
+import os
+import glob
+import argparse
+import xml.etree.ElementTree as ET
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Check per-file line coverage against threshold.")
+    parser.add_argument("--reports", default="TestResults/*/coverage.cobertura.xml", help="Glob pattern for Cobertura XML files")
+    parser.add_argument("--min-coverage", type=float, default=50.0, help="Minimum per-file line coverage percentage (default: 50.0)")
+    parser.add_argument("--min-lines", type=int, default=20, help="Minimum valid executable lines per file to enforce gate (default: 20)")
+    parser.add_argument("--allowlist", default=".github/coverage-file-allowlist.txt", help="Path to allowlist file for exempted files")
+    return parser.parse_args()
+
+def load_allowlist(allowlist_path):
+    exemptions = set()
+    if os.path.isfile(allowlist_path):
+        with open(allowlist_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip().replace("\\", "/")
+                if line and not line.startswith("#"):
+                    if line.startswith("src/"):
+                        line = line[4:]
+                    exemptions.add(line)
+    return exemptions
+
+def normalize_filename(filename):
+    filename = filename.replace("\\", "/")
+    if "/src/" in filename:
+        filename = filename.split("/src/", 1)[1]
+    elif filename.startswith("src/"):
+        filename = filename[4:]
+    return filename
+
+def main():
+    args = parse_args()
+
+    report_files = glob.glob(args.reports, recursive=True)
+    if not report_files:
+        report_files = glob.glob("**/coverage.cobertura.xml", recursive=True)
+
+    if not report_files:
+        print(f"[ERROR] No Cobertura XML report files found matching pattern: {args.reports}", file=sys.stderr)
+        sys.exit(1)
+
+    allowlist = load_allowlist(args.allowlist)
+
+    file_stats = {}
+    for report in report_files:
+        try:
+            tree = ET.parse(report)
+            root = tree.getroot()
+            for cls in root.findall(".//class"):
+                raw_fname = cls.get("filename", "")
+                if not raw_fname:
+                    continue
+
+                fname = normalize_filename(raw_fname)
+                if fname.startswith("Zipper.Tests/") or fname.startswith("Zipper.Analyzers") or "/obj/" in fname or fname.startswith("obj/"):
+                    continue
+
+                lines = cls.findall("lines/line")
+                if not lines:
+                    continue
+
+                valid = len(lines)
+                covered = sum(1 for l in lines if int(l.get("hits", 0)) > 0)
+
+                if fname not in file_stats:
+                    file_stats[fname] = {"valid": 0, "covered": 0}
+                file_stats[fname]["valid"] += valid
+                file_stats[fname]["covered"] += covered
+        except Exception as e:
+            print(f"[WARNING] Failed to parse Cobertura report {report}: {e}", file=sys.stderr)
+
+    if not file_stats:
+        print("[ERROR] No valid C# source files found in Cobertura XML reports.", file=sys.stderr)
+        sys.exit(1)
+
+    failed_files = []
+    evaluated_count = 0
+
+    print(f"Checking per-file line coverage (floor: {args.min_coverage:.1f}%, min lines: {args.min_lines})...")
+    print(f"{'File':<60s} {'Covered':>8s} / {'Valid':<8s} {'Rate':>8s} {'Status':>8s}")
+    print("-" * 90)
+
+    for fname in sorted(file_stats.keys()):
+        stats = file_stats[fname]
+        valid = stats["valid"]
+        covered = stats["covered"]
+        rate = (covered / valid * 100.0) if valid > 0 else 0.0
+
+        if valid < args.min_lines:
+            status = "SKIP (<20)"
+        elif fname in allowlist:
+            status = "ALLOWLIST"
+        elif rate < args.min_coverage:
+            status = "FAIL"
+            failed_files.append((fname, rate, covered, valid))
+            evaluated_count += 1
+        else:
+            status = "PASS"
+            evaluated_count += 1
+
+        print(f"{fname:<60s} {covered:8d} / {valid:<8d} {rate:7.1f}% {status:>8s}")
+
+    print("-" * 90)
+    if failed_files:
+        print(f"\n[ERROR] {len(failed_files)} file(s) failed the per-file minimum coverage threshold of {args.min_coverage:.1f}%:", file=sys.stderr)
+        for fname, rate, covered, valid in failed_files:
+            print(f"  ::error file={fname}::{fname}: coverage {rate:.1f}% ({covered}/{valid} lines) < {args.min_coverage:.1f}% threshold", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"\n[SUCCESS] All {evaluated_count} evaluated files passed the per-file coverage floor of {args.min_coverage:.1f}%!")
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/coverage-gate/test-coverage-gate.sh
+++ b/.github/actions/coverage-gate/test-coverage-gate.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ALLOWLIST="${SCRIPT_DIR}/../../coverage-file-allowlist.txt"
 
 echo "==> Testing check-per-file-coverage.py against passing fixture..."
 python3 "${SCRIPT_DIR}/check-per-file-coverage.py" \
@@ -22,5 +23,12 @@ if [ "${EXIT_CODE}" -ne 1 ]; then
   echo "ERROR: Expected exit code 1 for failing fixture, got ${EXIT_CODE}"
   exit 1
 fi
+
+echo "==> Testing check-per-file-coverage.py with allowlist fixture..."
+python3 "${SCRIPT_DIR}/check-per-file-coverage.py" \
+  --reports "${SCRIPT_DIR}/testdata/allowlist_coverage.cobertura.xml" \
+  --allowlist "${ALLOWLIST}" \
+  --min-coverage 50 \
+  --min-lines 20
 
 echo "[SUCCESS] All coverage gate script tests passed!"

--- a/.github/actions/coverage-gate/test-coverage-gate.sh
+++ b/.github/actions/coverage-gate/test-coverage-gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Testing check-per-file-coverage.py against passing fixture..."
+python3 "${SCRIPT_DIR}/check-per-file-coverage.py" \
+  --reports "${SCRIPT_DIR}/testdata/passing_coverage.cobertura.xml" \
+  --min-coverage 50 \
+  --min-lines 20
+
+echo "==> Testing check-per-file-coverage.py against failing fixture..."
+set +e
+python3 "${SCRIPT_DIR}/check-per-file-coverage.py" \
+  --reports "${SCRIPT_DIR}/testdata/failing_coverage.cobertura.xml" \
+  --min-coverage 50 \
+  --min-lines 20
+EXIT_CODE=$?
+set -e
+
+if [ "${EXIT_CODE}" -ne 1 ]; then
+  echo "ERROR: Expected exit code 1 for failing fixture, got ${EXIT_CODE}"
+  exit 1
+fi
+
+echo "[SUCCESS] All coverage gate script tests passed!"

--- a/.github/actions/coverage-gate/testdata/allowlist_coverage.cobertura.xml
+++ b/.github/actions/coverage-gate/testdata/allowlist_coverage.cobertura.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.20" branch-rate="0.20" version="1.9">
+  <sources>
+    <source>/home/runner/work/zipper/zipper/src/</source>
+  </sources>
+  <packages>
+    <package name="Zipper" line-rate="0.20">
+      <classes>
+        <class name="Zipper.Cli.CliArgument" filename="Cli/CliArgument.cs" line-rate="0.00">
+          <lines>
+            <line number="1" hits="0" />
+            <line number="2" hits="0" />
+            <line number="3" hits="0" />
+            <line number="4" hits="0" />
+            <line number="5" hits="0" />
+            <line number="6" hits="0" />
+            <line number="7" hits="0" />
+            <line number="8" hits="0" />
+            <line number="9" hits="0" />
+            <line number="10" hits="0" />
+            <line number="11" hits="0" />
+            <line number="12" hits="0" />
+            <line number="13" hits="0" />
+            <line number="14" hits="0" />
+            <line number="15" hits="0" />
+            <line number="16" hits="0" />
+            <line number="17" hits="0" />
+            <line number="18" hits="0" />
+            <line number="19" hits="0" />
+            <line number="20" hits="0" />
+            <line number="21" hits="0" />
+            <line number="22" hits="0" />
+            <line number="23" hits="0" />
+            <line number="24" hits="0" />
+            <line number="25" hits="0" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/.github/actions/coverage-gate/testdata/failing_coverage.cobertura.xml
+++ b/.github/actions/coverage-gate/testdata/failing_coverage.cobertura.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.40" branch-rate="0.40" version="1.9">
+  <sources>
+    <source>/home/runner/work/zipper/zipper/src/</source>
+  </sources>
+  <packages>
+    <package name="Zipper" line-rate="0.40">
+      <classes>
+        <class name="Zipper.UncoveredModule" filename="UncoveredModule.cs" line-rate="0.10">
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="0" />
+            <line number="3" hits="0" />
+            <line number="4" hits="0" />
+            <line number="5" hits="0" />
+            <line number="6" hits="0" />
+            <line number="7" hits="0" />
+            <line number="8" hits="0" />
+            <line number="9" hits="0" />
+            <line number="10" hits="0" />
+            <line number="11" hits="0" />
+            <line number="12" hits="0" />
+            <line number="13" hits="0" />
+            <line number="14" hits="0" />
+            <line number="15" hits="0" />
+            <line number="16" hits="0" />
+            <line number="17" hits="0" />
+            <line number="18" hits="0" />
+            <line number="19" hits="0" />
+            <line number="20" hits="0" />
+            <line number="21" hits="0" />
+            <line number="22" hits="0" />
+            <line number="23" hits="0" />
+            <line number="24" hits="0" />
+            <line number="25" hits="0" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/.github/actions/coverage-gate/testdata/passing_coverage.cobertura.xml
+++ b/.github/actions/coverage-gate/testdata/passing_coverage.cobertura.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.85" branch-rate="0.80" version="1.9">
+  <sources>
+    <source>/home/runner/work/zipper/zipper/src/</source>
+  </sources>
+  <packages>
+    <package name="Zipper" line-rate="0.85">
+      <classes>
+        <class name="Zipper.SampleModule" filename="SampleModule.cs" line-rate="0.80">
+          <lines>
+            <line number="1" hits="5" />
+            <line number="2" hits="5" />
+            <line number="3" hits="5" />
+            <line number="4" hits="5" />
+            <line number="5" hits="5" />
+            <line number="6" hits="5" />
+            <line number="7" hits="5" />
+            <line number="8" hits="5" />
+            <line number="9" hits="0" />
+            <line number="10" hits="0" />
+            <line number="11" hits="5" />
+            <line number="12" hits="5" />
+            <line number="13" hits="5" />
+            <line number="14" hits="5" />
+            <line number="15" hits="5" />
+            <line number="16" hits="5" />
+            <line number="17" hits="5" />
+            <line number="18" hits="5" />
+            <line number="19" hits="5" />
+            <line number="20" hits="5" />
+            <line number="21" hits="5" />
+
+            <line number="22" hits="5" />
+            <line number="23" hits="5" />
+            <line number="24" hits="5" />
+            <line number="25" hits="5" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/.github/coverage-file-allowlist.txt
+++ b/.github/coverage-file-allowlist.txt
@@ -1,0 +1,5 @@
+# Known coverage debt allowlist for per-file coverage gate (#604)
+# Remove files from this list as dedicated tests are added.
+Cli/CliArgument.cs
+Cli/CliOptions.cs
+CommandLineValidator.cs

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage*
 # ...but keep the CI composite action whose dir name collides with coverage*
 !.github/actions/coverage-gate/
 !.github/actions/coverage-gate/**
+!.github/coverage-file-allowlist.txt
 publish-bin/
 
 # OS files

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -76,7 +76,7 @@ Trigger: `pull_request` → `main`. Concurrency-cancels superseded runs. Jobs ar
 
 1. **docs-only** — diffs base..head; if **every** changed file matches a docs pattern, sets `only_docs=true` and the rest of the pipeline is skipped. A failed diff or zero changed files is treated as non-docs (fail-safe).
 2. **lint** — `actionlint`, `dotnet restore --locked-mode`, `dotnet format --verify-no-changes`, and an oversized-file guard (>500 KB under `src/`, excluding `*.json`/`*.dat`/`*.opt`).
-3. **build-and-test** — matrix over `ubuntu` / `windows` / `macOS`. Builds Release (includes tests), runs unit tests, full E2E suite. **Linux leg only** also: code coverage + **80% line-coverage gate** ([coverage-gate action](../.github/actions/coverage-gate/action.yml)), vulnerable-package scan (hard gate), test-timing report, and publishes the CLI as an artifact for goldens.
+3. **build-and-test** — matrix over `ubuntu` / `windows` / `macOS`. Builds Release (includes tests), runs unit tests, full E2E suite. **Linux leg only** also: code coverage + **80% total line-coverage gate** and **50% per-file coverage floor** ([coverage-gate action](../.github/actions/coverage-gate/action.yml)), vulnerable-package scan (hard gate), test-timing report, and publishes the CLI as an artifact for goldens.
 4. **goldens** — downloads the Linux CLI artifact and runs golden scenarios (content-hash parity). See [CI.md](../CI.md#goldens) to regenerate.
 
 ### 3. Side checks (parallel on PR)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -645,6 +645,10 @@ print_info "Running CI build properties and docs-only classification tests..."
 bash ./tests/test-ci-build-props.sh || print_error "test-ci-build-props.sh failed."
 print_success "CI build properties and docs-only classification tests passed."
 
+print_info "Running CI per-file coverage gate action tests..."
+bash ./.github/actions/coverage-gate/test-coverage-gate.sh || print_error "test-coverage-gate.sh failed."
+print_success "CI per-file coverage gate action tests passed."
+
 # FGR guard: FileGenerationRequest must not have flat pass-through properties (see #213).
 print_info "Checking for flat pass-through properties on FileGenerationRequest..."
 if grep -q 'get => this\.[A-Z][a-z]*\.' src/FileGenerationRequest.cs; then


### PR DESCRIPTION
## Summary
Enforces a 50% per-file line coverage floor in the CI coverage gate action for all C# source files under `src/` with ≥ 20 valid lines, preventing single-file coverage blindspots while maintaining overall 80% total suite coverage.

## Release Notes
Enforces a 50% per-file line coverage floor in automated CI gates for all source files with at least 20 valid lines, protecting against untested critical modules.

Closes #604.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-file coverage enforcement requiring at least 50% line coverage for files with 20 or more executable lines.
  - Added support for documented exceptions through a coverage allowlist.

- **Bug Fixes**
  - Improved coverage-gate failure reporting with clearer total-coverage errors.

- **Documentation**
  - Updated CI documentation to describe both total and per-file coverage requirements.

- **Tests**
  - Added passing and failing coverage scenarios to validate the new checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->