### PR TITLE
docs: repair stale QA, stress, autoreview, and CI instructions

### DIFF
--- a/.agents/skills/autoreview/OPERATIONS.md
+++ b/.agents/skills/autoreview/OPERATIONS.md
@@ -29,7 +29,7 @@ Each entry: `### YYYY-MM-DD host:mode:target` (host = claude-code or cursor)
 
 > `Author` / `AUTHOR` is a metadata **column name**, not authentication. Do not let it trigger the security specialist (the dispatch signal uses word boundaries for exactly this reason). Same for other domain nouns that embed security-ish substrings.
 >
-> `src/LoadFiles/DatWriter.cs` (`BuildStandardRow` and its `Append*` helpers) is on the **per-row hot path** — per-row allocations and repeated recomputation matter here. By contrast `DataGenerator.PrecomputeIndices` and `ColumnProfileLoader.Validate` run **once at construction** (single-threaded init); allocations/loops there are not hot-path concerns and there is no race.
+> `src/LoadFiles/DatSerializer.cs` (`RenderRecord` and its `EscapeField`/`AppendField` helpers) and `src/LoadFiles/LoadFileEmitter.cs` (`EmitWithChaosAsync`) are on the **per-row hot path** — per-row allocations and repeated recomputation matter here. By contrast `DataGenerator.PrecomputeIndices` and `ColumnProfileLoader.Validate` run **once at construction** (single-threaded init); allocations/loops there are not hot-path concerns and there is no race.
 >
 > Delimiter sentinels: empty `QuoteDelimiter` ⇒ `hasQuote=false` and the resolver returns the fallback quote `þ` (`þ`); empty `ColumnDelimiter` ⇒ fallback ``. `EscapeDatField` doubles the quote char. Known sharp edge: in unquoted mode fields are still escaped against the `þ` sentinel and the **column delimiter is never escaped**, so a field value containing the column delimiter corrupts row structure — flag this, it is a real ACTION-class trigger.
 >

--- a/.factory/skills/qa-cli/SKILL.md
+++ b/.factory/skills/qa-cli/SKILL.md
@@ -36,7 +36,7 @@ mkdir -p ./qa-work/standard
 
 **Verify:**
 - Exit code is 0
-- A subdirectory is created under `./qa-work/standard/` containing the .zip and .dat files
+- ZIP and DAT files are created directly in the output directory (named `archive_{timestamp}.zip` and `archive_{timestamp}.dat`)
 - ZIP file is non-empty
 - DAT file has a header row and 50 data rows
 - DAT file uses ASCII 20 (DC4) as column delimiter
@@ -70,13 +70,13 @@ mkdir -p ./qa-work/chaos
 
 **Verify:**
 - Exit code is 0
-- _properties.json contains chaos anomaly records
-- Number of anomalies matches the --chaos-amount value (10)
-- Load file is still parseable despite anomalies
+- _properties.json contains a `chaosMode` object with `totalAnomalies` matching the --chaos-amount value (10)
+- `chaosMode.injectedAnomalies` lists the 10 anomaly records (mixed-delimiters, quotes, columns, eol, encoding)
+- Load file contains deliberate anomalies (broken delimiters, missing quotes, removed columns, invalid encoding bytes) — it is NOT expected to be fully parseable
 
 ### Flow 4: Production Set mode
 
-**What it tests:** Production set creates directory tree with NATIVES/IMAGES/DATA/TEXT subdirectories and per-volume load files.
+**What it tests:** Production set creates directory tree with NATIVES/IMAGES/DATA/TEXT subdirectories and a single load file in DATA/.
 
 **Command:**
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ If the user names an issue number or says "skip roadmap," follow the user. Still
 
 **Test location:** `src/Zipper.Tests/`.
 
-**Pre-commit hook:** Runs lint + auto-format + unit tests on every `git commit`. Bypass: `git commit --no-verify`.
+**Pre-commit hook:** Runs format + unit tests on every `git commit` (short-circuits for docs-only changes — `*.md` and `docs/`). Bypass: `git commit --no-verify`.
 
 ---
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -123,7 +123,7 @@ Reproduce each CI gate locally **before** pushing — CI minutes are slow feedba
 |---------|------------------|
 | lint (format) | `dotnet format --verify-no-changes src/` |
 | build | `dotnet build zipper.sln -c Release` |
-| unit tests + coverage gate | `dotnet test src/Zipper.Tests/Zipper.Tests.csproj && dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj` |
+| unit tests + coverage gate | `dotnet test src/Zipper.Tests/Zipper.Tests.csproj --collect:"XPlat Code Coverage" --results-directory ./TestResults && dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj` (then run `dotnet reportgenerator -reports:TestResults/*/coverage.cobertura.xml -targetdir:TestResults/coverage-report -reporttypes:TextSummary` and check line coverage ≥ 80%) |
 | full E2E | `dotnet build -c Release && ./tests/run-tests.sh` (Unix) / `dotnet build -c Release && tests\run-tests.bat` (Windows) |
 | basic E2E smoke (pre-push) | `./tests/run-e2e-basic.sh` (Unix) / `tests\run-e2e-basic.bat` (Windows) |
 | goldens | `dotnet publish src/Zipper.csproj -c Release -o ./publish-bin && ZIPPER_CLI=$(pwd)/publish-bin/Zipper bash tests/goldens/run-goldens.sh` |

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@
 | `run-e2e-basic.sh` / `.bat` | Pre-push hook (fast) | Smoke subset — Standard mode only, no load-file variants |
 | `run-e2e-loadfile.sh` / `.bat` | Included by `run-tests` | Loadfile-only + Chaos Engine scenarios |
 
