### PR TITLE
fix(ci): pin SDK for locked restore

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.300",
-    "rollForward": "latestPatch",
+    "version": "10.0.302",
+    "rollForward": "disable",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Release Notes
Pinned the .NET SDK used for dependency resolution so Dependabot and CI generate compatible package lock files.

## Description

Pins the repository SDK to 10.0.302 and disables roll-forward. Dependabot previously resolved the SDK-owned ILLink package with 10.0.8 while CI restored with 10.0.10, causing locked restore to fail.

## Type of Change

- [x] Bug fix
- [x] CI/Build

## Testing Done

- [x] Locked restore passes locally with `dotnet restore zipper.sln --locked-mode`

## Architecture

- [x] No deviation from the architecture diagrams.

## Affected Requirements

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configured .NET SDK version to 10.0.302.
  * Disabled automatic SDK patch-level roll-forward to ensure the specified version is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->