### PR TITLE
test: add CI drift detection for E2E .sh/.bat parity

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Validate requirement traceability
         shell: bash
         run: bash tests/validate-req-traceability.sh --strict
+      - name: Validate E2E .sh/.bat parity
+        shell: bash
+        run: bash tests/validate-e2e-parity.sh --strict
       - name: Check for oversized files
         shell: bash
         run: |

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@
 | `run-e2e-basic.sh` / `.bat` | Pre-push hook (fast) | Smoke subset — Standard mode only, no load-file variants |
 | `run-e2e-loadfile.sh` / `.bat` | Included by `run-tests` | Loadfile-only + Chaos Engine scenarios |
 
-Core E2E scripts (those called by `run-tests.sh`) have `.bat` counterparts for Windows CI. Utility scripts (`test-autoreview-validator.sh`, `test-compute-version.sh`, `test-zip64-boundary.sh`, `validate-req-traceability.sh`, `wait-for-reviews.sh`) are Linux-only. See [#624](https://github.com/dwojtraszek/zipper/issues/624) for planned CI drift detection.
+Core E2E scripts (those called by `run-tests.sh`) have `.bat` counterparts for Windows CI. Utility scripts (`test-autoreview-validator.sh`, `test-compute-version.sh`, `test-zip64-boundary.sh`, `validate-e2e-parity.sh`, `validate-req-traceability.sh`, `wait-for-reviews.sh`) are Linux-only. `validate-e2e-parity.sh` runs in PR CI (strict mode) and fails if the inline test cases or invoked sub-script suites drift between `run-tests.sh` and `run-tests.bat` (#624); platform-specific suites need a documented exemption in the script.
 
 ## Subdirectories
 

--- a/tests/validate-e2e-parity.sh
+++ b/tests/validate-e2e-parity.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# validate-e2e-parity.sh — detect drift between the Linux (.sh) and Windows
+# (.bat) E2E orchestrators. Both must run the same inline "Test Case N" cases
+# and the same sub-script suites, so a test added on one side cannot be
+# silently dropped on the other (#624).
+#
+# Detection relies on the established invocation conventions:
+#   inline cases:  run_test_case "Test Case N: ..." (both runners) and custom
+#                  blocks announced via a "START: Test Case N: ..." print line
+#   sub-scripts:   bash ./<repo-relative-path>.sh  |  call .\<path>.bat
+# Invoke new suites in exactly these forms or the gate cannot see them.
+#
+# Usage:
+#   validate-e2e-parity.sh [--strict]
+#
+#   --strict   Fail on any drift (CI mode). Without --strict, report only.
+#
+# Exit codes:
+#   0  no drift (or report-only mode)
+#   1  drift detected (--strict)
+#   2  missing files / parse errors
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SH_RUNNER="$SCRIPT_DIR/run-tests.sh"
+BAT_RUNNER="$SCRIPT_DIR/run-tests.bat"
+
+# Sub-scripts that exist on one side only, by design:
+#   tests/test-run-tests-fatal — Windows-only regression guard for #442
+#     (cmd/batch errorlevel semantics); run-tests.sh has no
+#     --meta-test-fail-only path.
+#   .github/actions/coverage-gate/test-coverage-gate — self-test for the
+#     Linux-only CI composite action; no Windows counterpart by design.
+EXEMPT_SUBSCRIPTS=(
+    tests/test-run-tests-fatal
+    .github/actions/coverage-gate/test-coverage-gate
+)
+
+STRICT=0
+[[ "${1:-}" == "--strict" ]] && STRICT=1
+
+for f in "$SH_RUNNER" "$BAT_RUNNER"; do
+    if [[ ! -f "$f" ]]; then
+        echo "Error: runner not found at $f" >&2
+        exit 2
+    fi
+done
+
+# --- Extract inline test case names ---
+# Invocation strings ('run_test_case "Test Case N: ..."' on both sides) plus
+# custom blocks announced via 'START: Test Case N: ...' print lines.
+extract_cases_sh() {
+    {
+        grep -oE 'run_test_case "Test Case [^"]+"' "$SH_RUNNER" | sed 's/^run_test_case "//; s/"$//'
+        grep -oE '"START: Test Case [^"]+"' "$SH_RUNNER" | sed 's/^"START: //; s/"$//'
+    } | sort -u
+}
+
+extract_cases_bat() {
+    {
+        grep -oiE 'call :run_test_case "Test Case [^"]+"' "$BAT_RUNNER" | sed 's/^call :run_test_case "//I; s/"$//'
+        grep -oE '"START: Test Case [^"]+"' "$BAT_RUNNER" | sed 's/^"START: //; s/"$//'
+    } | sort -u
+}
+
+# --- Extract invoked sub-script path-stems (repo-relative, no extension) ---
+# Invocation convention (both runners): `bash ./<path>.sh` / `call .\<path>.bat`.
+extract_scripts_sh() {
+    grep -oE 'bash \./[A-Za-z0-9._/-]+\.sh' "$SH_RUNNER" | sed 's|^bash \./||; s|\.sh$||' | sort -u
+}
+
+extract_scripts_bat() {
+    grep -oiE 'call \.\\[A-Za-z0-9._\\/-]+\.bat' "$BAT_RUNNER" | sed 's|\\|/|g; s|^call \./||I; s|\.bat$||I' | sort -u
+}
+
+is_exempt() {
+    local stem="$1"
+    for e in "${EXEMPT_SUBSCRIPTS[@]}"; do
+        [[ "$stem" == "$e" ]] && return 0
+    done
+    return 1
+}
+
+mapfile -t SH_CASES < <(extract_cases_sh)
+mapfile -t BAT_CASES < <(extract_cases_bat)
+mapfile -t SH_SCRIPTS < <(extract_scripts_sh)
+mapfile -t BAT_SCRIPTS < <(extract_scripts_bat)
+
+if [[ ${#SH_CASES[@]} -eq 0 || ${#BAT_CASES[@]} -eq 0 || ${#SH_SCRIPTS[@]} -eq 0 || ${#BAT_SCRIPTS[@]} -eq 0 ]]; then
+    echo "Error: extraction yielded an empty set (sh cases: ${#SH_CASES[@]}, bat cases: ${#BAT_CASES[@]}, sh scripts: ${#SH_SCRIPTS[@]}, bat scripts: ${#BAT_SCRIPTS[@]})" >&2
+    exit 2
+fi
+
+DRIFT=0
+
+report_diff() {
+    local label="$1"; shift
+    local -n only_sh_ref=$1
+    local -n only_bat_ref=$2
+    if [[ ${#only_sh_ref[@]} -gt 0 ]]; then
+        DRIFT=1
+        echo "$label present in run-tests.sh only:"
+        printf '  - %s\n' "${only_sh_ref[@]}"
+    fi
+    if [[ ${#only_bat_ref[@]} -gt 0 ]]; then
+        DRIFT=1
+        echo "$label present in run-tests.bat only:"
+        printf '  - %s\n' "${only_bat_ref[@]}"
+    fi
+}
+
+# Inline test cases
+# shellcheck disable=SC2034  # consumed via nameref in report_diff
+mapfile -t SH_ONLY_CASES < <(comm -23 <(printf '%s\n' "${SH_CASES[@]}") <(printf '%s\n' "${BAT_CASES[@]}"))
+# shellcheck disable=SC2034  # consumed via nameref in report_diff
+mapfile -t BAT_ONLY_CASES < <(comm -13 <(printf '%s\n' "${SH_CASES[@]}") <(printf '%s\n' "${BAT_CASES[@]}"))
+report_diff "Inline test case" SH_ONLY_CASES BAT_ONLY_CASES
+
+# Sub-scripts (exemptions filtered from both sides)
+mapfile -t SH_ONLY_SCRIPTS_RAW < <(comm -23 <(printf '%s\n' "${SH_SCRIPTS[@]}") <(printf '%s\n' "${BAT_SCRIPTS[@]}"))
+mapfile -t BAT_ONLY_SCRIPTS_RAW < <(comm -13 <(printf '%s\n' "${SH_SCRIPTS[@]}") <(printf '%s\n' "${BAT_SCRIPTS[@]}"))
+# shellcheck disable=SC2034  # consumed via nameref in report_diff
+SH_ONLY_SCRIPTS=()
+for s in ${SH_ONLY_SCRIPTS_RAW[@]+"${SH_ONLY_SCRIPTS_RAW[@]}"}; do
+    is_exempt "$s" || SH_ONLY_SCRIPTS+=("$s")
+done
+# shellcheck disable=SC2034  # consumed via nameref in report_diff
+BAT_ONLY_SCRIPTS=()
+for s in ${BAT_ONLY_SCRIPTS_RAW[@]+"${BAT_ONLY_SCRIPTS_RAW[@]}"}; do
+    is_exempt "$s" || BAT_ONLY_SCRIPTS+=("$s")
+done
+report_diff "Sub-script suite" SH_ONLY_SCRIPTS BAT_ONLY_SCRIPTS
+
+if [[ $DRIFT -eq 0 ]]; then
+    echo "OK: run-tests.sh and run-tests.bat are in sync (${#SH_CASES[@]} inline cases, ${#SH_SCRIPTS[@]} sub-script suites)."
+    exit 0
+fi
+
+echo
+echo "Drift detected between run-tests.sh and run-tests.bat."
+echo "Add the missing test to the other runner, or add a documented exemption in $0."
+[[ $STRICT -eq 1 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Release Notes
Added a CI gate that fails PRs when the Windows and Linux E2E orchestrators drift apart: inline test cases and invoked sub-script suites are now diffed between `run-tests.sh` and `run-tests.bat`.

## Description

Fixes #624. New `tests/validate-e2e-parity.sh` (modeled on `validate-req-traceability.sh`: report-only by default, `--strict` for CI) extracts and compares two sets between the runners: inline `Test Case N` names (from `run_test_case` invocations and `START: Test Case` print lines) and invoked sub-script suites as repo-relative path-stems (`bash ./<path>.sh` vs `call .\<path>.bat`). It runs as a strict-mode step in the PR `lint` job, so adding a suite to only one orchestrator now fails the PR.

The detector immediately surfaced two pre-existing one-sided suites, documented as exemptions in the script with reasons: `tests/test-run-tests-fatal` (Windows-only regression guard for #442 batch errorlevel semantics; `run-tests.sh` has no `--meta-test-fail-only` path) and `.github/actions/coverage-gate/test-coverage-gate` (self-test for the Linux-only CI composite action). Adversarial review caught that the first draft only compared `./tests/` filenames and would have missed the coverage-gate drift, so extraction compares full repo-relative path-stems.

Verified red/green: with exemptions removed the validator reports both one-sided suites and exits 1; as committed it exits 0 (21 inline cases, 22 sub-script suites in sync). shellcheck clean. The new CI step exercises the gate on this very PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Test coverage
- [ ] Documentation
- [x] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass — no C# changes; pre-commit hook green
- [ ] E2E tests pass — N/A, no generator behavior change
- [x] Lint clean — no C# changes
- [x] `bash -n` + shellcheck clean; validator red/green verified with synthetic drift; new CI step runs on this PR

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

## Affected Requirements

None — test/CI tooling only, no REQ-XXX/FR-XXX impact.
