### PR TITLE
refactor: extract built-in column profiles to embedded JSON resources (#622)

### DIFF
--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -1,7 +1,11 @@
+using System.Text.Json;
+
 namespace Zipper.Profiles;
 
 /// <summary>
 /// Provides built-in column profiles for common e-discovery workflows.
+/// Profile data lives in embedded JSON resources under Profiles/BuiltIns/ and is
+/// deserialized with the same JSON format and serializer options as custom JSON profiles.
 /// </summary>
 public static class BuiltInProfiles
 {
@@ -10,157 +14,50 @@ public static class BuiltInProfiles
     /// </summary>
     public static readonly string[] ProfileNames = { "minimal", "standard", "litigation", "full" };
 
+    private static readonly string[] ResourceNames =
+    {
+        "minimal", "standard", "litigation", "full", "legacywithmetadata", "legacyeml", "legacywithcollectionmetadata",
+    };
+
+    private static readonly Lazy<IReadOnlyDictionary<string, ColumnProfile>> Profiles = new(LoadProfiles);
+
     /// <summary>
     /// Gets the minimal profile (5 columns).
     /// </summary>
-    public static ColumnProfile Minimal { get; } = new()
-    {
-        Name = "minimal",
-        Description = "Basic fields for minimal load file generation",
-        Version = "1.0",
-        FieldNamingConvention = "UPPERCASE",
-        Settings = new ProfileSettings
-        {
-            EmptyValuePercentage = 0,
-            DateFormat = "yyyy-MM-dd",
-        },
-        DataSources = new Dictionary<string, DataSourceConfig>
-(StringComparer.Ordinal)
-        {
-            ["custodians"] = new DataSourceConfig { Count = 10, Distribution = "pareto", Prefix = "Custodian_" },
-        },
-        Columns = new List<ColumnDefinition>
-        {
-            new() { Name = "DOCID", Type = "identifier", Required = true },
-            new() { Name = "FILEPATH", Type = "text", Required = true },
-            new() { Name = "CUSTODIAN", Type = "text", DataSource = "custodians", EmptyPercentage = 0 },
-            new() { Name = "DATECREATED", Type = "date", DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" } },
-            new() { Name = "FILESIZE", Type = "number", Range = new RangeConfig { Min = 1024, Max = 10485760 }, Distribution = "exponential" },
-        },
-    };
+    public static ColumnProfile Minimal => GetShared("minimal");
 
     /// <summary>
     /// Gets the standard profile (24 columns).
     /// </summary>
-    public static ColumnProfile Standard { get; } = new()
-    {
-        Name = "standard",
-        Description = "Common e-discovery fields for standard workflows",
-        Version = "1.0",
-        FieldNamingConvention = "UPPERCASE",
-        Settings = new ProfileSettings
-        {
-            EmptyValuePercentage = 10,
-            MultiValueDelimiter = ";",
-            DateFormat = "yyyy-MM-dd",
-        },
-        DataSources = new Dictionary<string, DataSourceConfig>
-(StringComparer.Ordinal)
-        {
-            ["custodians"] = new DataSourceConfig { Count = 25, Distribution = "pareto", Prefix = "Custodian_" },
-            ["authors"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Author_" },
-            ["departments"] = new DataSourceConfig { Values = new List<string> { "Legal", "Finance", "HR", "Engineering", "Sales", "Marketing", "Operations", "Executive" } },
-            ["docTypes"] = new DataSourceConfig { Values = new List<string> { "Email", "Document", "Spreadsheet", "Presentation", "Image", "PDF", "Other" } },
-        },
-        Columns = new List<ColumnDefinition>
-        {
-            // Identifiers
-            new() { Name = "DOCID", Type = "identifier", Required = true },
-            new() { Name = "BEGBATES", Type = "text", Required = true },
-            new() { Name = "ENDBATES", Type = "text", Required = true },
-            new() { Name = "CONTROLNUMBER", Type = "text", Required = true },
-
-            // File info
-            new() { Name = "FILEPATH", Type = "text", Required = true },
-            new() { Name = "TEXTPATH", Type = "text", EmptyPercentage = 5 },
-            new() { Name = "NATIVEPATH", Type = "text", EmptyPercentage = 0 },
-            new() { Name = "FILENAME", Type = "text", Required = true },
-            new() { Name = "FILEEXT", Type = "text", Required = true },
-            new() { Name = "FILESIZE", Type = "number", Range = new RangeConfig { Min = 1024, Max = 104857600 }, Distribution = "exponential" },
-
-            // Dates
-            new() { Name = "DATECREATED", Type = "date", DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" } },
-            new() { Name = "DATEMODIFIED", Type = "date", DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" } },
-            new() { Name = "DATESENT", Type = "datetime", DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" }, EmptyPercentage = 30 },
-            new() { Name = "DATERECEIVED", Type = "datetime", DateRange = new DateRangeConfig { Min = "2020-01-01", Max = "2024-12-31" }, EmptyPercentage = 30 },
-
-            // People
-            new() { Name = "CUSTODIAN", Type = "text", DataSource = "custodians", EmptyPercentage = 0 },
-            new() { Name = "AUTHOR", Type = "text", DataSource = "authors", EmptyPercentage = 5 },
-            new() { Name = "EMAILFROM", Type = "email", EmptyPercentage = 30 },
-            new() { Name = "EMAILTO", Type = "email", MultiValue = true, MultiValueCount = new RangeConfig { Min = 1, Max = 5 }, EmptyPercentage = 30 },
-            new() { Name = "EMAILCC", Type = "email", MultiValue = true, MultiValueCount = new RangeConfig { Min = 0, Max = 10 }, EmptyPercentage = 50 },
-
-            // Classification
-            new() { Name = "DOCTYPE", Type = "coded", DataSource = "docTypes" },
-            new() { Name = "DEPARTMENT", Type = "coded", DataSource = "departments", EmptyPercentage = 20 },
-            new() { Name = "RESPONSIVE", Type = "boolean", TruePercentage = 60, Format = "YN" },
-            new() { Name = "PRIVILEGED", Type = "boolean", TruePercentage = 10, Format = "YN" },
-            new() { Name = "CONFIDENTIAL", Type = "boolean", TruePercentage = 25, Format = "YN" },
-        },
-    };
+    public static ColumnProfile Standard => GetShared("standard");
 
     /// <summary>
     /// Gets the litigation profile (48 columns).
     /// </summary>
-    public static ColumnProfile Litigation { get; } = new()
-    {
-        Name = "litigation",
-        Description = "Full litigation support with comprehensive metadata",
-        Version = "1.0",
-        FieldNamingConvention = "UPPERCASE",
-        Settings = new ProfileSettings
-        {
-            EmptyValuePercentage = 15,
-            MultiValueDelimiter = ";",
-            DateFormat = "yyyy-MM-dd",
-        },
-        DataSources = new Dictionary<string, DataSourceConfig>
-(StringComparer.Ordinal)
-        {
-            ["custodians"] = new DataSourceConfig { Count = 50, Distribution = "pareto", Prefix = "Custodian_" },
-            ["authors"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Author_" },
-            ["departments"] = new DataSourceConfig { Values = new List<string> { "Legal", "Finance", "HR", "Engineering", "Sales", "Marketing", "Operations", "Executive", "IT", "Compliance" } },
-            ["docTypes"] = new DataSourceConfig { Values = new List<string> { "Email", "Document", "Spreadsheet", "Presentation", "Image", "PDF", "Contract", "Invoice", "Memo", "Report" } },
-            ["privilegeTypes"] = new DataSourceConfig { Values = new List<string> { "Attorney-Client", "Work Product", "Not Privileged", "Needs Review" }, Weights = new List<int> { 5, 5, 80, 10 } },
-            ["responsiveness"] = new DataSourceConfig { Values = new List<string> { "Responsive", "Not Responsive", "Needs Review", "Privileged" }, Weights = new List<int> { 40, 35, 15, 10 } },
-            ["confidentiality"] = new DataSourceConfig { Values = new List<string> { "Public", "Internal", "Confidential", "Highly Confidential" }, Weights = new List<int> { 20, 50, 25, 5 } },
-            ["languages"] = new DataSourceConfig { Values = new List<string> { "English", "Spanish", "French", "German", "Chinese", "Japanese" }, Weights = new List<int> { 85, 5, 3, 2, 3, 2 } },
-        },
-        Columns = CreateLitigationColumns(),
-    };
+    public static ColumnProfile Litigation => GetShared("litigation");
 
     /// <summary>
     /// Gets the full profile (138 columns).
     /// </summary>
-    public static ColumnProfile Full { get; } = new()
-    {
-        Name = "full",
-        Description = "Maximum field coverage for comprehensive data generation",
-        Version = "1.0",
-        FieldNamingConvention = "UPPERCASE",
-        Settings = new ProfileSettings
-        {
-            EmptyValuePercentage = 20,
-            MultiValueDelimiter = ";",
-            DateFormat = "yyyy-MM-dd",
-        },
-        DataSources = new Dictionary<string, DataSourceConfig>
-(StringComparer.Ordinal)
-        {
-            ["custodians"] = new DataSourceConfig { Count = 100, Distribution = "pareto", Prefix = "Custodian_" },
-            ["authors"] = new DataSourceConfig { Count = 200, Distribution = "pareto", Prefix = "Author_" },
-            ["departments"] = new DataSourceConfig { Values = new List<string> { "Legal", "Finance", "HR", "Engineering", "Sales", "Marketing", "Operations", "Executive", "IT", "Compliance", "Research", "Support" } },
-            ["docTypes"] = new DataSourceConfig { Values = new List<string> { "Email", "Document", "Spreadsheet", "Presentation", "Image", "PDF", "Contract", "Invoice", "Memo", "Report", "Letter", "Fax", "Note" } },
-            ["privilegeTypes"] = new DataSourceConfig { Values = new List<string> { "Attorney-Client", "Work Product", "Not Privileged", "Needs Review" }, Weights = new List<int> { 5, 5, 80, 10 } },
-            ["responsiveness"] = new DataSourceConfig { Values = new List<string> { "Responsive", "Not Responsive", "Needs Review", "Privileged" }, Weights = new List<int> { 40, 35, 15, 10 } },
-            ["confidentiality"] = new DataSourceConfig { Values = new List<string> { "Public", "Internal", "Confidential", "Highly Confidential" }, Weights = new List<int> { 20, 50, 25, 5 } },
-            ["tags"] = new DataSourceConfig { Values = new List<string> { "Key Document", "Hot Document", "Duplicate", "Near-Duplicate", "Foreign Language", "Privileged Review", "Redaction Required" } },
-            ["issues"] = new DataSourceConfig { Values = new List<string> { "Issue 1", "Issue 2", "Issue 3", "Issue 4", "Issue 5", "Issue 6", "Issue 7", "Issue 8" } },
-            ["languages"] = new DataSourceConfig { Values = new List<string> { "English", "Spanish", "French", "German", "Chinese", "Japanese", "Korean", "Portuguese", "Italian", "Russian" }, Weights = new List<int> { 80, 5, 3, 2, 2, 2, 1, 2, 2, 1 } },
-        },
-        Columns = CreateFullColumns(),
-    };
+    public static ColumnProfile Full => GetShared("full");
+
+    /// <summary>
+    /// Gets the legacy metadata pseudo-profile activated by --with-metadata on non-EML files.
+    /// Four fixed columns: CUSTODIAN (folder-based), DATESENT, AUTHOR, FILESIZE.
+    /// </summary>
+    public static ColumnProfile LegacyWithMetadata => GetShared("legacywithmetadata");
+
+    /// <summary>
+    /// Gets the legacy EML pseudo-profile for EML files.
+    /// Includes metadata columns plus five email columns read from fileData.Email.
+    /// </summary>
+    public static ColumnProfile LegacyEml => GetShared("legacyeml");
+
+    /// <summary>
+    /// Gets the collection metadata profile activated by --with-collection-metadata.
+    /// Five columns: DATA_SOURCE, COLLECTION_DATE, DENISTED, DEDUPE_GROUP_ID, PROCESSING_STATUS.
+    /// </summary>
+    public static ColumnProfile LegacyWithCollectionMetadata => GetShared("legacywithcollectionmetadata");
 
     /// <summary>
     /// Gets a built-in profile by name.
@@ -168,273 +65,10 @@ public static class BuiltInProfiles
     public static ColumnProfile? GetProfile(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        var profile = name.ToLowerInvariant() switch
-        {
-            "minimal" => Minimal,
-            "standard" => Standard,
-            "litigation" => Litigation,
-            "full" => Full,
-            "legacywithmetadata" => LegacyWithMetadata,
-            "legacyeml" => LegacyEml,
-            _ => null,
-        };
-        return profile?.Clone();
-    }
-
-    /// <summary>
-    /// Gets the legacy metadata pseudo-profile activated by --with-metadata on non-EML files.
-    /// Four fixed columns: CUSTODIAN (folder-based), DATESENT, AUTHOR, FILESIZE.
-    /// </summary>
-    public static ColumnProfile LegacyWithMetadata { get; } = new()
-    {
-        Name = "legacyWithMetadata",
-        Description = "Legacy --with-metadata pseudo-profile (non-EML)",
-        Version = "1.0",
-        FieldNamingConvention = null,
-        Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
-        Columns = new List<ColumnDefinition>
-        {
-            new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
-            new() { Name = "DATESENT", Type = "legacydatesent", Required = true, EmptyPercentage = 0 },
-            new() { Name = "AUTHOR", Type = "legacyauthor", Required = true, EmptyPercentage = 0 },
-            new() { Name = "FILESIZE", Type = "filedatasize", Required = true, EmptyPercentage = 0 },
-        },
-    };
-
-    /// <summary>
-    /// Gets the legacy EML pseudo-profile for EML files.
-    /// Includes metadata columns plus five email columns read from fileData.Email.
-    /// </summary>
-    public static ColumnProfile LegacyEml { get; } = new()
-    {
-        Name = "legacyEml",
-        Description = "Legacy EML pseudo-profile with metadata + email columns",
-        Version = "1.0",
-        FieldNamingConvention = null,
-        Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal),
-        Columns = new List<ColumnDefinition>
-        {
-            new() { Name = "CUSTODIAN", Type = "foldercustodian", Required = true, EmptyPercentage = 0 },
-            new() { Name = "DATESENT", Type = "legacydatesent", Required = true, EmptyPercentage = 0 },
-            new() { Name = "AUTHOR", Type = "legacyauthor", Required = true, EmptyPercentage = 0 },
-            new() { Name = "FILESIZE", Type = "filedatasize", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILTO", Type = "emailto", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILFROM", Type = "emailfrom", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILCC", Type = "emailcc", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILSUBJECT", Type = "emailsubject", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILSENTDATE", Type = "emailsentdate", Required = true, EmptyPercentage = 0 },
-            new() { Name = "EMAILATTACHMENT", Type = "emailattachment", Required = true, EmptyPercentage = 0 },
-        },
-    };
-
-    /// <summary>
-    /// Gets the collection metadata profile activated by --with-collection-metadata.
-    /// Five columns: DATA_SOURCE, COLLECTION_DATE, DENISTED, DEDUPE_GROUP_ID, PROCESSING_STATUS.
-    /// </summary>
-    public static ColumnProfile LegacyWithCollectionMetadata { get; } = new()
-    {
-        Name = "legacyWithCollectionMetadata",
-        Description = "Legacy --with-collection-metadata pseudo-profile",
-        Version = "1.0",
-        FieldNamingConvention = null,
-        Settings = new ProfileSettings { EmptyValuePercentage = 0 },
-        DataSources = new Dictionary<string, DataSourceConfig>(StringComparer.Ordinal)
-        {
-            ["datasource"] = new DataSourceConfig
-            {
-                Values = ["Email Server", "Network Share", "Cloud Storage", "Mobile Device", "Laptop", "Desktop", "Server", "External Media"],
-                Weights = [25, 20, 15, 10, 10, 8, 7, 5],
-            },
-            ["processingstatus"] = new DataSourceConfig
-            {
-                Values = ["Processed", "Pending Review", "Approved", "Privileged", "Redacted", "Produced"],
-                Weights = [40, 20, 15, 10, 10, 5],
-            },
-        },
-        Columns = new List<ColumnDefinition>
-        {
-            new() { Name = "DATA_SOURCE", Type = "coded", DataSource = "datasource", Required = true, EmptyPercentage = 0 },
-            new() { Name = "COLLECTION_DATE", Type = "date", Required = true, EmptyPercentage = 0 },
-            new() { Name = "DENISTED", Type = "boolean", Required = true, EmptyPercentage = 0 },
-            new() { Name = "DEDUPE_GROUP_ID", Type = "identifier", Required = true, EmptyPercentage = 0 },
-            new() { Name = "PROCESSING_STATUS", Type = "coded", DataSource = "processingstatus", Required = true, EmptyPercentage = 0 },
-        },
-    };
-
-    private static List<ColumnDefinition> CreateLitigationColumns()
-    {
-        var columns = new List<ColumnDefinition>
-        {
-            // Core identifiers
-            new() { Name = "DOCID", Type = "identifier", Required = true },
-            new() { Name = "BEGBATES", Type = "text", Required = true },
-            new() { Name = "ENDBATES", Type = "text", Required = true },
-            new() { Name = "CONTROLNUMBER", Type = "text", Required = true },
-            new() { Name = "BEGATTACH", Type = "text", EmptyPercentage = 70 },
-            new() { Name = "ENDATTACH", Type = "text", EmptyPercentage = 70 },
-            new() { Name = "PARENTDOCID", Type = "text", EmptyPercentage = 70 },
-            new() { Name = "FAMILYID", Type = "text", EmptyPercentage = 50 },
-
-            // File info
-            new() { Name = "FILEPATH", Type = "text", Required = true },
-            new() { Name = "TEXTPATH", Type = "text", EmptyPercentage = 5 },
-            new() { Name = "NATIVEPATH", Type = "text", EmptyPercentage = 0 },
-            new() { Name = "FILENAME", Type = "text", Required = true },
-            new() { Name = "FILEEXT", Type = "text", Required = true },
-            new() { Name = "FILESIZE", Type = "number", Range = new RangeConfig { Min = 1024, Max = 104857600 }, Distribution = "exponential" },
-            new() { Name = "PAGECOUNT", Type = "number", Range = new RangeConfig { Min = 1, Max = 500 }, Distribution = "exponential" },
-            new() { Name = "WORDCOUNT", Type = "number", Range = new RangeConfig { Min = 0, Max = 50000 }, Distribution = "exponential" },
-            new() { Name = "CHARCOUNT", Type = "number", Range = new RangeConfig { Min = 0, Max = 250000 }, Distribution = "exponential" },
-
-            // Dates
-            new() { Name = "DATECREATED", Type = "date", DateRange = new DateRangeConfig { Min = "2018-01-01", Max = "2024-12-31" } },
-            new() { Name = "DATEMODIFIED", Type = "date", DateRange = new DateRangeConfig { Min = "2018-01-01", Max = "2024-12-31" } },
-            new() { Name = "DATESENT", Type = "datetime", DateRange = new DateRangeConfig { Min = "2018-01-01", Max = "2024-12-31" }, EmptyPercentage = 30 },
-            new() { Name = "DATERECEIVED", Type = "datetime", DateRange = new DateRangeConfig { Min = "2018-01-01", Max = "2024-12-31" }, EmptyPercentage = 30 },
-            new() { Name = "DATEPRODUCED", Type = "date", DateRange = new DateRangeConfig { Min = "2024-01-01", Max = "2024-12-31" }, EmptyPercentage = 50 },
-
-            // People
-            new() { Name = "CUSTODIAN", Type = "text", DataSource = "custodians", EmptyPercentage = 0 },
-            new() { Name = "AUTHOR", Type = "text", DataSource = "authors", EmptyPercentage = 5 },
-            new() { Name = "EMAILFROM", Type = "email", EmptyPercentage = 30 },
-            new() { Name = "EMAILTO", Type = "email", MultiValue = true, MultiValueCount = new RangeConfig { Min = 1, Max = 10 }, EmptyPercentage = 30 },
-            new() { Name = "EMAILCC", Type = "email", MultiValue = true, MultiValueCount = new RangeConfig { Min = 0, Max = 15 }, EmptyPercentage = 50 },
-            new() { Name = "EMAILBCC", Type = "email", MultiValue = true, MultiValueCount = new RangeConfig { Min = 0, Max = 3 }, EmptyPercentage = 90 },
-            new() { Name = "EMAILSUBJECT", Type = "text", Generator = "emailsubject", EmptyPercentage = 30 },
-            new() { Name = "CONVERSATIONID", Type = "text", EmptyPercentage = 50 },
-            new() { Name = "MESSAGEID", Type = "text", EmptyPercentage = 50 },
-
-            // Classification
-            new() { Name = "DOCTYPE", Type = "coded", DataSource = "docTypes" },
-            new() { Name = "DEPARTMENT", Type = "coded", DataSource = "departments", EmptyPercentage = 20 },
-            new() { Name = "PRIVILEGE", Type = "coded", DataSource = "privilegeTypes" },
-            new() { Name = "RESPONSIVE", Type = "coded", DataSource = "responsiveness" },
-            new() { Name = "CONFIDENTIALITY", Type = "coded", DataSource = "confidentiality" },
-            new() { Name = "LANGUAGE", Type = "coded", DataSource = "languages" },
-
-            // Boolean flags
-            new() { Name = "ISRESPONSIVE", Type = "boolean", TruePercentage = 60, Format = "YN" },
-            new() { Name = "ISPRIVILEGED", Type = "boolean", TruePercentage = 10, Format = "YN" },
-            new() { Name = "ISCONFIDENTIAL", Type = "boolean", TruePercentage = 25, Format = "YN" },
-            new() { Name = "HASATTACHMENTS", Type = "boolean", TruePercentage = 30, Format = "YN" },
-            new() { Name = "ISNATIVE", Type = "boolean", TruePercentage = 70, Format = "YN" },
-            new() { Name = "NEEDSREDACTION", Type = "boolean", TruePercentage = 15, Format = "YN" },
-
-            // Hashes
-            new() { Name = "MD5HASH", Type = "text", Generator = "md5Hash" },
-            new() { Name = "SHA1HASH", Type = "text", Generator = "sha1Hash" },
-            new() { Name = "SHA256HASH", Type = "text", Generator = "sha256Hash" },
-
-            // Notes and text
-            new() { Name = "REVIEWNOTES", Type = "longtext", Generator = "reviewNote", EmptyPercentage = 80 },
-            new() { Name = "REDACTIONREASON", Type = "text", EmptyPercentage = 90 },
-        };
-
-        return columns;
-    }
-
-    private static List<ColumnDefinition> CreateFullColumns()
-    {
-        // Start with litigation columns
-        var columns = CreateLitigationColumns();
-
-        // Add many more columns for the full profile
-        var extraColumns = new List<ColumnDefinition>();
-
-        // Additional metadata fields
-        for (int i = 1; i <= 20; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"CUSTOMTEXT{i:D2}",
-                Type = "text",
-                EmptyPercentage = 50 + (i * 2),
-            });
-        }
-
-        for (int i = 1; i <= 15; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"CUSTOMDATE{i:D2}",
-                Type = "date",
-                DateRange = new DateRangeConfig { Min = "2015-01-01", Max = "2024-12-31" },
-                EmptyPercentage = 40 + (i * 3),
-            });
-        }
-
-        for (int i = 1; i <= 15; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"CUSTOMNUMBER{i:D2}",
-                Type = "number",
-                Range = new RangeConfig { Min = 0, Max = 10000 },
-                EmptyPercentage = 30 + (i * 3),
-            });
-        }
-
-        for (int i = 1; i <= 10; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"CUSTOMBOOL{i:D2}",
-                Type = "boolean",
-                TruePercentage = 30 + (i * 4),
-                Format = "YN",
-            });
-        }
-
-        // Issue tags (multi-value)
-        for (int i = 1; i <= 5; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"ISSUETAG{i:D2}",
-                Type = "coded",
-                DataSource = "issues",
-                MultiValue = true,
-                MultiValueCount = new RangeConfig { Min = 0, Max = 3 },
-                EmptyPercentage = 60,
-            });
-        }
-
-        // Long text fields
-        for (int i = 1; i <= 10; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"NOTES{i:D2}",
-                Type = "longtext",
-                Generator = "loremParagraphs",
-                GeneratorParams = new Dictionary<string, object>(StringComparer.Ordinal) { ["min"] = 1, ["max"] = 3 },
-                EmptyPercentage = 70 + (i * 2),
-            });
-        }
-
-        // Additional identifiers
-        extraColumns.Add(new ColumnDefinition { Name = "PRODUCTIONSTATUS", Type = "coded", DataSource = "responsiveness", EmptyPercentage = 30 });
-        extraColumns.Add(new ColumnDefinition { Name = "REVIEWSTATUS", Type = "coded", DataSource = "responsiveness", EmptyPercentage = 20 });
-        extraColumns.Add(new ColumnDefinition { Name = "QCSTATUS", Type = "coded", DataSource = "responsiveness", EmptyPercentage = 60 });
-        extraColumns.Add(new ColumnDefinition { Name = "ENCODING", Type = "text", Generator = "encoding", EmptyPercentage = 10 });
-        extraColumns.Add(new ColumnDefinition { Name = "TIMEZONE", Type = "text", Generator = "timezone", EmptyPercentage = 20 });
-
-        // More classification
-        for (int i = 1; i <= 10; i++)
-        {
-            extraColumns.Add(new ColumnDefinition
-            {
-                Name = $"TAG{i:D2}",
-                Type = "coded",
-                DataSource = "tags",
-                EmptyPercentage = 70,
-            });
-        }
-
-        columns.AddRange(extraColumns);
-        return columns;
+        var key = name.ToLowerInvariant();
+        return key is "minimal" or "standard" or "litigation" or "full" or "legacywithmetadata" or "legacyeml"
+            ? Profiles.Value[key].Clone()
+            : null;
     }
 
     /// <summary>
