### PR TITLE
docs: clarify delimiter argument precedence (#617)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--load-file-formats` vs `--load-file-format` | Multi-format list takes precedence over single format |
 | `--include-load-file` + `--load-file-formats` | All specified formats are included in the ZIP |
 | `--delimiter-*` + `--dat-delimiters` | Specific delimiter flags override the preset for that delimiter only |
+| Strict-prefix `--col-delim`/`--quote-delim`/etc. + old-style flags or preset | Strict-prefix arguments win per delimiter; full chain: defaults → `--dat-delimiters` preset → `--delimiter-*` → strict-prefix (all DAT-only) |
 | `--load-file-format csv` vs `--dat-delimiters csv` | Distinct: former selects a true `.csv` (RFC 4180) writer; latter only swaps a `.dat` file's delimiters to comma/quote |
 | `--hash-algorithms` | Requires `--hash-mode` to be `actual` or `simulated` |
 | `--hash-mode actual` + `--loadfile-only` | **Conflict**: cannot compute actual hashes without generated Native Files |

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | `--load-file-formats` vs `--load-file-format` | Multi-format list takes precedence over single format |
 | `--include-load-file` + `--load-file-formats` | All specified formats are included in the ZIP |
 | `--delimiter-*` + `--dat-delimiters` | Specific delimiter flags override the preset for that delimiter only |
-| Strict-prefix `--col-delim`/`--quote-delim`/etc. + old-style flags or preset | Strict-prefix arguments win per delimiter; full chain: defaults → `--dat-delimiters` preset → `--delimiter-*` → strict-prefix (all DAT-only) |
+| Strict-prefix `--col-delim`/`--quote-delim`/etc. + old-style flags or preset | Strict-prefix arguments win per delimiter; full chain: defaults → `--dat-delimiters` preset → `--delimiter-*` → strict-prefix. Preset and old-style flags are DAT-only; strict-prefix work in all generation modes but affect only DAT output |
 | `--load-file-format csv` vs `--dat-delimiters csv` | Distinct: former selects a true `.csv` (RFC 4180) writer; latter only swaps a `.dat` file's delimiters to comma/quote |
 | `--hash-algorithms` | Requires `--hash-mode` to be `actual` or `simulated` |
 | `--hash-mode actual` + `--loadfile-only` | **Conflict**: cannot compute actual hashes without generated Native Files |

--- a/Requirements.md
+++ b/Requirements.md
@@ -371,7 +371,7 @@ Based on the above research, the following requirements apply to the Zipper Load
 
 - **REQ-048**: The `--load-file-format` argument shall support the following formats: `dat`, `opt`, `csv`, `edrm-xml`, `concordance`.
 - **REQ-049**: DAT format shall use standard Concordance delimiters (ASCII 20, 254, 174) by default.
-- **REQ-050**: A new argument `--dat-delimiters <standard|csv>` shall allow switching between standard Concordance delimiters and standard CSV format.
+- **REQ-050**: A new argument `--dat-delimiters <standard|csv>` shall allow switching between standard Concordance delimiters and standard CSV format. Delimiter precedence, lowest to highest: Concordance defaults (ASCII 20/254/174) → `--dat-delimiters` preset (column/quote/newline only) → old-style `--delimiter-*` flags (per delimiter) → strict-prefix arguments (REQ-093). Per REQ-083, all of these apply only when the Load File Format is DAT.
 - **REQ-051**: OPT format shall use comma delimiters and ANSI encoding by default.
 - **REQ-052**: EDRM-XML format shall generate well-formed XML conforming to EDRM schema version 1.2.
 - **REQ-053**: **DEPRECATED** — Original requirement for CSV delimiter customization. Superseded by REQ-124.
@@ -656,7 +656,7 @@ This section clarifies behavior when multiple arguments interact:
   - `--nested-delim <ascii:N|char:C>`: Nested value separator
 
 > [!NOTE]
-> The strict `ascii:`/`char:` prefix format is distinct from the existing `--delimiter-column`/`--delimiter-quote`/`--delimiter-newline` arguments which accept bare values.
+> The strict `ascii:`/`char:` prefix format is distinct from the existing `--delimiter-column`/`--delimiter-quote`/`--delimiter-newline` arguments which accept bare values. When several styles are given, strict-prefix arguments take precedence over both the `--dat-delimiters` preset (REQ-050) and the old-style flags, per delimiter.
 
 ---
 

--- a/Requirements.md
+++ b/Requirements.md
@@ -371,7 +371,7 @@ Based on the above research, the following requirements apply to the Zipper Load
 
 - **REQ-048**: The `--load-file-format` argument shall support the following formats: `dat`, `opt`, `csv`, `edrm-xml`, `concordance`.
 - **REQ-049**: DAT format shall use standard Concordance delimiters (ASCII 20, 254, 174) by default.
-- **REQ-050**: A new argument `--dat-delimiters <standard|csv>` shall allow switching between standard Concordance delimiters and standard CSV format. Delimiter precedence, lowest to highest: Concordance defaults (ASCII 20/254/174) → `--dat-delimiters` preset (column/quote/newline only) → old-style `--delimiter-*` flags (per delimiter) → strict-prefix arguments (REQ-093). Per REQ-083, all of these apply only when the Load File Format is DAT.
+- **REQ-050**: A new argument `--dat-delimiters <standard|csv>` shall allow switching between standard Concordance delimiters and standard CSV format. Delimiter precedence, lowest to highest: Concordance defaults (ASCII 20/254/174) → `--dat-delimiters` preset (column/quote/newline only) → old-style `--delimiter-*` flags (per delimiter) → strict-prefix arguments (REQ-093). Per REQ-083, the preset and old-style flags apply only when the Load File Format is DAT; strict-prefix arguments are supported in all generation modes (REQ-093) but likewise only affect DAT-family output (OPT and CSV writers use fixed formats).
 - **REQ-051**: OPT format shall use comma delimiters and ANSI encoding by default.
 - **REQ-052**: EDRM-XML format shall generate well-formed XML conforming to EDRM schema version 1.2.
 - **REQ-053**: **DEPRECATED** — Original requirement for CSV delimiter customization. Superseded by REQ-124.


### PR DESCRIPTION
## Summary
Fixes #617 (audit finding R1-005). REQ-050's scope was ambiguous relative to REQ-083 (DAT-only) and REQ-093 (strict-prefix, all modes). The interaction lived only in Section 10. Now REQ-050 spells out the full precedence chain (Concordance defaults → `--dat-delimiters` preset → old-style `--delimiter-*` → strict-prefix arguments, all DAT-only per REQ-083), and the REQ-093 note states that strict-prefix arguments win when styles are mixed. README's Argument Interactions table gains a matching row. Wording verified against `RequestBuilder`'s actual resolution order (preset first, then old-style, then strict-prefix). Docs-only; no behavior change.

## Release Notes
Documentation only: the requirements and README now state the exact precedence between --dat-delimiters, the old-style --delimiter-* flags, and the strict-prefix delimiter arguments.

## Test plan
- [x] Docs-only change (self-review per AGENTS.md exemption)
- [x] Requirement traceability gate passes (100%)

🤖 Generated with [Factory](https://factory.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented delimiter precedence for DAT generation.
  * Clarified that strict-prefix delimiter options take precedence over presets and legacy delimiter flags.
  * Specified that these precedence rules apply only to DAT generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->