### PR TITLE
fix: log Rolling Production Set context in generator catch block (#623)

### DIFF
--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -88,6 +88,8 @@ internal static class ProductionSetGenerator
             }
             catch (Exception ex)
             {
+                await Console.Error.WriteLineAsync(string.Format(System.Globalization.CultureInfo.InvariantCulture, "Error: Rolling Production Set '{0}' ({1} of {2}) failed: {3}", productionName, i + 1, rollingCount, ex.Message)).ConfigureAwait(false);
+
                 if (ex is not Validation.ValidationFailedException)
                 {
                     for (int j = 0; j <= i; j++)

--- a/src/Zipper.Tests/ProductionSetTests.cs
+++ b/src/Zipper.Tests/ProductionSetTests.cs
@@ -607,6 +607,44 @@ public class ProductionSetTests : IDisposable
     }
 
     [Fact]
+    public async Task GenerateAsync_OnRollingProductionFailure_LogsProductionIdContext()
+    {
+        // Output path is an existing file, so the first Rolling Production Set's
+        // directory creation throws IOException inside the rolling loop.
+        var outputFile = Path.Combine(Directory.GetCurrentDirectory(), $"zipper_prod_ctx_{Guid.NewGuid():N}");
+        await File.WriteAllTextAsync(outputFile, "not a directory");
+        var originalError = Console.Error;
+        using var errWriter = new StringWriter();
+        try
+        {
+            Console.SetError(errWriter);
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    OutputPath = outputFile,
+                    FileCount = 10,
+                    FileType = "pdf",
+                },
+                Production = new ProductionConfig { ProductionSet = true, VolumeSize = 10, ProductionId = "PROD_A,PROD_B", RollingCount = 2 },
+                Bates = new BatesNumberConfig { Prefix = "CTX", Start = 1, Digits = 8 },
+            };
+
+            await Assert.ThrowsAnyAsync<IOException>(() => ProductionSetGenerator.GenerateAsync(request));
+
+            var errorOutput = errWriter.ToString();
+            Assert.Contains("PROD_A", errorOutput, StringComparison.Ordinal);
+            Assert.Contains("(1 of 2)", errorOutput, StringComparison.Ordinal);
+            Assert.Contains("failed:", errorOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+            File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
     public async Task GenerateAsync_WithMultiPageTiff_ShouldWritePageLevelImageFilesToDisk()
     {
         // Arrange


### PR DESCRIPTION
## Summary
Fixes #623 (audit R3-010). The top-level catch in `ProductionSetGenerator`'s rolling loop did best-effort cleanup and rethrew, but nothing recorded **which** Rolling Production Set failed — the rethrown exception only carries the inner message. The catch now writes `Error: Rolling Production Set '<id>' (<n> of <count>) failed: <message>` to stderr before cleanup, for both the cleanup and `ValidationFailedException` paths. Control flow, exception type, and cleanup behavior are unchanged.

Terminology follows UBIQUITOUS_LANGUAGE.md (Rolling Production Set, not the issue body's loose "volume" — a Volume is a partition *within* one set).

## Release Notes
When a Rolling Production Set fails mid-generation, the error output now names the failing production and its position in the rolling sequence before partial output is cleaned up.

## Test plan
- [x] TDD: new test fails before the fix (stderr empty), passes after — injects a deterministic IOException (output path is a file) with `--production-id PROD_A,PROD_B`, asserts stderr names PROD_A
- [x] Unit tests 1585/1585, analyzer tests 44/44
- [x] `dotnet format --verify-no-changes` clean
- [x] Goldens 20/20 byte-identical
- [x] Self-review exemption: single-line diagnostic change (per AGENTS.md autoreview policy)

🤖 Generated with [Factory](https://factory.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed rolling production generation by including the production name, sequence position, and error details.
  * Added production context to failure logs, making issues easier to identify and troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->