@@ -472,5 +106,70 @@ public static class BuiltInProfiles
         }
 
         return merged;
+    }
+
+    private static ColumnProfile GetShared(string name) => Profiles.Value[name];
+
+    private static IReadOnlyDictionary<string, ColumnProfile> LoadProfiles()
+    {
+        var assembly = typeof(BuiltInProfiles).Assembly;
+        var profiles = new Dictionary<string, ColumnProfile>(StringComparer.Ordinal);
+        foreach (var name in ResourceNames)
+        {
+            var resourceName = $"Zipper.Profiles.BuiltIns.{name}.json";
+            using var stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded column profile resource '{resourceName}' is missing.");
+            ColumnProfile? profile;
+            try
+            {
+                profile = JsonSerializer.Deserialize<ColumnProfile>(stream, ColumnProfileLoader.ProfileSerializerOptions);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"Embedded column profile resource '{resourceName}' failed to parse: {ex.Message}", ex);
+            }
+
+            if (profile is null)
+            {
+                throw new InvalidOperationException($"Embedded column profile resource '{resourceName}' failed to parse.");
+            }
+
+            NormalizeGeneratorParams(profile);
+            profiles[name] = profile;
+        }
+
+        return profiles;
+    }
+
+    /// <summary>
+    /// Converts JsonElement generator parameter values produced by deserialization back to the
+    /// primitives a C# object literal would hold (int/double/bool/string), so generator consumers
+    /// see identical types for built-in and in-code profiles.
+    /// </summary>
+    private static void NormalizeGeneratorParams(ColumnProfile profile)
+    {
+        foreach (var column in profile.Columns)
+        {
+            if (column.GeneratorParams is null)
+            {
+                continue;
+            }
+
+            foreach (var key in column.GeneratorParams.Keys.ToList())
+            {
+                if (column.GeneratorParams[key] is JsonElement element)
+                {
+                    column.GeneratorParams[key] = element.ValueKind switch
+                    {
+                        JsonValueKind.Number when element.TryGetInt32(out var intValue) => intValue,
+                        JsonValueKind.Number => element.GetDouble(),
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        JsonValueKind.String => element.GetString()!,
+                        _ => element,
+                    };
+                }
+            }
+        }
     }
 }

