### PR TITLE
fix(req): align REQ-033 with actual CI versioning behavior (#645)

### DIFF
--- a/.github/scripts/compute-version.sh
+++ b/.github/scripts/compute-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Computes the build version for CI.
+#
+# Tag push (refs/tags/v*):  exact tag version, e.g. v1.2.3 → 1.2.3
+# Main-branch push:        next patch from latest tag with -dev suffix,
+#                          e.g. latest tag v1.2.3 → 1.2.4-dev
+#
+# Usage: GITHUB_REF=refs/tags/v1.2.3 bash compute-version.sh
+# Output: writes "version=X.Y.Z[-dev]" to GITHUB_OUTPUT (or stdout if unset)
+set -euo pipefail
+
+ref="${GITHUB_REF:-}"
+
+if [[ "$ref" == refs/tags/v* ]]; then
+  version="${ref#refs/tags/v}"
+  echo "Version from tag: $version"
+else
+  latest_tag=$(git tag -l 'v*' | sort -V | tail -1)
+  if [[ -z "$latest_tag" ]]; then
+    latest_tag="v0.0.0"
+  fi
+  base="${latest_tag#v}"
+  IFS='.' read -r major minor patch <<< "$base"
+  new_patch=$((patch + 1))
+  version="$major.$minor.$new_patch-dev"
+  echo "Version from bump: $version (latest tag: $latest_tag)"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=$version" >> "$GITHUB_OUTPUT"
+else
+  echo "version=$version"
+fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,22 +31,7 @@ jobs:
       - name: Set Version
         id: version
         shell: bash
-        run: |
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-            echo "Version from tag: $VERSION"
-          else
-            LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -1)
-            if [[ -z "$LATEST_TAG" ]]; then
-              LATEST_TAG="v0.0.0"
-            fi
-            BASE=${LATEST_TAG#v}
-            IFS='.' read -r major minor patch <<< "$BASE"
-            NEW_PATCH=$((patch + 1))
-            VERSION="$major.$minor.$NEW_PATCH-dev"
-            echo "Version from bump: $VERSION (latest tag: $LATEST_TAG)"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/compute-version.sh
 
   lint:
     needs: prepare

--- a/Requirements.md
+++ b/Requirements.md
@@ -161,7 +161,7 @@ To enforce the pre-commit testing requirement, the repository will include a scr
 - **REQ-030**: The application's version will follow Semantic Versioning in the format `MAJOR.MINOR.PATCH`.
 - **REQ-031**: Version numbers are managed through Git tags (e.g., `v1.2.3`). When a PR is merged to `main`, the CI/CD pipeline automatically increments the patch version.
 - **REQ-032**: Manual version control is supported by pushing specific tags (e.g., `git tag v1.1.0 && git push origin v1.1.0`).
-- **REQ-033**: On every push to the `main` branch, the CI/CD pipeline will build the application, embedding the version from the tag into the assembly as the `InformationalVersion`.
+- **REQ-033**: On every push to the `main` branch, the CI/CD pipeline will build the application, embedding a development version (next patch from the latest tag with a `-dev` suffix) into the assembly as the `InformationalVersion`. On tag pushes (`v*`), the pipeline embeds the exact tag version.
 - **REQ-034**: The application must display its full version string when invoked with `--version` (or equivalent version flag), and must embed it as the assembly `InformationalVersion` so it appears in diagnostic output. It need not print a startup banner on normal invocations.
 - **REQ-035**: The CI/CD pipeline will automatically create a new GitHub Release for each successful `main` branch build. The release tag and title will be named according to the version (e.g., `v1.2.3`).
 

--- a/tests/test-compute-version.sh
+++ b/tests/test-compute-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tests compute-version.sh for both tag-push and main-push cases.
+set -euo pipefail
+
+SCRIPT="$(dirname "$0")/../.github/scripts/compute-version.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label — expected '$expected', got '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== compute-version.sh tests =="
+
+# Case 1: tag push — exact version from tag
+echo "Testing tag push (refs/tags/v1.2.3)..."
+output=$(GITHUB_REF=refs/tags/v1.2.3 bash "$SCRIPT" 2>&1)
+version=$(echo "$output" | grep '^version=' | cut -d= -f2)
+assert_eq "tag push version" "1.2.3" "$version"
+
+# Case 2: main push — next patch with -dev suffix
+# Uses the repo's actual latest tag, so we test the script logic
+# without hardcoding a specific version. We verify the -dev suffix
+# and that the base version is the latest tag bumped by one patch.
+echo "Testing main push (refs/heads/main)..."
+latest_tag=$(git tag -l 'v*' | sort -V | tail -1)
+if [[ -z "$latest_tag" ]]; then
+  latest_tag="v0.0.0"
+fi
+base="${latest_tag#v}"
+IFS='.' read -r major minor patch <<< "$base"
+expected="${major}.${minor}.$((patch + 1))-dev"
+
+output=$(GITHUB_REF=refs/heads/main bash "$SCRIPT" 2>&1)
+version=$(echo "$output" | grep '^version=' | cut -d= -f2)
+assert_eq "main push version" "$expected" "$version"
+assert_eq "main push has -dev suffix" "true" "$( [[ "$version" == *-dev ]] && echo true || echo false )"
+
+# Case 3: empty GITHUB_REF — should fall through to main-push logic
+echo "Testing empty ref..."
+output=$(GITHUB_REF="" bash "$SCRIPT" 2>&1)
+version=$(echo "$output" | grep '^version=' | cut -d= -f2)
+assert_eq "empty ref version" "$expected" "$version"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

REQ-033 stated that main-branch pushes embed "the version from the tag" into the assembly `InformationalVersion`. The actual CI workflow computes a development version (next patch from latest tag with `-dev` suffix) for main pushes, and uses the exact tag version only for tag pushes. This PR aligns the requirement with the implementation.

**Changes:**
- **Requirements.md**: Revised REQ-033 to distinguish main-push development versions (`X.Y.Z-dev`) from tag-push exact versions (`X.Y.Z`). Requirement ID unchanged.
- **`.github/scripts/compute-version.sh`** (NEW): Extracted version computation logic from `build-and-test.yml` into a standalone script for testability.
- **`.github/workflows/build-and-test.yml`**: Updated to call the extracted script.
- **`tests/test-compute-version.sh`** (NEW): Tests tag push (exact version), main push (next patch + `-dev`), and empty ref cases. 4/4 pass.

**`docs/cicd.md`** already accurately describes the two-case versioning behavior (lines 44 and 91) — no changes needed.

## Release Notes

Revises REQ-033 to accurately describe the CI versioning behavior: main-branch pushes embed a development version (next patch with -dev suffix) while tag pushes use the exact tag version. Extracts the version computation script for testability.

## Architecture

No architecture changes — requirements documentation and CI script extraction only.

*Self-review exemption: docs + CI script extraction, no logic/public-contract changes.*

Fixes #645