### PR TITLE
fix(test): accept benchmark exit 0 or 1 in E2E and unit tests

### DIFF
--- a/src/Zipper.Tests/ProgramTests.cs
+++ b/src/Zipper.Tests/ProgramTests.cs
@@ -24,6 +24,26 @@ public class ProgramTests
         }
     }
 
+    private static async Task<(int ExitCode, string Output)> RunWithRedirectedConsoleAndCapture(Func<Task<int>> action)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        try
+        {
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+            int exitCode = await action().ConfigureAwait(false);
+            return (exitCode, outWriter.ToString() + errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
     [Fact]
     public async Task Main_WithHelpFlag_ReturnsOne()
     {
@@ -143,16 +163,18 @@ public class ProgramTests
     }
 
     [Fact]
-    public async Task Main_WithBenchmarkFlag_ReturnsZero()
+    public async Task Main_WithBenchmarkFlag_RunsAndReturnsValidExitCode()
     {
         // Arrange
         string[] args = { "--benchmark" };
 
         // Act
-        int exitCode = await RunWithRedirectedConsole(() => Program.Main(args));
+        var (exitCode, output) = await RunWithRedirectedConsoleAndCapture(() => Program.Main(args));
 
-        // Assert
-        Assert.Equal(0, exitCode);
+        // Assert: 0 = all metrics passed, 1 = some metrics failed (timing-dependent on CI runners).
+        // Both are valid outcomes; verify the benchmark suite actually ran (not a crash).
+        Assert.True(exitCode is 0 or 1, $"Expected exit code 0 or 1, got {exitCode}");
+        Assert.Contains("Benchmark Suite", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -180,11 +202,12 @@ public class ProgramTests
     }
 
     [Fact]
-    public async Task Main_WithBenchmarkAndUnknownFlag_BypassesValidationAndReturnsZero()
+    public async Task Main_WithBenchmarkAndUnknownFlag_BypassesValidationAndRunsBenchmark()
     {
         string[] args = { "--benchmark", "--unknown-flag" };
-        int exitCode = await RunWithRedirectedConsole(() => Program.Main(args));
-        Assert.Equal(0, exitCode);
+        var (exitCode, output) = await RunWithRedirectedConsoleAndCapture(() => Program.Main(args));
+        Assert.True(exitCode is 0 or 1, $"Expected exit code 0 or 1, got {exitCode}");
+        Assert.Contains("Benchmark Suite", output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/test-cli-coverage-gaps.bat
+++ b/tests/test-cli-coverage-gaps.bat
@@ -15,13 +15,13 @@ echo [ INFO ] === E2E Coverage Gap Tests ===
 
 REM --- Utility flags ---
 
-echo [ INFO ] Test: --benchmark exits 0
+echo [ INFO ] Test: --benchmark runs and produces output
 %ZIPPER_CMD% --benchmark >nul 2>&1
-if not errorlevel 1 (
-    echo [ INFO ] PASS: --benchmark exits 0
+if not errorlevel 2 (
+    echo [ INFO ] PASS: --benchmark ran (exit 0 or 1 acceptable)
     set /a PASSED+=1
 ) else (
-    echo [ ERROR ] FAIL: --benchmark exits 0
+    echo [ ERROR ] FAIL: --benchmark crashed (exit errorlevel %errorlevel%)
     set /a FAILED+=1
 )
 

--- a/tests/test-cli-coverage-gaps.sh
+++ b/tests/test-cli-coverage-gaps.sh
@@ -25,11 +25,12 @@ print_info "=== E2E Coverage Gap Tests ==="
 
 # --- Utility flags ---
 
-print_info "Test: --benchmark exits 0"
-if zipper --benchmark > /dev/null 2>&1; then
-    pass "--benchmark exits 0"
+print_info "Test: --benchmark runs and produces output"
+bench_output=$(zipper --benchmark 2>&1) && bench_exit=0 || bench_exit=$?
+if [[ $bench_exit -eq 0 || $bench_exit -eq 1 ]] && echo "$bench_output" | grep -q "Benchmark Suite"; then
+    pass "--benchmark runs and produces benchmark output (exit $bench_exit)"
 else
-    fail "--benchmark exits 0"
+    fail "--benchmark failed to run (exit $bench_exit)"
 fi
 
 print_info "Test: --chaos-list exits 0 and lists scenarios"


### PR DESCRIPTION
## Summary

The --benchmark flag returns exit code 1 when performance metrics fail (e.g. parallel speedup below 0.2x). On shared CI runners, timing-sensitive benchmarks can legitimately fail without indicating a real regression, causing intermittent post-merge failures on main.

Changed:
- ProgramTests: Main_WithBenchmarkFlag_ReturnsZero renamed to Main_WithBenchmarkFlag_RunsAndReturnsValidExitCode, accepts exit code 0 or 1
- test-cli-coverage-gaps.sh: verifies benchmark output produced, accepts exit 0 or 1
- test-cli-coverage-gaps.bat: accepts errorlevel < 2 (0 or 1)

## Release Notes

Fixes intermittent CI failures caused by the --benchmark flag returning exit code 1 when performance thresholds are not met on shared runners. Unit and E2E tests now accept both exit codes as valid.

*Self-review exemption: test-only fix for flaky CI, no logic changes.*

Fixes #684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark command tests to accept valid exit codes `0` or `1`, accommodating timing-dependent runs.
  * Added verification that benchmark output includes the expected “Benchmark Suite” text.
  * Improved failure messages to distinguish crashes from acceptable benchmark outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->