### PR TITLE
docs(arch): refresh stale component map and AGENTS paths (#635, #607, #608)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,12 +229,12 @@ See [CI.md](CI.md) for SonarCloud, CodeRabbit, CodeQL, and golden file procedure
 |------|---------|
 | `src/Program.cs` | Entry point, CLI orchestration, mode dispatch |
 | `src/Cli/` | CLI parsing, validation, help text, request assembly |
-| `src/FileGenerationRequest.cs` | Configuration root (8 sub-configs + `LoadfileOnly` flag) |
+| `src/FileGenerationRequest.cs` | Configuration root (9 sub-configs + `LoadfileOnly` flag) |
 | `src/IGenerationMode.cs` / `GenerationRunner.cs` | Mode interface + dispatcher |
 | `src/StandardMode.cs` / `LoadFileOnlyMode.cs` / `ProductionSetMode.cs` | Three generation mode adapters |
 | `src/IFileGenerator.cs` / `FileGeneratorFactory.cs` | File generator interface + factory |
 | `src/ParallelFileGenerator.cs` | Standard mode file generation pipeline |
-| `src/ZipArchiveService.cs` | Archive creation + Load File writing |
+| `src/IArchiveSink.cs` / `src/ZipArchiveSink.cs` | Archive creation + Load File writing (Standard mode consumer) |
 | `src/LoadFileOnlyGenerator.cs` | Standalone Load File generation |
 | `src/ProductionSetGenerator.cs` | Production Set directory tree + Load Files |
 | `src/ChaosEngine.cs` | Chaos anomaly injection |
@@ -248,12 +248,16 @@ See [CI.md](CI.md) for SonarCloud, CodeRabbit, CodeQL, and golden file procedure
 | `src/Emails/` | Email domain model |
 | `src/LoadFiles/` | Load File seam: composers, serializers, emitter, thin composing writers + `XmlLoadFileWriter` carve-out |
 | `src/Profiles/` | Column profile system (loader, data generator, built-ins) |
-| `src/LoadfileAuditWriter.cs` / `ProductionManifestWriter.cs` | Audit + manifest writers |
+| `src/Config/` | Nested request config records (`OutputConfig`, `MetadataConfig`, `LoadFileConfig`, `DelimiterConfig`, `BatesNumberConfig`, `TiffConfig`, `ChaosConfig`, `ProductionConfig`, `HashConfig`) + `HashUtility` |
+| `src/Validation/` | Post-generation / Production Set / supplemental validators (`PostGenerationValidator`, `ValidatorRunner`, `ProductionSetPostValidator`, `SupplementalValidator`) |
+| `src/ManifestComparison/` | Production Manifest comparison reports (`ProductionManifestComparer`, `--compare-production-manifests`) |
+| `src/Utils/` | `NamingConventionHelper` |
+| `src/LoadFileAuditWriter.cs` / `ProductionManifestWriter.cs` | Audit + manifest writers |
 | `src/Zipper.Tests/` | Unit tests |
 | `src/Zipper.Analyzers/` | Roslyn analyzers |
 | `tests/` | E2E test scripts |
 
-Individual file generators (`EmlFileGenerator.cs`, `TiffFileGenerator.cs`, `OfficeFileGenerator.cs`, `PlaceholderFileGenerator.cs`, `BatesNumberGenerator.cs`) live in `src/` — grep by type.
+Individual file generators (`EmlFileGenerator.cs`, `TiffFileGenerator.cs`, `OfficeFileGenerator.cs`, `PlaceholderFileGenerator.cs`) and `BatesSequence.cs` live in `src/` — grep by type.
 
 ---
 
@@ -277,7 +281,7 @@ Individual file generators (`EmlFileGenerator.cs`, `TiffFileGenerator.cs`, `Offi
 ### Test Naming Convention
 
 Test classes and methods follow the pattern:
-- **Class:** `{Subject}Tests` (e.g., `BatesNumberGeneratorTests`, `ChaosEngineTests`)
+- **Class:** `{Subject}Tests` (e.g., `BatesSequenceTests`, `ChaosEngineTests`)
 - **Method:** `{Method}_{Scenario}_{Expected}` (e.g., `Generate_WithCustomPrefix_ShouldIncludePrefix`)
 
 This convention is enforced by code review and the existing test corpus. All new tests must follow it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ graph TD
 ```mermaid
 graph LR
     subgraph CLI Layer
+        Program["Program.cs<br/>(SelectMode dispatch)"]
         CliParser["CliParser"]
         CliValidator["CliValidator"]
         RequestBuilder["RequestBuilder"]
@@ -84,6 +85,14 @@ graph LR
         FGR --> Production["ProductionConfig"]
         FGR --> Hash["HashConfig"]
         FGR --> LoadfileOnly["LoadfileOnly flag"]
+    end
+
+    subgraph Mode Adapters
+        StdMode["StandardMode"]
+        LFMode["LoadFileOnlyMode"]
+        PSMode["ProductionSetMode"]
+        PSG["ProductionSetGenerator"]
+        PSMode --> PSG
     end
 
     subgraph File Generators
@@ -122,7 +131,15 @@ graph LR
         PMC["ProductionManifestComparer<br/>(--compare-production-manifests)"]
     end
 
-    CliParser --> CliValidator --> RequestBuilder --> FGR
+    Program --> CliParser --> CliValidator --> RequestBuilder --> FGR
+    Program -->|"--compare-production-manifests"| PMC
+    Program -->|"SelectMode(request)"| StdMode
+    Program -->|"SelectMode(request)"| LFMode
+    Program -->|"SelectMode(request)"| PSMode
+    StdMode --> PGV
+    LFMode --> PGV
+    PSMode --> PGV
+    PSG --> SuppV
     FGR --> File Generators
     FGR --> Load File Seam
     Profiles --> DataGen

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ The diagrams in this file are a **contract**, not just documentation:
 
 1. **Work channel**: Produces `FileWorkItem` objects using the configured distribution algorithm. Bounded channel provides backpressure.
 2. **Generation**: N concurrent producers generate file data and write to result channel. All file types run in parallel.
-3. **Archive writing**: Single consumer (`ZipArchiveService`) writes ZIP entries, then writes Load Files through the composer → serializer → emitter seam (selected via `ILoadFileWriter`; see [Load File Composition Seam](#load-file-composition-seam)).
+3. **Archive writing**: Single consumer (`ZipArchiveSink`, implementing `IArchiveSink`) writes ZIP entries, then writes Load Files through the composer → serializer → emitter seam (selected via `ILoadFileWriter`; see [Load File Composition Seam](#load-file-composition-seam)).
 4. **Deadlock protection**: `Task.WhenAny` races consumer with producers; if consumer faults, result channel is completed with its exception to unblock producers.
 
 ## Chaos Engine (Loadfile-Only Mode only)
@@ -47,7 +47,7 @@ graph TD
 
     StandardMode --> PFG["ParallelFileGenerator"]
     PFG -->|"Work Channel"| Producers["N Concurrent Producers"]
-    Producers -->|"Result Channel"| ZAS["ZipArchiveService (Consumer)"]
+    Producers -->|"Result Channel"| ZAS["ZipArchiveSink (Consumer)"]
     ZAS --> ZIP["ZIP Archive"]
     ZAS --> LF1["Load Files (all formats)"]
 
@@ -74,15 +74,16 @@ graph LR
 
     subgraph Config
         FGR["FileGenerationRequest"]
-        FGR --> Output["Output"]
-        FGR --> Metadata["Metadata"]
-        FGR --> LoadFile["LoadFile"]
-        FGR --> Delimiters["Delimiters"]
-        FGR --> Bates["Bates"]
-        FGR --> Tiff["Tiff"]
-        FGR --> Chaos["Chaos"]
-        FGR --> Production["Production"]
-        FGR --> Hash["Hash"]
+        FGR --> Output["OutputConfig"]
+        FGR --> Metadata["MetadataConfig"]
+        FGR --> LoadFile["LoadFileConfig"]
+        FGR --> Delimiters["DelimiterConfig"]
+        FGR --> Bates["BatesNumberConfig"]
+        FGR --> Tiff["TiffConfig"]
+        FGR --> Chaos["ChaosConfig"]
+        FGR --> Production["ProductionConfig"]
+        FGR --> Hash["HashConfig"]
+        FGR --> LoadfileOnly["LoadfileOnly flag"]
     end
 
     subgraph File Generators
@@ -108,11 +109,32 @@ graph LR
         BuiltIns["BuiltInProfiles"]
     end
 
+    subgraph Validation
+        PGV["PostGenerationValidator<br/>(Standard / Loadfile-Only / Production Set)"]
+        Runner["ValidatorRunner"]
+        PSPV["ProductionSetPostValidator"]
+        SuppV["SupplementalValidator<br/>(pre-output, supplemental mode)"]
+        PGV --> Runner
+        PGV --> PSPV
+    end
+
+    subgraph Manifest Comparison
+        PMC["ProductionManifestComparer<br/>(--compare-production-manifests)"]
+    end
+
     CliParser --> CliValidator --> RequestBuilder --> FGR
     FGR --> File Generators
     FGR --> Load File Seam
     Profiles --> DataGen
 ```
+
+## Post-Generation Validation
+
+Each mode adapter runs `PostGenerationValidator.Validate(ValidationContext)` after its generator completes:
+
+- **Standard / Loadfile-Only / Production Set**: `StandardMode`, `LoadFileOnlyMode`, and `ProductionSetMode` each construct `PostGenerationValidator`, which drives `ValidatorRunner` over the emitted Load File(s). For Production Set mode it additionally calls `ProductionSetPostValidator.Validate`.
+- **Supplemental**: `SupplementalValidator.ValidateAsync` runs during supplemental Production Set generation (before output is written) to validate Bates Number ranges against prior Production Manifests.
+- **Manifest Comparison**: `--compare-production-manifests` short-circuits normal generation in `Program.cs` and dispatches directly to `ProductionManifestComparer.CompareAndReportAsync`, which writes the comparison JSON report. This path bypasses `PostGenerationValidator` entirely.
 
 ## Load File Composition Seam
 


### PR DESCRIPTION
## Summary
Refreshes the architecture source of truth so every named type/path exists with exact casing and every `FileGenerationRequest` sub-config appears. Replaces the removed `ZipArchiveService` with `ZipArchiveSink` (implements `IArchiveSink`) in the Standard Pipeline prose and the Three-Mode Pipeline diagram. Relabels the Config subgraph nodes with the actual sub-config type names (`OutputConfig` through `HashConfig`) and adds the `LoadfileOnly` flag. Adds `Validation` and `Manifest Comparison` subgraphs to the Component Map (`PostGenerationValidator` -> `ValidatorRunner` + `ProductionSetPostValidator`; `SupplementalValidator`; `ProductionManifestComparer` for the `--compare-production-manifests` short-circuit) plus a Post-Generation Validation section describing how each mode adapter runs validation after generation and how the comparison path bypasses it.

Corrects AGENTS.md stale paths and casing: `src/ZipArchiveService.cs` -> `src/IArchiveSink.cs` / `src/ZipArchiveSink.cs`; `src/LoadfileAuditWriter.cs` -> `src/LoadFileAuditWriter.cs`; nonexistent `BatesNumberGenerator.cs` -> `BatesSequence.cs` (file-generators note and test-naming example); `8 sub-configs` -> `9 sub-configs`. Adds the missing directory rows `src/Validation/`, `src/ManifestComparison/`, `src/Config/`, and `src/Utils/`.

The `composer -> serializer -> emitter` seam and the EDRM-XML carve-out are preserved unchanged; this change makes the diagrams match the code rather than deviating from the invariants.

Batches #607 and #608 into the #635 docs change per the maintainer batching plan, so a single diagram update does not overwrite the others.

Closes #635. Closes #607. Closes #608.

## Release Notes
Refreshed the architecture component map and AGENTS.md project structure table to match the current codebase: replaced the removed `ZipArchiveService` with `ZipArchiveSink`/`IArchiveSink`, labeled all nine `FileGenerationRequest` sub-configs with exact type names, added the Validation and Manifest Comparison subsystems to the diagram, and corrected stale/mis-cased source paths.

## Type of Change

- [x] Documentation

## Testing Done

- [x] Lint clean (`dotnet format --verify-no-changes src/`)
- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj`) — 1379 — as a sanity check; the change is docs-only.
- [x] Self-review (docs-only change per the autoreview exemption): verified every named type/path in the updated diagrams exists with exact casing against `src/`.

## Architecture

- [x] This PR *corrects* the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required) to match the current code (stale `ZipArchiveService` name, missing `HashConfig`, missing Validation/ManifestComparison subsystems). The `composer -> serializer -> emitter` invariant and the EDRM-XML carve-out are preserved unchanged; no structural deviation is introduced. The corrections implement the maintainer-filed issues #635/#607/#608, which constitute the approval for the diagram update.

## Affected Requirements

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to reflect current components, configuration areas, generators, and test conventions.
  * Revised architecture documentation to clarify archive generation flows and configuration mapping.
  * Added documentation for post-generation validation across standard, loadfile-only, production, supplemental, and manifest-comparison workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->