### PR TITLE
fix: normalize generatorParams for custom column profiles (#720)

### DIFF
--- a/src/Profiles/BuiltInProfiles.cs
+++ b/src/Profiles/BuiltInProfiles.cs
@@ -134,42 +134,10 @@ public static class BuiltInProfiles
                 throw new InvalidOperationException($"Embedded column profile resource '{resourceName}' failed to parse.");
             }
 
-            NormalizeGeneratorParams(profile);
+            ColumnProfileLoader.NormalizeGeneratorParams(profile);
             profiles[name] = profile;
         }
 
         return profiles;
-    }
-
-    /// <summary>
-    /// Converts JsonElement generator parameter values produced by deserialization back to the
-    /// primitives a C# object literal would hold (int/double/bool/string), so generator consumers
-    /// see identical types for built-in and in-code profiles.
-    /// </summary>
-    private static void NormalizeGeneratorParams(ColumnProfile profile)
-    {
-        foreach (var column in profile.Columns)
-        {
-            if (column.GeneratorParams is null)
-            {
-                continue;
-            }
-
-            foreach (var key in column.GeneratorParams.Keys.ToList())
-            {
-                if (column.GeneratorParams[key] is JsonElement element)
-                {
-                    column.GeneratorParams[key] = element.ValueKind switch
-                    {
-                        JsonValueKind.Number when element.TryGetInt32(out var intValue) => intValue,
-                        JsonValueKind.Number => element.GetDouble(),
-                        JsonValueKind.True => true,
-                        JsonValueKind.False => false,
-                        JsonValueKind.String => element.GetString()!,
-                        _ => element,
-                    };
-                }
-            }
-        }
     }
 }

--- a/src/Profiles/ColumnProfileLoader.cs
+++ b/src/Profiles/ColumnProfileLoader.cs
@@ -65,6 +65,7 @@ public static class ColumnProfileLoader
             }
 
             Validate(profile);
+            NormalizeGeneratorParams(profile);
             return profile;
         }
         catch (JsonException ex)