--- a/src/Profiles/BuiltIns/full.json
+++ b/src/Profiles/BuiltIns/full.json
@@ -1,0 +1,1410 @@
+{
+  "name": "full",
+  "description": "Maximum field coverage for comprehensive data generation",
+  "version": "1.0",
+  "fieldNamingConvention": "UPPERCASE",
+  "settings": {
+    "emptyValuePercentage": 20,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {
+    "custodians": {
+      "count": 100,
+      "distribution": "pareto",
+      "prefix": "Custodian_"
+    },
+    "authors": {
+      "count": 200,
+      "distribution": "pareto",
+      "prefix": "Author_"
+    },
+    "departments": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Legal",
+        "Finance",
+        "HR",
+        "Engineering",
+        "Sales",
+        "Marketing",
+        "Operations",
+        "Executive",
+        "IT",
+        "Compliance",
+        "Research",
+        "Support"
+      ]
+    },
+    "docTypes": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Email",
+        "Document",
+        "Spreadsheet",
+        "Presentation",
+        "Image",
+        "PDF",
+        "Contract",
+        "Invoice",
+        "Memo",
+        "Report",
+        "Letter",
+        "Fax",
+        "Note"
+      ]
+    },
+    "privilegeTypes": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Attorney-Client",
+        "Work Product",
+        "Not Privileged",
+        "Needs Review"
+      ],
+      "weights": [
+        5,
+        5,
+        80,
+        10
+      ]
+    },
+    "responsiveness": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Responsive",
+        "Not Responsive",
+        "Needs Review",
+        "Privileged"
+      ],
+      "weights": [
+        40,
+        35,
+        15,
+        10
+      ]
+    },
+    "confidentiality": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Public",
+        "Internal",
+        "Confidential",
+        "Highly Confidential"
+      ],
+      "weights": [
+        20,
+        50,
+        25,
+        5
+      ]
+    },
+    "tags": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Key Document",
+        "Hot Document",
+        "Duplicate",
+        "Near-Duplicate",
+        "Foreign Language",
+        "Privileged Review",
+        "Redaction Required"
+      ]
+    },
+    "issues": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Issue 1",
+        "Issue 2",
+        "Issue 3",
+        "Issue 4",
+        "Issue 5",
+        "Issue 6",
+        "Issue 7",
+        "Issue 8"
+      ]
+    },
+    "languages": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "English",
+        "Spanish",
+        "French",
+        "German",
+        "Chinese",
+        "Japanese",
+        "Korean",
+        "Portuguese",
+        "Italian",
+        "Russian"
+      ],
+      "weights": [
+        80,
+        5,
+        3,
+        2,
+        2,
+        2,
+        1,
+        2,
+        2,
+        1
+      ]
+    }
+  },
+  "columns": [
+    {
+      "name": "DOCID",
+      "type": "identifier",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "BEGBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "ENDBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "CONTROLNUMBER",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "BEGATTACH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "ENDATTACH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "PARENTDOCID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "FAMILYID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "FILEPATH",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "TEXTPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false
+    },
+    {
+      "name": "NATIVEPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "FILENAME",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILEEXT",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILESIZE",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1024,
+        "max": 104857600
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "PAGECOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1,
+        "max": 500
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "WORDCOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 50000
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "CHARCOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 250000
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "DATECREATED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATEMODIFIED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATESENT",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATERECEIVED",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATEPRODUCED",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2024-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTODIAN",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "custodians"
+    },
+    {
+      "name": "AUTHOR",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false,
+      "dataSource": "authors"
+    },
+    {
+      "name": "EMAILFROM",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILTO",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 1,
+        "max": 10
+      }
+    },
+    {
+      "name": "EMAILCC",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 15
+      }
+    },
+    {
+      "name": "EMAILBCC",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      }
+    },
+    {
+      "name": "EMAILSUBJECT",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "generator": "emailsubject"
+    },
+    {
+      "name": "CONVERSATIONID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "MESSAGEID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "DOCTYPE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "docTypes"
+    },
+    {
+      "name": "DEPARTMENT",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 20,
+      "multiValue": false,
+      "dataSource": "departments"
+    },
+    {
+      "name": "PRIVILEGE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "privilegeTypes"
+    },
+    {
+      "name": "RESPONSIVE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "responsiveness"
+    },
+    {
+      "name": "CONFIDENTIALITY",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "confidentiality"
+    },
+    {
+      "name": "LANGUAGE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "languages"
+    },
+    {
+      "name": "ISRESPONSIVE",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 60
+    },
+    {
+      "name": "ISPRIVILEGED",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 10
+    },
+    {
+      "name": "ISCONFIDENTIAL",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 25
+    },
+    {
+      "name": "HASATTACHMENTS",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 30
+    },
+    {
+      "name": "ISNATIVE",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 70
+    },
+    {
+      "name": "NEEDSREDACTION",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 15
+    },
+    {
+      "name": "MD5HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "md5Hash"
+    },
+    {
+      "name": "SHA1HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "sha1Hash"
+    },
+    {
+      "name": "SHA256HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "sha256Hash"
+    },
+    {
+      "name": "REVIEWNOTES",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 80,
+      "multiValue": false,
+      "generator": "reviewNote"
+    },
+    {
+      "name": "REDACTIONREASON",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT01",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 52,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT02",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 54,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT03",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 56,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT04",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 58,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT05",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT06",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 62,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT07",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 64,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT08",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 66,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT09",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 68,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT10",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT11",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 72,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT12",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 74,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT13",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 76,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT14",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 78,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT15",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 80,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT16",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 82,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT17",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 84,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT18",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 86,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT19",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 88,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMTEXT20",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTOMDATE01",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 43,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE02",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 46,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE03",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 49,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE04",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 52,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE05",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 55,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE06",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 58,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE07",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 61,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE08",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 64,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE09",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 67,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE10",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE11",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 73,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE12",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 76,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE13",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 79,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE14",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 82,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMDATE15",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 85,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2015-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER01",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 33,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER02",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 36,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER03",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 39,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER04",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 42,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER05",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 45,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER06",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 48,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER07",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 51,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER08",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 54,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER09",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 57,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER10",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER11",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 63,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER12",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 66,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER13",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 69,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER14",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 72,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMNUMBER15",
+      "type": "number",
+      "required": false,
+      "emptyPercentage": 75,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 10000
+      }
+    },
+    {
+      "name": "CUSTOMBOOL01",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 34
+    },
+    {
+      "name": "CUSTOMBOOL02",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 38
+    },
+    {
+      "name": "CUSTOMBOOL03",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 42
+    },
+    {
+      "name": "CUSTOMBOOL04",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 46
+    },
+    {
+      "name": "CUSTOMBOOL05",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 50
+    },
+    {
+      "name": "CUSTOMBOOL06",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 54
+    },
+    {
+      "name": "CUSTOMBOOL07",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 58
+    },
+    {
+      "name": "CUSTOMBOOL08",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 62
+    },
+    {
+      "name": "CUSTOMBOOL09",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 66
+    },
+    {
+      "name": "CUSTOMBOOL10",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 70
+    },
+    {
+      "name": "ISSUETAG01",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      },
+      "dataSource": "issues"
+    },
+    {
+      "name": "ISSUETAG02",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      },
+      "dataSource": "issues"
+    },
+    {
+      "name": "ISSUETAG03",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      },
+      "dataSource": "issues"
+    },
+    {
+      "name": "ISSUETAG04",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      },
+      "dataSource": "issues"
+    },
+    {
+      "name": "ISSUETAG05",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      },
+      "dataSource": "issues"
+    },
+    {
+      "name": "NOTES01",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 72,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES02",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 74,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES03",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 76,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES04",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 78,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES05",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 80,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES06",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 82,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES07",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 84,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES08",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 86,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES09",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 88,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "NOTES10",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": false,
+      "generator": "loremParagraphs",
+      "generatorParams": {
+        "min": 1,
+        "max": 3
+      }
+    },
+    {
+      "name": "PRODUCTIONSTATUS",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dataSource": "responsiveness"
+    },
+    {
+      "name": "REVIEWSTATUS",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 20,
+      "multiValue": false,
+      "dataSource": "responsiveness"
+    },
+    {
+      "name": "QCSTATUS",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 60,
+      "multiValue": false,
+      "dataSource": "responsiveness"
+    },
+    {
+      "name": "ENCODING",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 10,
+      "multiValue": false,
+      "generator": "encoding"
+    },
+    {
+      "name": "TIMEZONE",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 20,
+      "multiValue": false,
+      "generator": "timezone"
+    },
+    {
+      "name": "TAG01",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG02",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG03",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG04",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG05",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG06",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG07",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG08",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG09",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    },
+    {
+      "name": "TAG10",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false,
+      "dataSource": "tags"
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/legacyeml.json
+++ b/src/Profiles/BuiltIns/legacyeml.json
@@ -1,0 +1,84 @@
+{
+  "name": "legacyEml",
+  "description": "Legacy EML pseudo-profile with metadata \u002B email columns",
+  "version": "1.0",
+  "settings": {
+    "emptyValuePercentage": 0,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {},
+  "columns": [
+    {
+      "name": "CUSTODIAN",
+      "type": "foldercustodian",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "DATESENT",
+      "type": "legacydatesent",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "AUTHOR",
+      "type": "legacyauthor",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "FILESIZE",
+      "type": "filedatasize",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILTO",
+      "type": "emailto",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILFROM",
+      "type": "emailfrom",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILCC",
+      "type": "emailcc",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILSUBJECT",
+      "type": "emailsubject",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILSENTDATE",
+      "type": "emailsentdate",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILATTACHMENT",
+      "type": "emailattachment",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/legacywithcollectionmetadata.json
+++ b/src/Profiles/BuiltIns/legacywithcollectionmetadata.json
@@ -1,0 +1,98 @@
+{
+  "name": "legacyWithCollectionMetadata",
+  "description": "Legacy --with-collection-metadata pseudo-profile",
+  "version": "1.0",
+  "settings": {
+    "emptyValuePercentage": 0,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {
+    "datasource": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Email Server",
+        "Network Share",
+        "Cloud Storage",
+        "Mobile Device",
+        "Laptop",
+        "Desktop",
+        "Server",
+        "External Media"
+      ],
+      "weights": [
+        25,
+        20,
+        15,
+        10,
+        10,
+        8,
+        7,
+        5
+      ]
+    },
+    "processingstatus": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Processed",
+        "Pending Review",
+        "Approved",
+        "Privileged",
+        "Redacted",
+        "Produced"
+      ],
+      "weights": [
+        40,
+        20,
+        15,
+        10,
+        10,
+        5
+      ]
+    }
+  },
+  "columns": [
+    {
+      "name": "DATA_SOURCE",
+      "type": "coded",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "datasource"
+    },
+    {
+      "name": "COLLECTION_DATE",
+      "type": "date",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "DENISTED",
+      "type": "boolean",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "DEDUPE_GROUP_ID",
+      "type": "identifier",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "PROCESSING_STATUS",
+      "type": "coded",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "processingstatus"
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/legacywithmetadata.json
+++ b/src/Profiles/BuiltIns/legacywithmetadata.json
@@ -1,0 +1,42 @@
+{
+  "name": "legacyWithMetadata",
+  "description": "Legacy --with-metadata pseudo-profile (non-EML)",
+  "version": "1.0",
+  "settings": {
+    "emptyValuePercentage": 0,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {},
+  "columns": [
+    {
+      "name": "CUSTODIAN",
+      "type": "foldercustodian",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "DATESENT",
+      "type": "legacydatesent",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "AUTHOR",
+      "type": "legacyauthor",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "FILESIZE",
+      "type": "filedatasize",
+      "required": true,
+      "emptyPercentage": 0,
+      "multiValue": false
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/litigation.json
+++ b/src/Profiles/BuiltIns/litigation.json
@@ -1,0 +1,518 @@
+{
+  "name": "litigation",
+  "description": "Full litigation support with comprehensive metadata",
+  "version": "1.0",
+  "fieldNamingConvention": "UPPERCASE",
+  "settings": {
+    "emptyValuePercentage": 15,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {
+    "custodians": {
+      "count": 50,
+      "distribution": "pareto",
+      "prefix": "Custodian_"
+    },
+    "authors": {
+      "count": 100,
+      "distribution": "pareto",
+      "prefix": "Author_"
+    },
+    "departments": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Legal",
+        "Finance",
+        "HR",
+        "Engineering",
+        "Sales",
+        "Marketing",
+        "Operations",
+        "Executive",
+        "IT",
+        "Compliance"
+      ]
+    },
+    "docTypes": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Email",
+        "Document",
+        "Spreadsheet",
+        "Presentation",
+        "Image",
+        "PDF",
+        "Contract",
+        "Invoice",
+        "Memo",
+        "Report"
+      ]
+    },
+    "privilegeTypes": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Attorney-Client",
+        "Work Product",
+        "Not Privileged",
+        "Needs Review"
+      ],
+      "weights": [
+        5,
+        5,
+        80,
+        10
+      ]
+    },
+    "responsiveness": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Responsive",
+        "Not Responsive",
+        "Needs Review",
+        "Privileged"
+      ],
+      "weights": [
+        40,
+        35,
+        15,
+        10
+      ]
+    },
+    "confidentiality": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Public",
+        "Internal",
+        "Confidential",
+        "Highly Confidential"
+      ],
+      "weights": [
+        20,
+        50,
+        25,
+        5
+      ]
+    },
+    "languages": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "English",
+        "Spanish",
+        "French",
+        "German",
+        "Chinese",
+        "Japanese"
+      ],
+      "weights": [
+        85,
+        5,
+        3,
+        2,
+        3,
+        2
+      ]
+    }
+  },
+  "columns": [
+    {
+      "name": "DOCID",
+      "type": "identifier",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "BEGBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "ENDBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "CONTROLNUMBER",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "BEGATTACH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "ENDATTACH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "PARENTDOCID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 70,
+      "multiValue": false
+    },
+    {
+      "name": "FAMILYID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "FILEPATH",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "TEXTPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false
+    },
+    {
+      "name": "NATIVEPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "FILENAME",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILEEXT",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILESIZE",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1024,
+        "max": 104857600
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "PAGECOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1,
+        "max": 500
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "WORDCOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 50000
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "CHARCOUNT",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 0,
+        "max": 250000
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "DATECREATED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATEMODIFIED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATESENT",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATERECEIVED",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2018-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATEPRODUCED",
+      "type": "date",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2024-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTODIAN",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "custodians"
+    },
+    {
+      "name": "AUTHOR",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false,
+      "dataSource": "authors"
+    },
+    {
+      "name": "EMAILFROM",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILTO",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 1,
+        "max": 10
+      }
+    },
+    {
+      "name": "EMAILCC",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 15
+      }
+    },
+    {
+      "name": "EMAILBCC",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 3
+      }
+    },
+    {
+      "name": "EMAILSUBJECT",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "generator": "emailsubject"
+    },
+    {
+      "name": "CONVERSATIONID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "MESSAGEID",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": false
+    },
+    {
+      "name": "DOCTYPE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "docTypes"
+    },
+    {
+      "name": "DEPARTMENT",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 20,
+      "multiValue": false,
+      "dataSource": "departments"
+    },
+    {
+      "name": "PRIVILEGE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "privilegeTypes"
+    },
+    {
+      "name": "RESPONSIVE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "responsiveness"
+    },
+    {
+      "name": "CONFIDENTIALITY",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "confidentiality"
+    },
+    {
+      "name": "LANGUAGE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "languages"
+    },
+    {
+      "name": "ISRESPONSIVE",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 60
+    },
+    {
+      "name": "ISPRIVILEGED",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 10
+    },
+    {
+      "name": "ISCONFIDENTIAL",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 25
+    },
+    {
+      "name": "HASATTACHMENTS",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 30
+    },
+    {
+      "name": "ISNATIVE",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 70
+    },
+    {
+      "name": "NEEDSREDACTION",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 15
+    },
+    {
+      "name": "MD5HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "md5Hash"
+    },
+    {
+      "name": "SHA1HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "sha1Hash"
+    },
+    {
+      "name": "SHA256HASH",
+      "type": "text",
+      "required": false,
+      "multiValue": false,
+      "generator": "sha256Hash"
+    },
+    {
+      "name": "REVIEWNOTES",
+      "type": "longtext",
+      "required": false,
+      "emptyPercentage": 80,
+      "multiValue": false,
+      "generator": "reviewNote"
+    },
+    {
+      "name": "REDACTIONREASON",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 90,
+      "multiValue": false
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/minimal.json
+++ b/src/Profiles/BuiltIns/minimal.json
@@ -1,0 +1,62 @@
+{
+  "name": "minimal",
+  "description": "Basic fields for minimal load file generation",
+  "version": "1.0",
+  "fieldNamingConvention": "UPPERCASE",
+  "settings": {
+    "emptyValuePercentage": 0,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {
+    "custodians": {
+      "count": 10,
+      "distribution": "pareto",
+      "prefix": "Custodian_"
+    }
+  },
+  "columns": [
+    {
+      "name": "DOCID",
+      "type": "identifier",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILEPATH",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "CUSTODIAN",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "custodians"
+    },
+    {
+      "name": "DATECREATED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2020-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "FILESIZE",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1024,
+        "max": 10485760
+      },
+      "distribution": "exponential"
+    }
+  ]
+}

--- a/src/Profiles/BuiltIns/standard.json
+++ b/src/Profiles/BuiltIns/standard.json
@@ -1,0 +1,248 @@
+{
+  "name": "standard",
+  "description": "Common e-discovery fields for standard workflows",
+  "version": "1.0",
+  "fieldNamingConvention": "UPPERCASE",
+  "settings": {
+    "emptyValuePercentage": 10,
+    "multiValueDelimiter": ";",
+    "dateFormat": "yyyy-MM-dd",
+    "dateTimeFormat": "yyyy-MM-ddTHH:mm:ssZ"
+  },
+  "dataSources": {
+    "custodians": {
+      "count": 25,
+      "distribution": "pareto",
+      "prefix": "Custodian_"
+    },
+    "authors": {
+      "count": 50,
+      "distribution": "pareto",
+      "prefix": "Author_"
+    },
+    "departments": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Legal",
+        "Finance",
+        "HR",
+        "Engineering",
+        "Sales",
+        "Marketing",
+        "Operations",
+        "Executive"
+      ]
+    },
+    "docTypes": {
+      "count": 10,
+      "distribution": "uniform",
+      "prefix": "",
+      "values": [
+        "Email",
+        "Document",
+        "Spreadsheet",
+        "Presentation",
+        "Image",
+        "PDF",
+        "Other"
+      ]
+    }
+  },
+  "columns": [
+    {
+      "name": "DOCID",
+      "type": "identifier",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "BEGBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "ENDBATES",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "CONTROLNUMBER",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILEPATH",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "TEXTPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false
+    },
+    {
+      "name": "NATIVEPATH",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false
+    },
+    {
+      "name": "FILENAME",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILEEXT",
+      "type": "text",
+      "required": true,
+      "multiValue": false
+    },
+    {
+      "name": "FILESIZE",
+      "type": "number",
+      "required": false,
+      "multiValue": false,
+      "range": {
+        "min": 1024,
+        "max": 104857600
+      },
+      "distribution": "exponential"
+    },
+    {
+      "name": "DATECREATED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2020-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATEMODIFIED",
+      "type": "date",
+      "required": false,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2020-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATESENT",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2020-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "DATERECEIVED",
+      "type": "datetime",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false,
+      "dateRange": {
+        "min": "2020-01-01",
+        "max": "2024-12-31"
+      }
+    },
+    {
+      "name": "CUSTODIAN",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 0,
+      "multiValue": false,
+      "dataSource": "custodians"
+    },
+    {
+      "name": "AUTHOR",
+      "type": "text",
+      "required": false,
+      "emptyPercentage": 5,
+      "multiValue": false,
+      "dataSource": "authors"
+    },
+    {
+      "name": "EMAILFROM",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": false
+    },
+    {
+      "name": "EMAILTO",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 30,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 1,
+        "max": 5
+      }
+    },
+    {
+      "name": "EMAILCC",
+      "type": "email",
+      "required": false,
+      "emptyPercentage": 50,
+      "multiValue": true,
+      "multiValueCount": {
+        "min": 0,
+        "max": 10
+      }
+    },
+    {
+      "name": "DOCTYPE",
+      "type": "coded",
+      "required": false,
+      "multiValue": false,
+      "dataSource": "docTypes"
+    },
+    {
+      "name": "DEPARTMENT",
+      "type": "coded",
+      "required": false,
+      "emptyPercentage": 20,
+      "multiValue": false,
+      "dataSource": "departments"
+    },
+    {
+      "name": "RESPONSIVE",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 60
+    },
+    {
+      "name": "PRIVILEGED",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 10
+    },
+    {
+      "name": "CONFIDENTIAL",
+      "type": "boolean",
+      "required": false,
+      "multiValue": false,
+      "format": "YN",
+      "truePercentage": 25
+    }
+  ]
+}

