### PR TITLE
fix: stop cross-platform E2E from deleting tracked golden files

### DIFF
--- a/tests/test-cross-platform.bat
+++ b/tests/test-cross-platform.bat
@@ -8,7 +8,10 @@ REM This script tests core functionality across different platforms
 setlocal enabledelayedexpansion
 
 REM Test configuration
-set TEST_OUTPUT_DIR=.\cross-platform-results
+REM Scratch output goes to the gitignored results\ tree: cross-platform-results\
+REM contains tracked golden files, this script rmdir's its output dir, and
+REM Zipper rejects output paths outside the working directory (#707).
+set TEST_OUTPUT_DIR=.\results\cross-platform
 set PROJECT=src\Zipper.csproj
 
 REM Helper functions

--- a/tests/test-cross-platform.sh
+++ b/tests/test-cross-platform.sh
@@ -16,7 +16,10 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Test configuration
-TEST_OUTPUT_DIR="./cross-platform-results"
+# Scratch output goes to the gitignored results/ tree: cross-platform-results/
+# contains tracked golden files, this script rm -rf's its output dir, and
+# Zipper rejects output paths outside the working directory (#707).
+TEST_OUTPUT_DIR="./results/cross-platform"
 PROJECT="src/Zipper.csproj"
 PLATFORM=$(uname -s)
 


### PR DESCRIPTION
## Release Notes
Fixed the cross-platform E2E script deleting three tracked `cross-platform-results` files on every run; its scratch output now goes to the gitignored `results/` tree.

## Description

Fixes #707. `tests/test-cross-platform.sh` (invoked as Test 7 by `run-tests.sh`) used `./cross-platform-results` as its scratch directory and `rm -rf`'d it before and after the run, deleting the three tracked `archive_*.dat_properties.json` files and leaving the working tree dirty after every full E2E pass. The script now writes scratch output to `./results/cross-platform` (gitignored via `**/results/`), matching the convention used by the other E2E scripts; the `.bat` counterpart was updated in parity. A `/tmp` location was considered and rejected: Zipper's PathValidator rejects `--output-path` outside the working directory.

Reproduced before the fix (three tracked deletions in `git status`), re-ran after: suite passes (16 ZIP + 16 DAT verified) and the goldens stay untouched.

**Note for the maintainer (out of scope here):** the three tracked files appear to be accidentally-committed scratch output from a 2026-07-23 run — nothing in the repo consumes them (the golden harness lives in `tests/goldens/fixtures/`). They are preserved per the issue's ask; a follow-up issue could delete or wire them in.

Review: lightweight adversarial subagent review (7 axes) — no significant problems found.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test coverage
- [ ] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass — no C# changes; pre-commit hook green
- [x] E2E tests pass — `bash tests/test-cross-platform.sh` green end-to-end; git tree verified clean afterward
- [x] Lint clean — no C# changes
- [x] `bash -n` syntax check passes

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None — E2E tooling only, no REQ-XXX/FR-XXX impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cross-platform test output and cleanup paths to use the standardized `results/cross-platform` directory.
  * Improved test script documentation around temporary output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->