@@ -74,6 +75,38 @@ public static class ColumnProfileLoader
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
             throw new InvalidOperationException($"Unable to read column profile file '{filePath}': {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Converts JsonElement generator parameter values produced by deserialization back to the
+    /// primitives a C# object literal would hold (int/double/bool/string), so generator consumers
+    /// see identical types for deserialized and in-code profiles.
+    /// </summary>
+    internal static void NormalizeGeneratorParams(ColumnProfile profile)
+    {
+        foreach (var column in profile.Columns)
+        {
+            if (column.GeneratorParams is null)
+            {
+                continue;
+            }
+
+            foreach (var key in column.GeneratorParams.Keys.ToList())
+            {
+                if (column.GeneratorParams[key] is JsonElement element)
+                {
+                    column.GeneratorParams[key] = element.ValueKind switch
+                    {
+                        JsonValueKind.Number when element.TryGetInt32(out var intValue) => intValue,
+                        JsonValueKind.Number => element.GetDouble(),
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        JsonValueKind.String => element.GetString()!,
+                        _ => element,
+                    };
+                }
+            }
         }
     }
 

--- a/src/Zipper.Tests/Profiles/ColumnProfileLoaderTests.cs
+++ b/src/Zipper.Tests/Profiles/ColumnProfileLoaderTests.cs
@@ -620,6 +620,88 @@ public class ColumnProfileLoaderTests : IDisposable
         Assert.Contains("Path traversal detected", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void LoadFromFile_WithGeneratorParams_NormalizesJsonElementValues()
+    {
+        // Arrange
+        var json = @"{
+                ""name"": ""CustomParams"",
+                ""columns"": [
+                    { ""name"": ""DOCID"", ""type"": ""identifier"" },
+                    { ""name"": ""NOTES"", ""type"": ""longtext"", ""generator"": ""loremParagraphs"", ""generatorParams"": { ""min"": 1, ""max"": 3, ""label"": ""note"", ""flag"": true, ""off"": false, ""ratio"": 1.5 } }
+                ],
+                ""dataSources"": {}
+            }";
+
+        var filePath = Path.Combine(this.tempDir, "params.json");
+        File.WriteAllText(filePath, json);
+
+        // Act
+        var profile = ColumnProfileLoader.LoadFromFile(filePath);
+
+        // Assert: values must be primitives, not JsonElement, so generator consumers can Convert them
+        var notesColumn = profile.Columns[1];
+        Assert.NotNull(notesColumn.GeneratorParams);
+        Assert.IsType<int>(notesColumn.GeneratorParams["min"]);
+        Assert.IsType<int>(notesColumn.GeneratorParams["max"]);
+        Assert.Equal(1, notesColumn.GeneratorParams["min"]);
+        Assert.Equal(3, notesColumn.GeneratorParams["max"]);
+        Assert.IsType<string>(notesColumn.GeneratorParams["label"]);
+        Assert.IsType<bool>(notesColumn.GeneratorParams["flag"]);
+        Assert.Equal(false, notesColumn.GeneratorParams["off"]);
+        Assert.IsType<double>(notesColumn.GeneratorParams["ratio"]);
+    }
+
+    [Fact]
+    public void LoadFromFile_WithNullColumns_ThrowsInvalidOperationException()
+    {
+        // Arrange: explicit null must surface the validation error, not a NullReferenceException from normalization
+        var json = @"{ ""name"": ""NullColumns"", ""columns"": null, ""dataSources"": {} }";
+
+        var filePath = Path.Combine(this.tempDir, "null-columns.json");
+        File.WriteAllText(filePath, json);
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ColumnProfileLoader.LoadFromFile(filePath));
+
+        Assert.Contains("at least one column", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadFromFile_WithLoremParagraphsProfile_GenerateDoesNotThrow()
+    {
+        // Arrange: repro from issue #720 - custom profile with generatorParams must not crash generation
+        var json = @"{
+                ""name"": ""CustomLorem"",
+                ""columns"": [
+                    { ""name"": ""DOCID"", ""type"": ""identifier"" },
+                    { ""name"": ""NOTES"", ""type"": ""longtext"", ""generator"": ""loremParagraphs"", ""generatorParams"": { ""min"": 1, ""max"": 3 } }
+                ],
+                ""dataSources"": {}
+            }";
+
+        var filePath = Path.Combine(this.tempDir, "lorem.json");
+        File.WriteAllText(filePath, json);
+        var profile = ColumnProfileLoader.LoadFromFile(filePath);
+
+        var context = new Zipper.Profiles.Generation.ColumnGenerationContext
+        {
+            NativeFileIndex = 0,
+            FolderNumber = 1,
+            DocumentIndex = 0,
+            Seeded = new Random(42),
+            Now = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        // Act
+        var generator = new Zipper.Profiles.Generation.LongTextGenerator(profile.Columns[1]);
+        var text = generator.Generate(context);
+
+        // Assert
+        Assert.NotEmpty(text);
+    }
+
     private static ColumnProfile CreateMinimalProfile()
     {
         return new ColumnProfile


### PR DESCRIPTION
## Release Notes
Custom Column Profiles loaded from JSON no longer crash at generation time when they use generatorParams (e.g. loremParagraphs min/max); values are now normalized from JsonElement to primitives the same way as built-in profiles.

## Description

Fixes #720. `ColumnProfileLoader.LoadFromFile` deserialized `generatorParams` values as `JsonElement`, which is not `IConvertible`, so `LongTextGenerator`'s `Convert.ToInt32` threw `InvalidCastException` at generation time. The existing `BuiltInProfiles.NormalizeGeneratorParams` (from #719) moved to `ColumnProfileLoader` as an internal static so both the embedded built-in resources and custom file loads share one normalization path.

Review-driven hardening (autoreview): `Validate` now runs before normalization in `LoadFromFile`, so a profile with explicit `"columns": null` still throws the documented `InvalidOperationException` instead of a `NullReferenceException`.

Known remaining edge (out of scope, pre-existing): generatorParams with array/object values stay `JsonElement` and would still fail loudly at generation time; no consumer supports structured params. Can be a follow-up validation hardening if desired.

## Type of Change

- [x] Bug fix

## Testing Done

- [x] Unit tests pass (`dotnet test src/Zipper.Tests/Zipper.Tests.csproj` & `dotnet test src/Zipper.Analyzers.Tests/Zipper.Analyzers.Tests.csproj`) — 1634 + 44 passed
- [x] E2E tests pass (`bash tests/run-tests.sh`)
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

New tests: `LoadFromFile_WithGeneratorParams_NormalizesJsonElementValues`, `LoadFromFile_WithLoremParagraphsProfile_GenerateDoesNotThrow` (end-to-end repro of the issue), `LoadFromFile_WithNullColumns_ThrowsInvalidOperationException`.

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required)

## Affected Requirements

None — bug fix restoring documented custom Column Profile behavior; no REQ-XXX/FR-XXX semantics changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of custom profiles with generator parameters.
  * Ensured profile values are correctly interpreted when generating content.
  * Added validation for profiles missing required column definitions.

* **Tests**
  * Added coverage for parameter conversion, invalid profiles, and lorem paragraph generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->