### PR TITLE
fix(cli): reject --column-profile when --production-set is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ When family relationships create child Attachment Native Files, `nativeFileCount
 | Interaction | Behavior |
 |-------------|----------|
 | `--column-profile` + `--with-metadata` | Column profile takes precedence; `--with-metadata` is ignored with a warning |
+| `--column-profile` + `--production-set` | **Conflict**: `--column-profile` is not supported with `--production-set` |
 | `--column-profile` + `--with-collection-metadata` | Collection metadata columns are merged into the profile; profile values take precedence with synthetic fallback |
 | `--with-collection-metadata` + `--with-metadata` | Both add their own disjoint column sets; no conflict |
 | `--with-collection-metadata` + Production Set | Silently ignored (no columns added) |

--- a/Requirements.md
+++ b/Requirements.md
@@ -620,6 +620,7 @@ This section clarifies behavior when multiple arguments interact:
 | `--loadfile-only` + `--target-zip-size` | **Conflict**: cannot use both |
 | `--loadfile-only` + `--include-load-file` | **Conflict**: cannot use both |
 | `--loadfile-only` + `--production-set` | **Conflict**: cannot use both |
+| `--production-set` + `--column-profile` | **Conflict**: `--column-profile` is not supported with `--production-set` |
 | `--load-file-format` + `--production-set` | **Ignored**: See REQ-117. |
 | `--production-set` + `--bates-prefix` | **Required**: `--bates-prefix` is mandatory when `--production-set` is used |
 | `--production-zip` + `--production-set` | **Requires**: `--production-zip` cannot be used without `--production-set` |

--- a/src/Cli/Validation/CrossCuttingValidator.cs
+++ b/src/Cli/Validation/CrossCuttingValidator.cs
@@ -176,6 +176,12 @@ internal static class CrossCuttingValidator
 
     private static bool ValidateColumnProfile(ParsedArguments parsed)
     {
+        if (!string.IsNullOrEmpty(parsed.ColumnProfile) && parsed.ProductionSet)
+        {
+            Console.Error.WriteLine("Error: --column-profile is not supported with --production-set.");
+            return false;
+        }
+
         if (!string.IsNullOrEmpty(parsed.ColumnProfile) && !ColumnProfileLoader.IsBuiltInProfile(parsed.ColumnProfile))
         {
             if (!PathValidator.IsPathSafe(parsed.ColumnProfile, Directory.GetCurrentDirectory()))

--- a/src/Zipper.Tests/Cli/CliValidatorTests.cs
+++ b/src/Zipper.Tests/Cli/CliValidatorTests.cs
@@ -803,4 +803,13 @@ public class CliValidatorTests
         };
         Assert.True(CliValidator.Validate(args));
     }
+
+    [Fact]
+    public void Validate_ColumnProfile_WithProductionSet_ReturnsFalse()
+    {
+        var args = CreateValidArgs();
+        args.ProductionSet = true;
+        args.ColumnProfile = "edrm-standard";
+        Assert.False(CliValidator.Validate(args));
+    }
 }


### PR DESCRIPTION
Reject `--column-profile` when combined with `--production-set` in CLI validation to prevent silent ignoring of column profiles during Production Set generation.

Fixes #725

## Release Notes
Disallowed using `--column-profile` together with `--production-set` in CLI validation, returning a clear error instead of silently ignoring the custom column profile during Production Set generation.