### PR TITLE
docs(req): fix orphaned reference, document identifier gaps, add orphan validator

### DIFF
--- a/Requirements.md
+++ b/Requirements.md
@@ -3,6 +3,9 @@
 > [!CAUTION]
 > **Requirement numbers (REQ-XXX, FR-XXX) are IMMUTABLE.** Once a requirement is assigned a number, that number must NEVER be changed, reassigned, or renumbered. New requirements must use the next available number. If a requirement is deprecated, it should be marked as deprecated but its number must remain reserved.
 
+> [!NOTE]
+> **Identifier conventions:** This document uses two numbering sequences. The original prototype used the `_E` suffix (e.g., `REQ_E-008`, `FR_E-002`) for requirements defined in the initial "E-Discovery" spec. When the requirements were reorganized into the modern `REQ-NNN` / `FR-NNN` sequence, numbers already occupied by `_E` counterparts were intentionally skipped to avoid collisions — these reserved gaps are marked with HTML comments at their skip points. New requirements always use the next available number in the modern sequence. The `_E` IDs are immutable and will not be renumbered.
+
 > [!IMPORTANT]
 > **Documentation Sync Required**: When adding or modifying CLI arguments in this document, you MUST also update `README.md` to reflect the changes. The README contains an "Arguments Quick Reference" table and "Argument Interactions" section that must stay in sync with this specification.
 
@@ -56,7 +59,8 @@ The application operates in three distinct generation modes:
 - **REQ-008**: The `--type` argument shall be expanded to accept `eml` as a valid file type.
 - **REQ-009**: When `--type eml` is specified, the tool will generate Email Native Files with basic, valid headers (To, From, Subject, Sent-Date) and a simple, repetitive text body.
 - **REQ-010**: The associated `.dat` Load File will contain columns corresponding to the email headers, populated with auto-generated data. For Emails, metadata columns (To, From, Subject, Sent Date, Attachment) are always included regardless of the `--with-metadata` flag, as these are intrinsic to Emails.
-- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated Emails have a placeholder Native File (one of `jpg`, `tiff`, or `pdf` drawn from the internal attachment pool) included as a random Attachment. The Attachment uses internal placeholder content (consistent with REQ-012) rather than a reference to one of the `--count` generated Native Files, to preserve the streaming, no-intermediate-storage generation design. Defaults to 0.
+- **REQ-011**: A new optional argument `--attachment-rate <percentage>` will control what percentage of generated Emails have a placeholder Native File (one of `jpg`, `tiff`, or `pdf` drawn from the internal attachment pool) included as a random Attachment. The Attachment uses internal placeholder content (consistent with REQ_E-012) rather than a reference to one of the `--count` generated Native Files, to preserve the streaming, no-intermediate-storage generation design. Defaults to 0.
+<!-- REQ-012 through REQ-020: Reserved — functional areas covered by legacy REQ_E-008 through REQ_E-028. Skipped to avoid collisions when the modern sequence was introduced. -->
 
 ### FR_E-005: File Distribution Patterns
 - **REQ_E-022**: A new optional command-line argument `--distribution` shall be introduced.
@@ -66,6 +70,7 @@ The application operates in three distinct generation modes:
 - **REQ_E-026**: `gaussian` distribution shall assign Native Files in a bell-curve pattern, with most Native Files concentrated in the middle Folders.
 - **REQ_E-027**: `exponential` distribution shall assign Native Files in an exponential decay pattern, with most Native Files concentrated in the first few Folders.
 - **REQ_E-028**: The application must support distributing Native Files into a user-specified number of Folders (from 1 to 100), defaulting to 1.
+<!-- FR-003, FR-004: Reserved — functional areas covered by legacy FR_E-003 (Archive Creation) and FR_E-004 (Load File Generation). Skipped to avoid collisions when the modern sequence was introduced. -->
 
 ### FR-005: Target Zip Size via In-File Padding
 - **REQ-021**: A new optional command-line argument `--target-zip-size <size>` shall be introduced.
