### PR TITLE
fix(gitignore): remove over-broad *mixed* glob pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,6 @@ Thumbs.db
 *.swo
 
 # Path-traversal E2E test artifacts
-*mixed*
-!tests/test-mixed-file-types.sh
-!tests/test-mixed-file-types.bat
 /..\\*
 **/..\\*
 


### PR DESCRIPTION
Remove over-broad `*mixed*` pattern and specific test file negations from `.gitignore`. The pattern was eating legitimate files containing 'mixed' in their path.

Fixes #702

## Release Notes
Removed over-broad `*mixed*` pattern from `.gitignore` to prevent legitimate repository files containing 'mixed' in their path from being silently gitignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository file tracking rules to include mixed-file-type test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->