### PR TITLE
refactor(dat): extract Production mode to DatProductionComposer (#611 PR2)

### DIFF
--- a/src/LoadFiles/DatComposer.cs
+++ b/src/LoadFiles/DatComposer.cs
@@ -1,5 +1,4 @@
 using Zipper.Profiles;
-using Zipper.Utils;
 
 namespace Zipper.LoadFiles;
 
@@ -26,6 +25,7 @@ internal sealed class DatComposer : ILoadFileComposer
     private readonly DataGenerator? profileGenerator;
     private readonly List<string>? profileColumnNames;
     private readonly BatesSequence? batesSequence;
+    private readonly DatProductionComposer? productionComposer;
 
     public DatComposer(FileGenerationRequest request, WriterMode mode)
     {
@@ -34,7 +34,13 @@ internal sealed class DatComposer : ILoadFileComposer
         this.namingConvention = request.Metadata.ColumnProfile?.FieldNamingConvention;
         this.batesSequence = request.Bates != null ? BatesSequence.FromConfig(request.Bates) : null;
 
-        if (mode != WriterMode.ProductionSet && request.Metadata.ColumnProfile is not null)
+        if (mode == WriterMode.ProductionSet)
+        {
+            this.headerColumns = DatProductionComposer.BuildHeaders(request, this.namingConvention);
+            this.productionComposer = new DatProductionComposer(
+                request, this.batesSequence, this.headerColumns);
+        }
+        else if (mode != WriterMode.ProductionSet && request.Metadata.ColumnProfile is not null)
         {
             var profile = request.Metadata.ColumnProfile;
             this.profileGenerator = new DataGenerator(
@@ -60,42 +66,19 @@ internal sealed class DatComposer : ILoadFileComposer
             WriterMode.LoadfileOnly => this.profileGenerator is not null
                 ? this.ComposeProfile()
                 : this.ComposeLoadfileOnly(),
-            WriterMode.ProductionSet => this.ComposeProduction(processedFiles),
+            WriterMode.ProductionSet => this.productionComposer!.Compose(processedFiles),
             _ => this.ComposeStandard(processedFiles),
         };
 
-    private string Apply(string name) => NamingConventionHelper.ApplyConvention(name, this.namingConvention);
+    private string Apply(string name) => DatComposerShared.ApplyConvention(name, this.namingConvention);
 
-    private DateTime EffectiveNow() => this.request.Metadata.Seed.HasValue
-        ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
-        : DateTime.UtcNow;
+    private DateTime EffectiveNow() => DatComposerShared.EffectiveNow(this.request);
 
     private LoadFileRecord MakeRecord(string recordId, List<string> orderedValues)
-        => LoadFileRecordBuilder.Build(this.headerColumns, orderedValues, recordId);
+        => DatComposerShared.MakeRecord(this.headerColumns, recordId, orderedValues);
 
     private List<string> BuildHeaderColumns()
     {
-        if (this.mode == WriterMode.ProductionSet)
-        {
-            var headers = new List<string> { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
-            if (this.request.Production.RedactedProduction)
-            {
-                headers.AddRange(new[] { "REDACTED_IMAGE_PATH", "REDACTED_TEXT_PATH", "NATIVE_WITHHELD", "REDACTION_REASON" });
-            }
-
-            if (this.request.Metadata.ShouldIncludeEmlColumns(this.request.Output))
-            {
-                headers.AddRange(new[] { "Attachment", "EmailSubject", "EmailFrom", "EmailTo", "EmailCC", "EmailSentDate" });
-            }
-
-            if (this.request.Metadata.WithFamilies)
-            {
-                headers.AddRange(new[] { "BEGATTACH", "ENDATTACH", "PARENTDOCID" });
-            }
-
-            return headers.Select(this.Apply).ToList();
-        }
-
         if (this.mode == WriterMode.LoadfileOnly)
         {
             var lfCols = new List<string>
@@ -370,134 +353,6 @@ internal sealed class DatComposer : ILoadFileComposer
             : wi.FilePathInZip;
     }
 
-    private IEnumerable<LoadFileRecord> ComposeProduction(IReadOnlyList<FileData> processedFiles)
-    {
-        foreach (var fileData in processedFiles)
-        {
-            var (parentId, childId, hasAttachment) = this.GetFamilyIdentifiers(fileData, this.request);
-
-            yield return this.MakeRecord(
-                parentId,
-                this.ProductionRowValues(fileData, new DatRowContext { IdOverride = parentId, BegAttach = parentId, EndAttach = childId, ParentDocId = string.Empty }));
-
-            if (hasAttachment)
-            {
-                var attach = fileData.Attachment!.Value;
-                var childExt = Path.GetExtension(FamilyPlan.SanitizeAttachmentFilename(attach.filename));
-                var childBates = childId;
-                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace('/', '\\');
-                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\');
-                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\');
-
-                var childRedactedImageRelPath = this.request.Production.RedactedProduction
-                    ? Path.Combine("REDACTED", "IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\')
-                    : null;
-                var childRedactedTextRelPath = this.request.Production.RedactedProduction && this.request.Output.WithText
-                    ? Path.Combine("REDACTED", "TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\')
-                    : null;
-
-                yield return this.MakeRecord(
-                    childId,
-                    this.ProductionRowValues(fileData, new DatRowContext
-                    {
-                        IdOverride = childBates,
-                        NativePathOverride = childNativePath,
-                        TextPathOverride = childTextPath,
-                        ImagePathOverride = childImagePath,
-                        FileSizeOverride = attach.content.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        IsChild = true,
-                        BegAttach = parentId,
-                        EndAttach = childId,
-                        ParentDocId = parentId,
-                        RedactedImageRelPathOverride = childRedactedImageRelPath,
-                        RedactedTextRelPathOverride = childRedactedTextRelPath,
-                        NativeWithheldOverride = "NO",
-                        RedactionReasonOverride = fileData.RedactionReason,
-                    }));
-            }
-        }
-    }
-
-    private List<string> ProductionRowValues(FileData fileData, DatRowContext ctx)
-    {
-        var wi = fileData.WorkItem;
-        var batesNumber = ctx.IdOverride ?? this.batesSequence!.Format(wi.Index - 1).ToString();
-        var imagePath = ctx.ImagePathOverride ?? wi.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
-            .Replace(Path.GetExtension(wi.FilePathInZip), ".tif", StringComparison.Ordinal);
-        // FilePathInZip always uses forward slashes (ZIP spec); replace '/' directly so the
-        // backslash normalization also works on Windows (where DirectorySeparatorChar is '\').
-        var nativePath = ctx.NativePathOverride ?? fileData.NativePathOverride ?? wi.FilePathInZip.Replace('/', '\\');
-        // Derive text path from the original FilePathInZip (not the overridden nativePath) so
-        // replace-with-placeholder policy doesn't produce wrong text paths in the DAT.
-        var originalNativePath = wi.FilePathInZip.Replace('/', '\\');
-        var textPath = ctx.TextPathOverride ?? (originalNativePath.StartsWith("NATIVES\\", StringComparison.OrdinalIgnoreCase) ? "TEXT\\" + originalNativePath.Substring(8) : originalNativePath).Replace($".{this.request.Output.FileType}", ".txt", StringComparison.Ordinal);
-        var imagesPath = imagePath.Replace('/', '\\');
-
-#pragma warning disable S2245
-        var random = this.request.Metadata.Seed.HasValue ? new Random(unchecked((int)(this.request.Metadata.Seed.Value + wi.Index))) : Random.Shared;
-#pragma warning restore S2245
-        var now = this.EffectiveNow();
-        var maxCustodians = Math.Max(2, this.request.Metadata.CustodianCountOverride ?? 10);
-        var custodianProd = $"Custodian {random.Next(1, maxCustodians + 1)}";
-        var dateCreated = now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-
-        var fileSize = ctx.FileSizeOverride ?? fileData.DataLength.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var fileType = ctx.IsChild ? Path.GetExtension(fileData.Attachment!.Value.filename).TrimStart('.').ToUpperInvariant() : this.request.Output.FileType.ToUpperInvariant();
-
-        var v = new List<string>(this.headerColumns.Count)
-        {
-            batesNumber,
-            batesNumber,
-            wi.FolderName,
-            nativePath,
-            textPath,
-            imagesPath,
-            custodianProd,
-            dateCreated,
-            fileSize,
-            fileType,
-        };
-
-        if (this.request.Production.RedactedProduction)
-        {
-            var redactedImagePath = (ctx.RedactedImageRelPathOverride ?? fileData.RedactedImageRelPath)?.Replace('/', '\\') ?? string.Empty;
-            // Only populate REDACTED_TEXT_PATH when text output is enabled; otherwise the file
-            // on disk is not written and post-generation validation would flag the dangling reference.
-            var redactedTextPath = (this.request.Output.WithText ? (ctx.RedactedTextRelPathOverride ?? fileData.RedactedTextRelPath) : null)?.Replace('/', '\\') ?? string.Empty;
-            var nativeWithheld = ctx.NativeWithheldOverride ?? (fileData.NativePathOverride is not null ? "YES" : "NO");
-            var redactionReason = ctx.RedactionReasonOverride ?? fileData.RedactionReason ?? string.Empty;
-            v.Add(redactedImagePath);
-            v.Add(redactedTextPath);
-            v.Add(nativeWithheld);
-            v.Add(redactionReason);
-        }
-
-        if (this.request.Metadata.ShouldIncludeEmlColumns(this.request.Output))
-        {
-            var attachmentVal = ctx.IsChild ? string.Empty : (fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty);
-            var subjectVal = ctx.IsChild ? string.Empty : (fileData.Email?.Subject ?? $"Email Subject {wi.Index}");
-            var fromVal = ctx.IsChild ? string.Empty : (fileData.Email?.From ?? $"sender{wi.Index}@example.com");
-            var toVal = ctx.IsChild ? string.Empty : (fileData.Email?.To ?? $"recipient{wi.Index}@example.com");
-            var ccVal = ctx.IsChild ? string.Empty : (fileData.Email is not null ? (fileData.Email.Cc ?? string.Empty) : $"cc{wi.Index}@example.com");
-            var sentDateVal = ctx.IsChild ? string.Empty : (fileData.Email?.SentDate.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture) ?? now.AddDays(-random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture));
-            v.Add(attachmentVal);
-            v.Add(subjectVal);
-            v.Add(fromVal);
-            v.Add(toVal);
-            v.Add(ccVal);
-            v.Add(sentDateVal);
-        }
-
-        if (this.request.Metadata.WithFamilies)
-        {
-            v.Add(ctx.BegAttach);
-            v.Add(ctx.EndAttach);
-            v.Add(ctx.ParentDocId);
-        }
-
-        return v;
-    }
-
     private IEnumerable<LoadFileRecord> ComposeLoadfileOnly()
     {
         var now = this.EffectiveNow();
@@ -642,12 +497,5 @@ internal sealed class DatComposer : ILoadFileComposer
     }
 
     private (string ParentId, string ChildId, bool HasAttachment) GetFamilyIdentifiers(FileData fileData, FileGenerationRequest request)
-    {
-        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
-        string parentId = this.batesSequence is not null
-            ? this.batesSequence.Format(fileData.WorkItem.Index - 1).ToString()
-            : $"DOC{fileData.WorkItem.Index:D8}";
-        string childId = hasAttachment ? $"{parentId}_A001" : parentId;
-        return (parentId, childId, hasAttachment);
-    }
+        => DatComposerShared.GetFamilyIdentifiers(fileData, request, this.batesSequence);
 }

--- a/src/LoadFiles/DatComposerShared.cs
+++ b/src/LoadFiles/DatComposerShared.cs
@@ -1,4 +1,5 @@
 using Zipper.Profiles;
+using Zipper.Utils;
 
 namespace Zipper.LoadFiles;
 
@@ -7,6 +8,43 @@ namespace Zipper.LoadFiles;
 /// </summary>
 internal static class DatComposerShared
 {
+    /// <summary>
+    /// Applies the naming convention (if any) to a column name.
+    /// </summary>
+    internal static string ApplyConvention(string name, string? namingConvention)
+        => NamingConventionHelper.ApplyConvention(name, namingConvention);
+
+    /// <summary>
+    /// Returns the effective timestamp: fixed epoch when a seed is set (for reproducibility),
+    /// otherwise the current UTC time.
+    /// </summary>
+    internal static DateTime EffectiveNow(FileGenerationRequest request)
+        => request.Metadata.Seed.HasValue
+            ? new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            : DateTime.UtcNow;
+
+    /// <summary>
+    /// Builds a <see cref="LoadFileRecord"/> from the header columns and ordered values.
+    /// </summary>
+    internal static LoadFileRecord MakeRecord(
+        IReadOnlyList<string> headerColumns, string recordId, List<string> orderedValues)
+        => LoadFileRecordBuilder.Build(headerColumns, orderedValues, recordId);
+
+    /// <summary>
+    /// Resolves parent/child identifiers and attachment status for a file, using the Bates
+    /// sequence when configured or a DOC-index fallback otherwise.
+    /// </summary>
+    internal static (string ParentId, string ChildId, bool HasAttachment) GetFamilyIdentifiers(
+        FileData fileData, FileGenerationRequest request, BatesSequence? batesSequence)
+    {
+        bool hasAttachment = request.Metadata.WithFamilies && request.Output.IsEml && fileData.Attachment.HasValue;
+        string parentId = batesSequence is not null
+            ? batesSequence.Format(fileData.WorkItem.Index - 1).ToString()
+            : $"DOC{fileData.WorkItem.Index:D8}";
+        string childId = hasAttachment ? $"{parentId}_A001" : parentId;
+        return (parentId, childId, hasAttachment);
+    }
+
     /// <summary>
     /// Resolves a hash-column name (e.g. "MD5HASH") to its value from the file's pre-computed hashes.
     /// Returns null when the column is not a hash column or the hash is not present.

--- a/src/LoadFiles/DatProductionComposer.cs
+++ b/src/LoadFiles/DatProductionComposer.cs
@@ -1,0 +1,179 @@
+namespace Zipper.LoadFiles;
+
+/// <summary>
+/// Production Set mode composer for the DAT format. Builds Production Set header columns
+/// (including redaction columns when enabled) and generates row values with Bates numbering,
+/// native/image/text paths, custodian, and family-attachment expansion.
+/// </summary>
+internal sealed class DatProductionComposer
+{
+    private readonly FileGenerationRequest request;
+    private readonly BatesSequence? batesSequence;
+    private readonly IReadOnlyList<string> headerColumns;
+
+    public DatProductionComposer(
+        FileGenerationRequest request,
+        BatesSequence? batesSequence,
+        IReadOnlyList<string> headerColumns)
+    {
+        this.request = request;
+        this.batesSequence = batesSequence;
+        this.headerColumns = headerColumns;
+    }
+
+    /// <summary>
+    /// Builds the header columns for Production Set mode, including redaction, EML, and
+    /// family columns when the corresponding request flags are set.
+    /// </summary>
+    public static List<string> BuildHeaders(FileGenerationRequest request, string? namingConvention)
+    {
+        var headers = new List<string> { "DOCID", "BATES_NUMBER", "VOLUME", "NATIVE_PATH", "TEXT_PATH", "IMAGE_PATH", "CUSTODIAN", "DATE_CREATED", "FILE_SIZE", "FILE_TYPE" };
+        if (request.Production.RedactedProduction)
+        {
+            headers.AddRange(new[] { "REDACTED_IMAGE_PATH", "REDACTED_TEXT_PATH", "NATIVE_WITHHELD", "REDACTION_REASON" });
+        }
+
+        if (request.Metadata.ShouldIncludeEmlColumns(request.Output))
+        {
+            headers.AddRange(new[] { "Attachment", "EmailSubject", "EmailFrom", "EmailTo", "EmailCC", "EmailSentDate" });
+        }
+
+        if (request.Metadata.WithFamilies)
+        {
+            headers.AddRange(new[] { "BEGATTACH", "ENDATTACH", "PARENTDOCID" });
+        }
+
+        return headers.Select(h => DatComposerShared.ApplyConvention(h, namingConvention)).ToList();
+    }
+
+    public IEnumerable<LoadFileRecord> Compose(IReadOnlyList<FileData> processedFiles)
+    {
+        foreach (var fileData in processedFiles)
+        {
+            var (parentId, childId, hasAttachment) = DatComposerShared.GetFamilyIdentifiers(
+                fileData, this.request, this.batesSequence);
+
+            yield return DatComposerShared.MakeRecord(
+                this.headerColumns,
+                parentId,
+                this.ProductionRowValues(fileData, new DatRowContext { IdOverride = parentId, BegAttach = parentId, EndAttach = childId, ParentDocId = string.Empty }));
+
+            if (hasAttachment)
+            {
+                var attach = fileData.Attachment!.Value;
+                var childExt = Path.GetExtension(FamilyPlan.SanitizeAttachmentFilename(attach.filename));
+                var childBates = childId;
+                var childNativePath = Path.Combine("NATIVES", fileData.WorkItem.FolderName, $"{childBates}{childExt}").Replace('/', '\\');
+                var childTextPath = Path.Combine("TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\');
+                var childImagePath = Path.Combine("IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\');
+
+                var childRedactedImageRelPath = this.request.Production.RedactedProduction
+                    ? Path.Combine("REDACTED", "IMAGES", fileData.WorkItem.FolderName, $"{childBates}.tif").Replace('/', '\\')
+                    : null;
+                var childRedactedTextRelPath = this.request.Production.RedactedProduction && this.request.Output.WithText
+                    ? Path.Combine("REDACTED", "TEXT", fileData.WorkItem.FolderName, $"{childBates}.txt").Replace('/', '\\')
+                    : null;
+
+                yield return DatComposerShared.MakeRecord(
+                    this.headerColumns,
+                    childId,
+                    this.ProductionRowValues(fileData, new DatRowContext
+                    {
+                        IdOverride = childBates,
+                        NativePathOverride = childNativePath,
+                        TextPathOverride = childTextPath,
+                        ImagePathOverride = childImagePath,
+                        FileSizeOverride = attach.content.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        IsChild = true,
+                        BegAttach = parentId,
+                        EndAttach = childId,
+                        ParentDocId = parentId,
+                        RedactedImageRelPathOverride = childRedactedImageRelPath,
+                        RedactedTextRelPathOverride = childRedactedTextRelPath,
+                        NativeWithheldOverride = "NO",
+                        RedactionReasonOverride = fileData.RedactionReason,
+                    }));
+            }
+        }
+    }
+
+    private List<string> ProductionRowValues(FileData fileData, DatRowContext ctx)
+    {
+        var wi = fileData.WorkItem;
+        var batesNumber = ctx.IdOverride ?? this.batesSequence!.Format(wi.Index - 1).ToString();
+        var imagePath = ctx.ImagePathOverride ?? wi.FilePathInZip.Replace("NATIVES", "IMAGES", StringComparison.OrdinalIgnoreCase)
+            .Replace(Path.GetExtension(wi.FilePathInZip), ".tif", StringComparison.Ordinal);
+        // FilePathInZip always uses forward slashes (ZIP spec); replace '/' directly so the
+        // backslash normalization also works on Windows (where DirectorySeparatorChar is '\').
+        var nativePath = ctx.NativePathOverride ?? fileData.NativePathOverride ?? wi.FilePathInZip.Replace('/', '\\');
+        // Derive text path from the original FilePathInZip (not the overridden nativePath) so
+        // replace-with-placeholder policy doesn't produce wrong text paths in the DAT.
+        var originalNativePath = wi.FilePathInZip.Replace('/', '\\');
+        var textPath = ctx.TextPathOverride ?? (originalNativePath.StartsWith("NATIVES\\", StringComparison.OrdinalIgnoreCase) ? "TEXT\\" + originalNativePath.Substring(8) : originalNativePath).Replace($".{this.request.Output.FileType}", ".txt", StringComparison.Ordinal);
+        var imagesPath = imagePath.Replace('/', '\\');
+
+#pragma warning disable S2245
+        var random = this.request.Metadata.Seed.HasValue ? new Random(unchecked((int)(this.request.Metadata.Seed.Value + wi.Index))) : Random.Shared;
+#pragma warning restore S2245
+        var now = DatComposerShared.EffectiveNow(this.request);
+        var maxCustodians = Math.Max(2, this.request.Metadata.CustodianCountOverride ?? 10);
+        var custodianProd = $"Custodian {random.Next(1, maxCustodians + 1)}";
+        var dateCreated = now.AddDays(-random.Next(1, 730)).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+
+        var fileSize = ctx.FileSizeOverride ?? fileData.DataLength.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var fileType = ctx.IsChild ? Path.GetExtension(fileData.Attachment!.Value.filename).TrimStart('.').ToUpperInvariant() : this.request.Output.FileType.ToUpperInvariant();
+
+        var v = new List<string>(this.headerColumns.Count)
+        {
+            batesNumber,
+            batesNumber,
+            wi.FolderName,
+            nativePath,
+            textPath,
+            imagesPath,
+            custodianProd,
+            dateCreated,
+            fileSize,
+            fileType,
+        };
+
+        if (this.request.Production.RedactedProduction)
+        {
+            var redactedImagePath = (ctx.RedactedImageRelPathOverride ?? fileData.RedactedImageRelPath)?.Replace('/', '\\') ?? string.Empty;
+            // Only populate REDACTED_TEXT_PATH when text output is enabled; otherwise the file
+            // on disk is not written and post-generation validation would flag the dangling reference.
+            var redactedTextPath = (this.request.Output.WithText ? (ctx.RedactedTextRelPathOverride ?? fileData.RedactedTextRelPath) : null)?.Replace('/', '\\') ?? string.Empty;
+            var nativeWithheld = ctx.NativeWithheldOverride ?? (fileData.NativePathOverride is not null ? "YES" : "NO");
+            var redactionReason = ctx.RedactionReasonOverride ?? fileData.RedactionReason ?? string.Empty;
+            v.Add(redactedImagePath);
+            v.Add(redactedTextPath);
+            v.Add(nativeWithheld);
+            v.Add(redactionReason);
+        }
+
+        if (this.request.Metadata.ShouldIncludeEmlColumns(this.request.Output))
+        {
+            var attachmentVal = ctx.IsChild ? string.Empty : (fileData.Attachment.HasValue ? fileData.Attachment.Value.filename : string.Empty);
+            var subjectVal = ctx.IsChild ? string.Empty : (fileData.Email?.Subject ?? $"Email Subject {wi.Index}");
+            var fromVal = ctx.IsChild ? string.Empty : (fileData.Email?.From ?? $"sender{wi.Index}@example.com");
+            var toVal = ctx.IsChild ? string.Empty : (fileData.Email?.To ?? $"recipient{wi.Index}@example.com");
+            var ccVal = ctx.IsChild ? string.Empty : (fileData.Email is not null ? (fileData.Email.Cc ?? string.Empty) : $"cc{wi.Index}@example.com");
+            var sentDateVal = ctx.IsChild ? string.Empty : (fileData.Email?.SentDate.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture) ?? now.AddDays(-random.Next(1, 30)).ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture));
+            v.Add(attachmentVal);
+            v.Add(subjectVal);
+            v.Add(fromVal);
+            v.Add(toVal);
+            v.Add(ccVal);
+            v.Add(sentDateVal);
+        }
+
+        if (this.request.Metadata.WithFamilies)
+        {
+            v.Add(ctx.BegAttach);
+            v.Add(ctx.EndAttach);
+            v.Add(ctx.ParentDocId);
+        }
+
+        return v;
+    }
+}


### PR DESCRIPTION
## Summary

PR2 of the #611 DatComposer decomposition. Extracts Production Set mode logic from `DatComposer.cs` into a new `DatProductionComposer.cs` class.

**New file:** `DatProductionComposer.cs` (179 lines) — contains `BuildHeaders` (static), `Compose`, and `ProductionRowValues` for Production Set mode, including redaction columns, EML columns, and family-attachment expansion.

**Updated `DatComposerShared.cs`:** Added 4 shared helpers (`ApplyConvention`, `EffectiveNow`, `MakeRecord`, `GetFamilyIdentifiers`) as static methods, replacing the private instance methods in DatComposer. Both DatComposer and DatProductionComposer now delegate to these.

**Updated `DatComposer.cs`:** 653 → 501 lines. The constructor now creates a `DatProductionComposer` for ProductionSet mode, and `Compose()` delegates to it. The ProductionSet header-building branch was removed from `BuildHeaderColumns()`. The instance helpers (`Apply`, `EffectiveNow`, `MakeRecord`, `GetFamilyIdentifiers`) now delegate to `DatComposerShared`.

## Parity Verification

- 58/58 DatComposer tests pass (DatComposingWriterTests, DatComposingWriterLoadFileTests, ProfileDrivenDatComposingWriterTests)
- 1390/1390 total unit tests pass
- 13/13 golden regression scenarios pass (including production-set scenario with 1,500 docs, Bates numbering, 3 volumes)
- `dotnet format --verify-no-changes` clean

## Release Notes

Extracts Production Set mode column building and row generation from DatComposer into a separate DatProductionComposer class, with shared helpers consolidated in DatComposerShared. No behavior change; all golden regression scenarios pass byte-identical.

## Architecture

No architecture changes. The composer remains column authority per the load-file seam invariant. DatComposer is now a façade that delegates ProductionSet mode to DatProductionComposer.

Fixes #611 (partial — PR2 of 4)