### PR TITLE
fix: narrow exception catch in XmlLoadFileWriter

### DIFF
--- a/src/LoadFiles/XmlLoadFileWriter.cs
+++ b/src/LoadFiles/XmlLoadFileWriter.cs
@@ -34,9 +34,9 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
         };
 
         var writer = System.Xml.XmlWriter.Create(stream, settings);
-        await using (writer.ConfigureAwait(false))
+        try
         {
-            try
+            await using (writer.ConfigureAwait(false))
             {
                 // Match the original XDeclaration("1.0", "UTF-8", "yes")
                 await writer.WriteStartDocumentAsync(standalone: true);
@@ -125,16 +125,15 @@ internal sealed class XmlLoadFileWriter : ILoadFileWriter
 
                 await writer.FlushAsync().ConfigureAwait(false);
             }
-            catch (Exception ex)
-            {
-                if (ex is OperationCanceledException)
-                {
-                    throw;
-                }
-
-                throw new InvalidOperationException(
-                    $"Failed to write XML load file: {ex.Message}", ex);
-            }
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            // Expected failures (I/O and XmlWriter state errors, including
+            // ObjectDisposedException, from writes or final disposal) get load-file
+            // context. Anything else — including OperationCanceledException —
+            // propagates unwrapped.
+            throw new InvalidOperationException(
+                $"Failed to write XML load file: {ex.Message}", ex);
         }
     }
 

--- a/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
+++ b/src/Zipper.Tests/LoadFiles/XmlLoadFileWriterTests.cs
@@ -264,6 +264,98 @@ public class XmlLoadFileWriterTests : TempDirectoryTestBase
     }
 
     [Fact]
+    public async Task WriteAsync_WhenStreamThrowsIOException_WrapsWithContext()
+    {
+        var request = this.CreateTestRequest();
+        var fileData = this.CreateTestFileData();
+        var writer = new XmlLoadFileWriter();
+        using var stream = new ThrowingStream(new IOException("simulated disk failure"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            writer.WriteAsync(stream, request, fileData));
+
+        Assert.Contains("Failed to write XML load file", ex.Message, StringComparison.Ordinal);
+        Assert.IsType<IOException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenUnexpectedException_PropagatesUnwrapped()
+    {
+        var request = this.CreateTestRequest();
+        var fileData = this.CreateTestFileData();
+        var writer = new XmlLoadFileWriter();
+        using var stream = new ThrowingStream(new FormatException("simulated unexpected failure"));
+
+        var ex = await Assert.ThrowsAsync<FormatException>(() =>
+            writer.WriteAsync(stream, request, fileData));
+
+        Assert.Equal("simulated unexpected failure", ex.Message);
+    }
+
+    private sealed class ThrowingStream : Stream
+    {
+        private readonly Exception exception;
+
+        public ThrowingStream(Exception exception)
+        {
+            this.exception = exception;
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => 0;
+
+        public override long Position
+        {
+            get => 0;
+            set { }
+        }
+
+        public override void Flush()
+        {
+            throw this.exception;
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            throw this.exception;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return 0;
+        }
+
+        public override void SetLength(long value)
+        {
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw this.exception;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            throw this.exception;
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            throw this.exception;
+        }
+    }
+
+    [Fact]
     public async Task XmlLoadFileWriter_WithFamilies_ProducesParentChildDocumentsAndRelationships()
     {
         var request = new FileGenerationRequest


### PR DESCRIPTION
## Release Notes
XML Load File writing now wraps only expected I/O and writer-state errors with context; cancellation and unexpected exceptions propagate unwrapped with their original stack traces.

## Description

Fixes #621 (audit R3-008). `XmlLoadFileWriter.WriteAsync` caught `Exception` broadly and wrapped everything except `OperationCanceledException` in `InvalidOperationException`, masking unexpected errors. The catch is now filtered to `IOException` and `InvalidOperationException` (which covers `ObjectDisposedException`); cancellation and anything unexpected (e.g. `ArgumentException` from invalid XML characters in source data) propagate unwrapped, per the audit recommendation.

TDD surfaced a second, subtler bug the catch-all was hiding: the try block sat **inside** the `await using (writer)`, so a permanently broken stream made `XmlWriter.DisposeAsync` rethrow the raw exception during unwind, silently replacing the contextual wrapper produced in the catch. The try is now hoisted outside the `await using`, so disposal-time flush failures also get load-file context.

New tests (red before the fix): `WriteAsync_WhenStreamThrowsIOException_WrapsWithContext` asserts the `InvalidOperationException` wrapper with the `IOException` inner exception; `WriteAsync_WhenUnexpectedException_PropagatesUnwrapped` asserts an unexpected exception type escapes unwrapped with its original message. The existing cancellation test stays green. Adversarial review found no significant problems (verified the filter set, caller impact, and hoist semantics independently); its two minor suggestions (test naming convention, stronger unwrapped assertion) are included.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test coverage
- [ ] Documentation
- [ ] CI/Build
- [ ] Chore / Maintenance
- [ ] Dependency update

## Testing Done

- [x] Unit tests pass — 1578/1578 (2 new)
- [x] E2E tests pass — goldens byte-parity 20/20 (includes EDRM-XML scenarios)
- [x] Lint clean — `dotnet format --verify-no-changes src/` green

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required), **OR** the deviation is human-approved and `docs/architecture.md` is updated in this PR.

Error-handling change only; the EDRM-XML carve-out shape is untouched.

## Affected Requirements

None — exception-surface hardening only; no REQ-XXX/FR-XXX behavior change on the happy path (goldens byte-identical).