@@ -757,6 +762,7 @@ This section clarifies behavior when multiple arguments interact:
 - **REQ-146**: Redacted Production mode shall add redaction reason Metadata to the Load File via `REDACTION_REASON` column.
 - **REQ-147**: Redacted Production mode shall record redaction counts, withheld Native File counts, and reason distributions in the Production Manifest.
 - **REQ-148**: Post-generation validation shall verify that redacted image and text references point to existing files on disk, and that `NATIVE_WITHHELD` values are `YES` or `NO`.
+<!-- REQ-149 through REQ-156: Reserved for future Production Set requirements. -->
 - **REQ-157**: Zipper shall support comparing two or more Production Manifests.
 - **REQ-158**: Comparison reports shall support replacement workflows.
 - **REQ-159**: Comparison reports shall support supplemental workflows.

--- a/tests/req-traceability.tsv
+++ b/tests/req-traceability.tsv
@@ -11,7 +11,6 @@ REQ-008	unit	FileGeneratorFactoryTests.Create_KnownType_ReturnsCorrectGenerator	
 REQ-009	unit	Emails.EmailSerializerTests.ToEml_ProducesRfc2822ValidHeaders	Email Native Files with valid headers
 REQ-010	unit	DatComposingWriterTests.WriteAsync_WithEmailType_IncludesEmlColumns	Email header columns in .dat
 REQ-011	unit	Emails.EmailAttachmentPickerTests.Pick_RespectsRate	--attachment-rate percentage control
-REQ-012	exemption	-	Undefined dangling reference in REQ-011; tracked by #644
 REQ-021	unit	CliValidatorTests.Validate_InvalidTargetZipSize_ReturnsFalse	--target-zip-size argument
 REQ-022	unit	CliValidatorTests.Validate_TargetZipSizeWithoutCount_ReturnsFalse	Validation error without --count
 REQ-023	unit	ParallelFileGeneratorTests.GenerateFilesAsync_WithTargetZipSize_PadsFilesToReachTargetSize	Padding calculation

--- a/tests/validate-req-traceability.sh
+++ b/tests/validate-req-traceability.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # validate-req-traceability.sh — verify every active REQ-NNN in Requirements.md
-# is mapped to a test or explicit exemption in req-traceability.tsv.
+# is mapped to a test or explicit exemption in req-traceability.tsv, and that
+# no requirement cross-reference points to an undefined ID.
 #
 # Usage:
 #   validate-req-traceability.sh [--strict]
 #
-#   --strict   Fail on any unmapped active requirement (CI mode).
-#              Without --strict, report only (local development).
+#   --strict   Fail on any unmapped active requirement or orphaned reference
+#              (CI mode). Without --strict, report only (local development).
 #
 # Exit codes:
-#   0  all active requirements mapped or exempted (or report-only mode)
-#   1  unmapped active requirements remain (--strict mode)
+#   0  all active requirements mapped or exempted, no orphan references
+#   1  unmapped active requirements or orphaned references remain (--strict)
 #   2  missing files / parse errors
 #
 # Manifest format (tab-separated, header row required):
@@ -39,8 +40,10 @@ if [[ ! -f "$MANIFEST" ]]; then
     exit 2
 fi
 
