### PR TITLE
refactor(manifest): extract report writer (#601 PR4)

### DIFF
--- a/src/ManifestComparison/ComparisonReportWriter.cs
+++ b/src/ManifestComparison/ComparisonReportWriter.cs
@@ -1,0 +1,111 @@
+using System.Text;
+
+namespace Zipper.ManifestComparison;
+
+/// <summary>
+/// Renders a <see cref="ComparisonResult"/> as a markdown summary file and a
+/// console summary string. Pure rendering — no I/O, no comparison logic.
+/// Extracted from <see cref="ProductionManifestComparer"/> (#601 PR4).
+/// </summary>
+internal static class ComparisonReportWriter
+{
+    public static string GenerateMarkdownSummary(ComparisonResult result, string mode)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Production Set Comparison Report");
+        sb.AppendLine();
+        sb.Append("**Mode:** ").Append(mode.ToUpperInvariant()).AppendLine();
+        sb.Append("**Date Generated:** ").Append(DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture)).Append(" UTC").AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("## Summary");
+        sb.AppendLine();
+        sb.AppendLine("| Metric | Value |");
+        sb.AppendLine("|--------|-------|");
+        sb.Append("| Total Prior Records | ").Append(result.Summary.TotalPriorRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Total New Records | ").Append(result.Summary.TotalNewRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Added Records | ").Append(result.Summary.AddedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Removed Records | ").Append(result.Summary.RemovedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Unchanged Records | ").Append(result.Summary.UnchangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Changed Records (Metadata/Hash) | ").Append(result.Summary.ChangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Replaced Records (Different Bates) | ").Append(result.Summary.ReplacedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.Append("| Duplicates/Overlaps | ").Append(result.Summary.DuplicateCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("## Bates Number Analysis");
+        sb.AppendLine();
+        sb.Append("* **Prior Bates Range:** ").Append(result.BatesAnalysis.PriorRange).AppendLine();
+        sb.Append("* **New Bates Range:** ").Append(result.BatesAnalysis.NewRange).AppendLine();
+        sb.AppendLine();
+
+        if (result.BatesAnalysis.PriorRangesByProductionSet.Count > 0)
+        {
+            sb.AppendLine("### Prior Bates Ranges by Production Set");
+            sb.AppendLine();
+            foreach (var kvp in result.BatesAnalysis.PriorRangesByProductionSet.OrderBy(k => k.Key))
+            {
+                sb.Append("* **").Append(kvp.Key).Append(":** ").Append(kvp.Value).AppendLine();
+            }
+            sb.AppendLine();
+        }
+
+        if (result.BatesAnalysis.Gaps.Count > 0)
+        {
+            sb.AppendLine("### Skipped Bates Ranges (Gaps)");
+            sb.AppendLine();
+            foreach (var gap in result.BatesAnalysis.Gaps)
+            {
+                sb.Append("- `").Append(gap.Start).Append("` to `").Append(gap.End).Append('`').AppendLine();
+            }
+            sb.AppendLine();
+        }
+
+        if (result.BatesAnalysis.Overlaps.Count > 0)
+        {
+            sb.AppendLine("### Overlapping Bates Ranges");
+            sb.AppendLine();
+            foreach (var overlap in result.BatesAnalysis.Overlaps)
+            {
+                sb.Append("- `").Append(overlap.Start).Append("` to `").Append(overlap.End).Append('`').AppendLine();
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("## Volume Analysis");
+        sb.AppendLine();
+        sb.AppendLine("| Production Set | Volume | Prior Bates Range | New Bates Range | Status |");
+        sb.AppendLine("|----------------|--------|-------------------|-----------------|--------|");
+        foreach (var vol in result.VolumeAnalysis)
+        {
+            sb.Append("| ").Append(vol.ProductionId).Append(" | ").Append(vol.VolumeName).Append(" | ").Append(vol.PriorBatesRange).Append(" | ").Append(vol.NewBatesRange).Append(" | ").Append(vol.Status).Append(" |").AppendLine();
+        }
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    public static string GenerateConsoleSummary(ComparisonResult result, string mode)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("======================================================================");
+        sb.AppendLine("                   PRODUCTION MANIFEST COMPARISON SUMMARY             ");
+        sb.AppendLine("======================================================================");
+        sb.Append("Mode: ").Append(mode.ToUpperInvariant()).AppendLine();
+        sb.AppendLine();
+        sb.Append("Total Prior Records: ").Append(result.Summary.TotalPriorRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Total New Records:   ").Append(result.Summary.TotalNewRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Added Records:       ").Append(result.Summary.AddedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Removed Records:     ").Append(result.Summary.RemovedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Unchanged Records:   ").Append(result.Summary.UnchangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Changed Records:     ").Append(result.Summary.ChangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Replaced Records:    ").Append(result.Summary.ReplacedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.Append("Duplicate Warnings:  ").Append(result.Summary.DuplicateCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
+        sb.AppendLine();
+        sb.Append("Prior Bates Range:   ").Append(result.BatesAnalysis.PriorRange).AppendLine();
+        sb.Append("New Bates Range:     ").Append(result.BatesAnalysis.NewRange).AppendLine();
+        if (result.BatesAnalysis.Gaps.Count > 0)
+        {
+            sb.Append("Gaps Detected:       ").Append(result.BatesAnalysis.Gaps.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine(" range(s) skipped.");
+        }
+        sb.AppendLine("======================================================================");
+        return sb.ToString();
+    }
+}

--- a/src/ManifestComparison/ProductionManifestComparer.cs
+++ b/src/ManifestComparison/ProductionManifestComparer.cs
@@ -118,11 +118,11 @@ public static class ProductionManifestComparer
 
         // Write human-readable summary
         var summaryPath = Path.ChangeExtension(outputPath, ".summary.md");
-        var summaryMarkdown = GenerateMarkdownSummary(result, mode);
+        var summaryMarkdown = ComparisonReportWriter.GenerateMarkdownSummary(result, mode);
         await File.WriteAllTextAsync(summaryPath, summaryMarkdown).ConfigureAwait(false);
 
         // Print human-readable summary to console
-        Console.WriteLine(GenerateConsoleSummary(result, mode));
+        Console.WriteLine(ComparisonReportWriter.GenerateConsoleSummary(result, mode));
 
         return true;
     }
@@ -298,105 +298,5 @@ public static class ProductionManifestComparer
         }
         fields.Add(currentField.ToString());
         return fields;
-    }
-
-    private static string GenerateMarkdownSummary(ComparisonResult result, string mode)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("# Production Set Comparison Report");
-        sb.AppendLine();
-        sb.Append("**Mode:** ").Append(mode.ToUpperInvariant()).AppendLine();
-        sb.Append("**Date Generated:** ").Append(DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture)).Append(" UTC").AppendLine();
-        sb.AppendLine();
-        sb.AppendLine("## Summary");
-        sb.AppendLine();
-        sb.AppendLine("| Metric | Value |");
-        sb.AppendLine("|--------|-------|");
-        sb.Append("| Total Prior Records | ").Append(result.Summary.TotalPriorRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Total New Records | ").Append(result.Summary.TotalNewRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Added Records | ").Append(result.Summary.AddedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Removed Records | ").Append(result.Summary.RemovedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Unchanged Records | ").Append(result.Summary.UnchangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Changed Records (Metadata/Hash) | ").Append(result.Summary.ChangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Replaced Records (Different Bates) | ").Append(result.Summary.ReplacedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.Append("| Duplicates/Overlaps | ").Append(result.Summary.DuplicateCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(" |").AppendLine();
-        sb.AppendLine();
-        sb.AppendLine("## Bates Number Analysis");
-        sb.AppendLine();
-        sb.Append("* **Prior Bates Range:** ").Append(result.BatesAnalysis.PriorRange).AppendLine();
-        sb.Append("* **New Bates Range:** ").Append(result.BatesAnalysis.NewRange).AppendLine();
-        sb.AppendLine();
-
-        if (result.BatesAnalysis.PriorRangesByProductionSet.Count > 0)
-        {
-            sb.AppendLine("### Prior Bates Ranges by Production Set");
-            sb.AppendLine();
-            foreach (var kvp in result.BatesAnalysis.PriorRangesByProductionSet.OrderBy(k => k.Key))
-            {
-                sb.Append("* **").Append(kvp.Key).Append(":** ").Append(kvp.Value).AppendLine();
-            }
-            sb.AppendLine();
-        }
-
-        if (result.BatesAnalysis.Gaps.Count > 0)
-        {
-            sb.AppendLine("### Skipped Bates Ranges (Gaps)");
-            sb.AppendLine();
-            foreach (var gap in result.BatesAnalysis.Gaps)
-            {
-                sb.Append("- `").Append(gap.Start).Append("` to `").Append(gap.End).Append('`').AppendLine();
-            }
-            sb.AppendLine();
-        }
-
-        if (result.BatesAnalysis.Overlaps.Count > 0)
-        {
-            sb.AppendLine("### Overlapping Bates Ranges");
-            sb.AppendLine();
-            foreach (var overlap in result.BatesAnalysis.Overlaps)
-            {
-                sb.Append("- `").Append(overlap.Start).Append("` to `").Append(overlap.End).Append('`').AppendLine();
-            }
-            sb.AppendLine();
-        }
-
-        sb.AppendLine("## Volume Analysis");
-        sb.AppendLine();
-        sb.AppendLine("| Production Set | Volume | Prior Bates Range | New Bates Range | Status |");
-        sb.AppendLine("|----------------|--------|-------------------|-----------------|--------|");
-        foreach (var vol in result.VolumeAnalysis)
-        {
-            sb.Append("| ").Append(vol.ProductionId).Append(" | ").Append(vol.VolumeName).Append(" | ").Append(vol.PriorBatesRange).Append(" | ").Append(vol.NewBatesRange).Append(" | ").Append(vol.Status).Append(" |").AppendLine();
-        }
-        sb.AppendLine();
-
-        return sb.ToString();
-    }
-
-    private static string GenerateConsoleSummary(ComparisonResult result, string mode)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("======================================================================");
-        sb.AppendLine("                   PRODUCTION MANIFEST COMPARISON SUMMARY             ");
-        sb.AppendLine("======================================================================");
-        sb.Append("Mode: ").Append(mode.ToUpperInvariant()).AppendLine();
-        sb.AppendLine();
-        sb.Append("Total Prior Records: ").Append(result.Summary.TotalPriorRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Total New Records:   ").Append(result.Summary.TotalNewRecords.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Added Records:       ").Append(result.Summary.AddedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Removed Records:     ").Append(result.Summary.RemovedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Unchanged Records:   ").Append(result.Summary.UnchangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Changed Records:     ").Append(result.Summary.ChangedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Replaced Records:    ").Append(result.Summary.ReplacedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.Append("Duplicate Warnings:  ").Append(result.Summary.DuplicateCount.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine();
-        sb.AppendLine();
-        sb.Append("Prior Bates Range:   ").Append(result.BatesAnalysis.PriorRange).AppendLine();
-        sb.Append("New Bates Range:     ").Append(result.BatesAnalysis.NewRange).AppendLine();
-        if (result.BatesAnalysis.Gaps.Count > 0)
-        {
-            sb.Append("Gaps Detected:       ").Append(result.BatesAnalysis.Gaps.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)).AppendLine(" range(s) skipped.");
-        }
-        sb.AppendLine("======================================================================");
-        return sb.ToString();
     }
 }


### PR DESCRIPTION
## Summary
Final slice of the `ProductionManifestComparer` god-class decomposition (#601). Extracts `ComparisonReportWriter` (internal static) from `src/ManifestComparison/ProductionManifestComparer.cs`: `GenerateMarkdownSummary` and `GenerateConsoleSummary` (pure rendering of a `ComparisonResult` into the markdown summary file content and the console summary string). The façade now delegates both calls.

No behavior, JSON contract, or public surface change. Output parity verified: `ComparisonTests` and `ProductionManifestComparerTests` still pass 29/29 through the façade.

After this slice the module is fully decomposed and no file in `src/ManifestComparison/` exceeds the ~350 LOC target:

| File | LOC | Responsibility |
|------|-----|----------------|
| `ProductionManifestComparer.cs` | 302 | façade (`CompareAndReportAsync`) + DAT loader + `ParseDatLine` |
| `ComparisonModels.cs` | 232 | DTOs |
| `ComparisonEngine.cs` | 219 | pure matching + duplicates |
| `BatesRangeAnalyzer.cs` | 213 | gap/overlap analysis |
| `ComparisonReportWriter.cs` | 111 | markdown + console rendering |
| `VolumeAnalyzer.cs` | 110 | per-volume rollups |

The `composer -> serializer -> emitter` seam and the EDRM-XML carve-out are untouched.

Closes #601. The god-class decomposition is complete: PR1 (DTOs, #673), PR3 (engine + analyzers, #674), PR4 (report writer, this PR); PR2 (encoding fallback) landed earlier in #602. `ComparisonTests` pass; pure unit tests cover Bates (`BatesRangeAnalyzerTests`), duplicates (`ComparisonEngineTests`), and encoding fallback (`ProductionManifestComparerTests`).

## Release Notes
Split the markdown and console report rendering out of `ProductionManifestComparer` into a dedicated `ComparisonReportWriter` class, completing the decomposition of the manifest comparison module. No behavior or output changes; no file in the module exceeds 350 lines.

## Type of Change

- [x] Refactor

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`) — 1390 + 44
- [x] Lint clean (`dotnet format --verify-no-changes src/`)
- [x] Comparison parity verified: `ComparisonTests` + `ProductionManifestComparerTests` pass 29/29 before and after extraction

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required) — internal split within the existing `Manifest Comparison` subsystem; the `composer -> serializer -> emitter` seam and EDRM-XML carve-out are untouched, and `ProductionManifestComparer` remains the public façade shown in the diagram.

## Affected Requirements

None. No comparison semantics or JSON contract changes; REQ-157 through REQ-163 and the REQ-170..REQ-180 CLI contracts are preserved.
