### PR TITLE
fix(ci): add wall_s soft warning annotation to perf guard (#614)

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -75,6 +75,8 @@ jobs:
               rw = mw / bw if bw > 0 else 0
               rr = mr / br if br > 0 else 0
               sw = "ℹ️" if rw <= wall_threshold else "⚠️"  # informational, never fails
+              if rw > 1.5:
+                  print(f"::warning title=Perf Guard (wall_s)::{sc} wall_s is {rw:.2f}× baseline ({mw:.2f}s vs {bw:.2f}s). Likely performance regression — review recommended.")
               sr = "✅" if rr <= rss_threshold else "❌"
               if rr > rss_threshold:
                   failed = True


### PR DESCRIPTION
## Summary

Adds a `::warning` GitHub Actions annotation to the perf-guard workflow when wall_s ratio exceeds 1.5x baseline. This does not fail the build but surfaces likely performance regressions for human review in the PR checks UI. RSS remains the hard gate at 1.20x.

## Release Notes

The perf guard CI workflow now emits a soft warning annotation when wall-clock time exceeds 1.5x baseline, surfacing potential performance regressions for review without failing the build.

## Architecture

No architecture changes — CI workflow annotation only.

*Self-review exemption: single-line CI workflow fix, no logic/public-contract changes.*

Fixes #614