### PR TITLE
fix(manifest): narrow encoding catch and warn on fallback in ManifestComparer (#602)

### DIFF
--- a/src/ManifestComparison/ProductionManifestComparer.cs
+++ b/src/ManifestComparison/ProductionManifestComparer.cs
@@ -159,7 +159,7 @@ public static class ProductionManifestComparer
         var resolvedEncoding = EncodingHelper.GetEncoding(encodingStr);
         if (resolvedEncoding is null)
         {
-            Console.Error.WriteLine($"Warning: Encoding '{encodingStr}' not recognized, falling back to UTF-8.");
+            Console.Error.WriteLine($"Warning: Encoding {JsonSerializer.Serialize(encodingStr)} not recognized, falling back to UTF-8.");
             encoding = System.Text.Encoding.UTF8;
         }
         else

--- a/src/ManifestComparison/ProductionManifestComparer.cs
+++ b/src/ManifestComparison/ProductionManifestComparer.cs
@@ -156,13 +156,15 @@ public static class ProductionManifestComparer
 
         var encodingStr = manifest.Settings?.Encoding ?? "UTF-8";
         System.Text.Encoding encoding;
-        try
+        var resolvedEncoding = EncodingHelper.GetEncoding(encodingStr);
+        if (resolvedEncoding is null)
         {
-            encoding = System.Text.Encoding.GetEncoding(encodingStr);
-        }
-        catch
-        {
+            Console.Error.WriteLine($"Warning: Encoding '{encodingStr}' not recognized, falling back to UTF-8.");
             encoding = System.Text.Encoding.UTF8;
+        }
+        else
+        {
+            encoding = resolvedEncoding;
         }
 
         var colDelim = ParseDelimiter(manifest.Settings?.ColumnDelimiter, '\x14');

--- a/src/Zipper.Tests/ManifestComparison/ProductionManifestComparerTests.cs
+++ b/src/Zipper.Tests/ManifestComparison/ProductionManifestComparerTests.cs
@@ -470,10 +470,72 @@ public class ProductionManifestComparerTests
         }
     }
 
+    [Fact]
+    public async Task CompareAndReportAsync_WithUnknownEncoding_ShouldWarnAndFallBackToUtf8()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test_unknown_encoding_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        var originalConsoleError = Console.Error;
+        using var sw = new StringWriter();
+        try
+        {
+            var p1 = CreateTestProductionSetWithEncoding(tempDir, "PROD001", "VOL001", new[] { "ABC00000001" }, "GARBAGE-ENCODING-XYZ");
+            var p2 = CreateTestProductionSetWithEncoding(tempDir, "PROD002", "VOL001", new[] { "ABC00000002" }, "GARBAGE-ENCODING-XYZ");
+            var outputPath = Path.Combine(tempDir, "report.json");
+
+            Console.SetError(sw);
+            var success = await ProductionManifestComparer.CompareAndReportAsync($"{p1},{p2}", "replacement", outputPath);
+
+            Assert.True(success, "Comparison should succeed even with unrecognized encoding");
+            Assert.True(File.Exists(outputPath), "Output JSON should still be written");
+
+            var stderr = sw.ToString();
+            Assert.Contains("GARBAGE-ENCODING-XYZ", stderr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("UTF-8", stderr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Console.SetError(originalConsoleError);
+            CleanupDirectory(tempDir);
+        }
+    }
+
     private static string CreateTestProductionSet(string baseDir, string prodId, string volume, string[] batesNumbers)
     {
         return CreateTestProductionSetWithCustomDatHeader(baseDir, prodId, volume, batesNumbers, "þBATES_NUMBERþ\u0014þVOLUMEþ\u0014þFILE_PATHþ\u0014þMD5HASHþ");
     }
+
+    private static string CreateTestProductionSetWithEncoding(string baseDir, string prodId, string volume, string[] batesNumbers, string encoding)
+    {
+        var prodDir = Path.Combine(baseDir, prodId);
+        var dataDir = Path.Combine(prodDir, "DATA");
+        Directory.CreateDirectory(dataDir);
+
+        var datPath = Path.Combine(dataDir, "loadfile.dat");
+        var sb = new StringBuilder();
+        sb.AppendLine("þBATES_NUMBERþ\u0014þVOLUMEþ\u0014þFILE_PATHþ\u0014þMD5HASHþ");
+        foreach (var bates in batesNumbers)
+        {
+            sb.AppendLine($"þ{bates}þ\u0014þ{volume}þ\u0014þIMAGES/001.tifþ\u0014þd41d8cd98f00b204e9800998ecf8427eþ");
+        }
+        File.WriteAllText(datPath, sb.ToString(), Encoding.UTF8);
+
+        var manifestData = new
+        {
+            ProductionId = prodId,
+            BatesNumberStart = batesNumbers.Length > 0 ? batesNumbers[0] : string.Empty,
+            BatesNumberEnd = batesNumbers.Length > 0 ? batesNumbers[^1] : string.Empty,
+            BatesRange = new { Start = batesNumbers.Length > 0 ? batesNumbers[0] : string.Empty, End = batesNumbers.Length > 0 ? batesNumbers[^1] : string.Empty, Prefix = "ABC", Digits = 8 },
+            LoadFiles = new { Dat = "DATA/loadfile.dat", Opt = "DATA/loadfile.opt" },
+            Settings = new { Encoding = encoding, ColumnDelimiter = "\u0014", QuoteDelimiter = "þ" }
+        };
+
+        var manifestPath = Path.Combine(prodDir, "_manifest.json");
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifestData));
+
+        return manifestPath;
+    }
+
 
     private static string CreateTestProductionSetWithCustomDatHeader(string baseDir, string prodId, string volume, string[] batesNumbers, string datHeader)
     {


### PR DESCRIPTION
## Summary
Replaces the bare `catch {}` at `ProductionManifestComparer.cs` lines 159-166 with a call to the existing `EncodingHelper.GetEncoding` helper. When the manifest specifies an encoding name that is not in the recognized set, a warning is now emitted to `Console.Error` (e.g. `Warning: Encoding \"WINDOWS-XYZ\" not recognized, falling back to UTF-8.`) and parsing continues with UTF-8. Previously, all failures were silently swallowed which could cause the comparer to misparse DAT records with no indication to the user.

A focused unit test `CompareAndReportAsync_WithUnknownEncoding_ShouldWarnAndFallBackToUtf8` verifies the warning is emitted and the comparison still succeeds and produces output.

Closes #602.

## Release Notes
Fixed a silent bare `catch` in `ProductionManifestComparer` that swallowed unrecognized encoding errors. The comparer now emits a `Warning:` message to stderr naming the bad encoding and the UTF-8 fallback, ensuring users know when a comparison may be unreliable due to encoding mismatch.

## Type of Change

- [x] Bug fix

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required) — change is internal to `ProductionManifestComparer` and uses the existing `EncodingHelper` seam.

## Affected Requirements

None. Internal manifest comparison behavior; no REQ/FR identifiers reference encoding fallback in the manifest comparer.