### PR TITLE
test(emails): strengthen weak Assert.NotNull-only assertions (#613)

### DIFF
--- a/src/Zipper.Tests/Emails/EmailAttachmentPickerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailAttachmentPickerTests.cs
@@ -96,6 +96,7 @@ public class EmailAttachmentPickerTests
         {
             var result = picker.Pick(-999L, 100.0, pool, new Random(i));
             Assert.NotNull(result);
+            Assert.Contains(result.FileName, new[] { "file0.pdf", "file1.pdf", "file2.pdf" });
         }
     }
 

--- a/src/Zipper.Tests/Emails/EmailSerializerTests.cs
+++ b/src/Zipper.Tests/Emails/EmailSerializerTests.cs
@@ -392,5 +392,10 @@ public class EmailSerializerTests
 
         Assert.NotNull(result);
         Assert.True(result.Length > 0);
+        var content = Encoding.UTF8.GetString(result);
+        Assert.Contains("Subject: Null FileName", content, StringComparison.Ordinal);
+        Assert.Contains("From: sender@example.com", content, StringComparison.Ordinal);
+        Assert.Contains("To: test@example.com", content, StringComparison.Ordinal);
+        Assert.Contains("multipart/mixed", content, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

Per the owner's scope-narrowing comment, only 2 of the 15 Assert.NotNull usages were genuinely weak. The remaining 13 are legitimate guards before real content assertions.

**Fixed:**
- EmailSerializerTests.ToEml_NullAttachmentFileName_HandlesGracefully: Added content assertions for Subject, From, To, and multipart/mixed presence in the EML output (was only asserting Length > 0).
- EmailAttachmentPickerTests.Pick_FullRate_NeverReturnsNull_WhenCandidatesExist: Added assertion that each returned FileName is one of the pool items (was only asserting NotNull in a loop).

## Release Notes

Strengthens two weak test assertions in EmailSerializerTests and EmailAttachmentPickerTests to verify actual content rather than just non-null return values.

*Self-review exemption: test-only change, two assertion additions.*

Fixes #613