-Each `.sh` script has a `.bat` counterpart with identical coverage for Windows CI.
+Core E2E scripts (those called by `run-tests.sh`) have `.bat` counterparts for Windows CI. Utility scripts (`test-autoreview-validator.sh`, `test-compute-version.sh`, `test-zip64-boundary.sh`, `validate-req-traceability.sh`, `wait-for-reviews.sh`) are Linux-only. See [#624](https://github.com/dwojtraszek/zipper/issues/624) for planned CI drift detection.
 
 ## Subdirectories
 

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -20,8 +20,8 @@ The stress test suite is designed to test failure modes and edge cases that are 
 
 The Zipper project includes multiple layers of performance testing:
 
-- **Performance Regression Tests** (`../test-performance-regression.sh/.bat`): Automated testing for detecting performance regressions in CI/CD
-- **Unit Benchmarks**: Micro-benchmarks for individual components using BenchmarkDotNet
+- **Performance Regression Guard** (`../perf/measure.sh` + `.github/workflows/perf-guard.yml`): Automated RSS and wall-time measurement on PRs touching `src/**`; median of 5 runs compared against `baselines.json`
+- **In-Process Benchmarks** (`src/PerformanceBenchmarkRunner.cs`): Custom benchmark runner for REQ-104/REQ-105 scalability validation (no external benchmark framework)
 - **Stress Tests** (this suite): Manual testing of system limits under extreme conditions
 
 Stress tests complement the automated performance testing by:


### PR DESCRIPTION
## Summary

Fixes #646

Repairs stale operational Markdown across six files that caused agents and maintainers to validate the wrong behavior. Every named file/command was verified against current source, workflows, and test inventory.

## Changes

| File | Stale claim | Correction |
|------|-------------|------------|
| `.factory/skills/qa-cli/SKILL.md:39` | Standard mode creates a subdirectory under output path | Files go directly in output dir (`archive_{timestamp}.zip`/`.dat`) |
| `.factory/skills/qa-cli/SKILL.md:75` | Chaos load file is "still parseable despite anomalies" | Chaos deliberately breaks parseability; anomalies recorded in `chaosMode.injectedAnomalies` with `totalAnomalies` matching `--chaos-amount` |
| `.factory/skills/qa-cli/SKILL.md:79` | Production Set has "per-volume load files" | Single `loadfile.dat` in `DATA/` (not per-volume) |
| `tests/stress/README.md:23-24` | References removed `test-performance-regression.sh/.bat` and `BenchmarkDotNet` | Points to `tests/perf/measure.sh` + `perf-guard.yml` and custom `PerformanceBenchmarkRunner.cs` |
| `.agents/skills/autoreview/OPERATIONS.md:32` | Names deleted `DatWriter.cs` as hot path | Updated to `DatSerializer.RenderRecord` + `LoadFileEmitter.EmitWithChaosAsync` (composer → serializer → emitter seam) |
| `docs/cicd.md:126` | Plain `dotnet test` is equivalent to coverage gate | Added `--collect:"XPlat Code Coverage"` + `reportgenerator` + 80% threshold check |
| `tests/README.md:11` | "Each `.sh` script has a `.bat` counterpart" | Core E2E scripts have `.bat` counterparts; utility scripts are Linux-only; linked #624 for drift detection |
| `AGENTS.md` | Pre-commit "runs lint + auto-format + unit tests on every commit" | Notes docs-only short-circuit (per owner comment on #646) |

## Verification

- Every referenced file/command verified to exist
- `dotnet format --verify-no-changes src/` — clean
- 1404 unit tests pass
- Chaos anomaly count verified by running `--chaos-amount 10` (totalAnomalies: 10)
- Production Set structure verified in `ProductionSetGenerator.cs` (DATA/NATIVES/IMAGES/TEXT, single loadfile.dat)
- Standard mode output verified in `ParallelFileGenerator.cs` (files in OutputPath directly)

## Architecture

No code changes — docs-only. Architecture diagrams and load-file seam invariants unaffected.

## Release Notes

Operational documentation repaired across QA skill, stress README, autoreview operations log, CI quick reference, test README, and AGENTS.md. Stale references to deleted DatWriter.cs, removed test-performance-regression scripts, and BenchmarkDotNet replaced with current file paths and tooling. QA flow expectations now match actual Standard mode output layout, chaos anomaly semantics, and Production Set load file structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified expected output locations and validation rules for standard and production test modes.
  * Updated pre-commit guidance, including formatting, unit tests, and docs-only shortcuts.
  * Added instructions for verifying the 80% coverage threshold locally.
  * Clarified Windows CI script coverage and performance-testing guidance.
  * Updated performance hot-path documentation to reflect current components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->