--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -10,7 +10,7 @@ public static class ColumnProfileLoader
 {
     private const int MaxColumns = 200;
 
-    private static readonly JsonSerializerOptions ProfileSerializerOptions = new()
+    internal static readonly JsonSerializerOptions ProfileSerializerOptions = new()
     {
         PropertyNameCaseInsensitive = true,
     };

--- a/src/Zipper.Tests/Profiles/BuiltInProfilesResourceTests.cs
+++ b/src/Zipper.Tests/Profiles/BuiltInProfilesResourceTests.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using Xunit;
+using Zipper.Profiles;
+
+namespace Zipper.Tests;
+
+public class BuiltInProfilesResourceTests
+{
+    [Fact]
+    public void GetProfile_FullProfileGeneratorParams_DeserializeAsUsableIntegers()
+    {
+        var profile = BuiltInProfiles.GetProfile("full");
+
+        Assert.NotNull(profile);
+        var notesColumn = profile.Columns.First(c => c.Generator == "loremParagraphs");
+        Assert.NotNull(notesColumn.GeneratorParams);
+        Assert.IsType<int>(notesColumn.GeneratorParams["min"]);
+        Assert.IsType<int>(notesColumn.GeneratorParams["max"]);
+        Assert.Equal(1, Convert.ToInt32(notesColumn.GeneratorParams["min"], CultureInfo.InvariantCulture));
+        Assert.Equal(3, Convert.ToInt32(notesColumn.GeneratorParams["max"], CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void GetProfile_MutatingReturnedClone_DoesNotAffectLaterCalls()
+    {
+        var first = BuiltInProfiles.GetProfile("standard");
+        Assert.NotNull(first);
+        first.Columns.Clear();
+
+        var second = BuiltInProfiles.GetProfile("standard");
+        Assert.NotNull(second);
+        Assert.Equal(24, second.Columns.Count);
+    }
+
+    [Fact]
+    public void GetProfile_CollectionMetadataPseudoProfile_ReturnsNull()
+    {
+        // Parity with the original in-code switch: the collection-metadata pseudo-profile
+        // is only reachable through MergeWithCollectionMetadata, never through GetProfile.
+        Assert.Null(BuiltInProfiles.GetProfile("legacywithcollectionmetadata"));
+    }
+
+    [Fact]
+    public void GetProfile_WeightedDataSources_PreserveValuesAndWeights()
+    {
+        var litigation = BuiltInProfiles.GetProfile("litigation");
+        Assert.NotNull(litigation);
+        Assert.Equal(new[] { 5, 5, 80, 10 }, litigation.DataSources["privilegeTypes"].Weights);
+
+        var full = BuiltInProfiles.GetProfile("full");
+        Assert.NotNull(full);
+        Assert.Equal(new[] { 80, 5, 3, 2, 2, 2, 1, 2, 2, 1 }, full.DataSources["languages"].Weights);
+    }
+
+    [Fact]
+    public void BuiltInProfiles_AllSevenProfiles_LoadWithExpectedNameAndColumnCount()
+    {
+        var expected = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["minimal"] = 5,
+            ["standard"] = 24,
+            ["litigation"] = 48,
+            ["full"] = 138,
+            ["legacywithmetadata"] = 4,
+            ["legacyeml"] = 10,
+            ["legacywithcollectionmetadata"] = 5,
+        };
+
+        var profiles = new[]
+        {
+            BuiltInProfiles.Minimal,
+            BuiltInProfiles.Standard,
+            BuiltInProfiles.Litigation,
+            BuiltInProfiles.Full,
+            BuiltInProfiles.LegacyWithMetadata,
+            BuiltInProfiles.LegacyEml,
+            BuiltInProfiles.LegacyWithCollectionMetadata,
+        };
+
+        foreach (var profile in profiles)
+        {
+            Assert.True(
+                expected.TryGetValue(profile.Name.ToLowerInvariant(), out var columnCount) && profile.Columns.Count == columnCount,
+                $"Profile '{profile.Name}' has {profile.Columns.Count} columns");
+        }
+    }
+}

--- a/src/Zipper.Tests/Profiles/BuiltInProfilesResourceTests.cs
+++ b/src/Zipper.Tests/Profiles/BuiltInProfilesResourceTests.cs
@@ -53,6 +53,15 @@ public class BuiltInProfilesResourceTests
     }
 
     [Fact]
+    public void Properties_RepeatedAccess_ReturnSameSharedInstance()
+    {
+        // Pre-existing contract: the static accessors always returned one shared instance
+        // ({ get; } initialized once); DatComposerShared relies on the shared statics directly.
+        Assert.Same(BuiltInProfiles.Standard, BuiltInProfiles.Standard);
+        Assert.Same(BuiltInProfiles.LegacyEml, BuiltInProfiles.LegacyEml);
+    }
+
+    [Fact]
     public void BuiltInProfiles_AllSevenProfiles_LoadWithExpectedNameAndColumnCount()
     {
         var expected = new Dictionary<string, int>(StringComparer.Ordinal)

--- a/src/Zipper.csproj
+++ b/src/Zipper.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Emails\email-templates.json" />
+    <EmbeddedResource Include="Profiles\BuiltIns\*.json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fixes #622 (audit R3-009). The 7 built-in Column Profile definitions (477 lines of C# literals, including the 138-column `full` profile) move to embedded JSON resources under `src/Profiles/BuiltIns/`, loaded once via `GetManifestResourceStream` and deserialized with the exact `JsonSerializerOptions` used for custom profiles (now shared from `ColumnProfileLoader`). Built-in and custom profiles now share one data format.

**API parity (verified, not just claimed):**
- `BuiltInProfiles.cs` keeps its exact public surface: 7 shared static instances, `ProfileNames` (4 user-selectable names), `GetProfile` clone-per-call with the original 6-name set — `legacywithcollectionmetadata` deliberately still returns null (pinned by a new test), and `MergeWithCollectionMetadata` is unchanged logic.
- The JSON was produced by serializing the original objects (round-trip identity by construction); an adversarial review re-compared every value against HEAD literals, including loop-generated columns, default materialization (`emptyValuePercentage` etc.), and dictionary ordering.
- **Rule 6 parity evidence:** the golden harness has no column-profile scenarios, so identity rests on the round-trip construction + the profile unit suite (ColumnProfileTests / DataGeneratorTests / ProfileDrivenDatComposingWriterTests, all unchanged and green) + 5 new tests + goldens 20/20 byte-identical.
- One shim was required: `NormalizeGeneratorParams` converts `JsonElement` values back to `int`/`double`/`bool`/`string`, because `LongTextGenerator` reads generator params via `Convert.ToInt32` and `JsonElement` is not `IConvertible`. Without it, the `full` profile's NOTES columns would crash. (The same latent bug exists for *custom* profiles and is out of scope — follow-up issue to be filed.)

## Release Notes
Built-in column profiles (minimal, standard, litigation, full, and the internal pseudo-profiles) are now defined as embedded JSON resources instead of C# object literals, sharing one format with custom column profiles. Behavior and generated output are unchanged; the profile system is easier to inspect and extend.

## Test plan
- [x] `dotnet build` — 0 errors/warnings (warnings-as-errors)
- [x] `dotnet format --verify-no-changes src/` — clean
- [x] Unit tests 1583/1583 (5 new: generator-param type guard, clone isolation, 7-profile resource wiring, GetProfile parity for the 7th name, weighted data-source spot checks)
- [x] Analyzer tests 44/44
- [x] Goldens 20/20 byte-identical
- [x] E2E smoke via pre-push hook
- [x] Adversarial review (identity verified value-by-value vs HEAD; all findings fixed)

🤖 Generated with [Factory](https://factory.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in profiles for minimal, standard, litigation, full, and legacy metadata workflows.
  * Profiles now provide comprehensive field schemas, data sources, formatting, and generation settings.
  * Profile retrieval returns independent copies, preventing changes from affecting future requests.
* **Bug Fixes**
  * Generator parameters now deserialize consistently into usable values.
  * Weighted data sources preserve their configured values and weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->