-# --- Extract active REQ IDs from Requirements.md ---
-mapfile -t ACTIVE_REQS < <(grep -oE 'REQ-[0-9]+' "$REQUIREMENTS" | sort -u -t- -k2 -n)
+# --- Extract defined REQ-NNN IDs from Requirements.md ---
+# Only count bullet-point definitions (e.g., "- **REQ-NNN**:"), not in-text
+# references or HTML comment reservation markers.
+mapfile -t ACTIVE_REQS < <(grep -oE '^\- \*\*REQ-[0-9]+\*\*' "$REQUIREMENTS" | grep -oE 'REQ-[0-9]+' | sort -u -t- -k2 -n)
 
 if [[ ${#ACTIVE_REQS[@]} -eq 0 ]]; then
     echo "Error: no REQ-NNN IDs found in Requirements.md" >&2
@@ -155,9 +158,43 @@ fi
 COVERAGE_PCT=$(( (MAPPED + EXEMPTED) * 100 / TOTAL ))
 echo "Coverage: ${COVERAGE_PCT}% (${MAPPED} mapped + ${EXEMPTED} exempted = $((MAPPED + EXEMPTED))/$TOTAL)"
 
+# --- Orphan reference check (#644) ---
+# Verify that every REQ-NNN / REQ_E-NNN mentioned in the text resolves to a
+# defined requirement (bullet-point definition) and is not just a dangling
+# reference. HTML comment lines (reservation markers) are excluded.
+mapfile -t DEFINED_IDS < <(grep -oE '^\- \*\*REQ_E?-[0-9]+\*\*' "$REQUIREMENTS" | grep -oE 'REQ_E?-[0-9]+' | sort -u)
+mapfile -t ALL_MENTIONS < <(grep -v '^<!--' "$REQUIREMENTS" | grep -oE 'REQ_E?-[0-9]+' | sort -u)
+
+declare -A DEFINED_SET
+for id in "${DEFINED_IDS[@]}"; do
+    DEFINED_SET["$id"]=1
+done
+
+ORPHAN_REFS=()
+for id in "${ALL_MENTIONS[@]}"; do
+    if [[ -z "${DEFINED_SET[$id]:-}" ]]; then
+        ORPHAN_REFS+=("$id")
+    fi
+done
+
+ORPHAN_COUNT=${#ORPHAN_REFS[@]}
+echo "Orphan references:    $ORPHAN_COUNT"
+echo ""
+
+if [[ $ORPHAN_COUNT -gt 0 ]]; then
+    echo "--- Orphan references (mentioned but never defined) ---"
+    printf '  %s\n' "${ORPHAN_REFS[@]}" | sort -u
+    echo ""
+fi
+
 if [[ $UNMAPPED_COUNT -gt 0 && $STRICT -eq 1 ]]; then
     echo ""
     echo "FAIL: $UNMAPPED_COUNT unmapped active requirements remain." >&2
+    exit 1
+fi
+
+if [[ $ORPHAN_COUNT -gt 0 && $STRICT -eq 1 ]]; then
+    echo "FAIL: $ORPHAN_COUNT orphaned requirement references found." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #605, #616, #644

Batched per owner comments on all three issues: document Requirements.md numeric gaps, explain legacy `_E` prefix convention, and fix the orphaned REQ-011 → REQ-012 reference.

## Changes

| Issue | Change |
|-------|--------|
| #644 | Fixed REQ-011: reference to undefined `REQ-012` corrected to `REQ_E-012` (which defines internal placeholder content) |
| #605 | Documented all numeric gaps with HTML comment reservation markers: REQ-012..020 (covered by legacy REQ_E-008..028), REQ-149..156 (reserved for future Production Set requirements), FR-003..004 (covered by legacy FR_E-003/FR_E-004) |
| #616 | Added identifier convention note after the immutability warning explaining the legacy `_E` prefix and reserved-gap policy |
| #644 | Updated `validate-req-traceability.sh` to extract only defined requirements (bullet-point `**REQ-NNN**:` patterns, not in-text references or HTML comments) and added orphan-reference check that flags any `REQ-NNN`/`REQ_E-NNN` mentioned in text but never defined |
| — | Removed `REQ-012` exemption from `req-traceability.tsv` (reference fixed, ID no longer appears in Requirements.md) |

## Verification

- `bash tests/validate-req-traceability.sh --strict` — 173 active requirements, 100% coverage, 0 orphan references
- `dotnet format --verify-no-changes src/` — clean
- 1404 unit tests pass
- All gap markers are HTML comments (invisible in rendered Markdown, ignored by the validator)
- Orphan check verified: would catch the old REQ-012 reference if reverted

## Architecture

No code changes — Requirements.md, traceability manifest, and validator script only. Architecture diagrams and load-file seam invariants unaffected.

## Release Notes

Requirements.md identifier hygiene: fixed orphaned REQ-011 reference (REQ-012 to REQ_E-012), documented all numeric gaps with reservation markers, explained legacy _E prefix convention, and added orphan-reference detection to the traceability validator.