### PR TITLE
docs: restore full CLI flag reference table and cross-platform OS examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zipper: Test Data Generation Tool
 
-Zipper is a high-performance .NET tool for generating synthetic e-discovery Archives (`.zip`), Production Sets, and Load Files (`.dat`, `.opt`, `.csv`, `.xml`). Designed for e-discovery platform testing, benchmark suites, and ingestion validation, Zipper can scale to 100+ million records.
+Zipper is a high-performance .NET command-line tool for generating synthetic e-discovery Archives (`.zip`), Production Sets, and Load Files (`.dat`, `.opt`, `.csv`, `.xml`). Designed for e-discovery platform testing, benchmark suites, and ingestion validation, Zipper scales to 100+ million records and runs cross-platform on **Windows**, **macOS**, and **Linux**.
 
 ---
 
@@ -9,20 +9,28 @@ Zipper is a high-performance .NET tool for generating synthetic e-discovery Arch
 ### Installation & Prerequisites
 
 - **Prerequisites**: [.NET 10.0 SDK](https://dotnet.microsoft.com/) (or newer)
+- **Cross-Platform Compatibility**: Windows (x64/arm64), macOS (x64/arm64), and Linux (x64/arm64)
 - **Build from Source**:
   ```bash
   git clone https://github.com/dwojtaszek/zipper.git
   cd zipper
   dotnet publish -c Release
   ```
-  The binary is built to `src/bin/Release/net10.0/<platform>/publish/zipper`.
+  The executable will be placed in `src/bin/Release/net10.0/<platform>/publish/` (`zipper.exe` on Windows, `zipper` on Linux/macOS).
 
 ### Core Use Cases
 
 #### 1. Generate an Archive with Native Files & DAT Load File
 Generate 10,000 PDF files distributed across 5 folders with standard metadata:
+
+**Linux / macOS (Bash / zsh)**:
 ```bash
 zipper --type pdf --count 10000 --output-path ./output --folders 5 --with-metadata
+```
+
+**Windows (Command Prompt / PowerShell)**:
+```cmd
+zipper.exe --type pdf --count 10000 --output-path .\output --folders 5 --with-metadata
 ```
 
 #### 2. Generate a File Type Mix
@@ -63,36 +71,83 @@ zipper --input-csv ./source.csv --output-path ./source_output --bates-prefix ABC
 
 ---
 
-## Usage & Arguments Reference
+## Usage & Arguments Quick Reference
 
-### Key Arguments
+All command-line flags recognized by Zipper:
 
-| Argument | Description | Default | Values / Examples |
-|----------|-------------|---------|-------------------|
-| `--count <N>` | Total records/files to generate | **Required** | Integer (e.g. `10000`) |
-| `--output-path <dir>` | Target output directory | **Required** | Directory path |
-| `--type <type>` | Single native file type | `pdf` | `pdf`, `jpg`, `tiff`, `eml`, `docx`, `xlsx` |
-| `--types <mix>` | File type mix weights | none | `pdf:70,eml:20,tiff:10` |
-| `--load-file-format <fmt>` | Load file format | `dat` | `dat`, `opt`, `csv`, `edrm-xml`, `concordance` |
-| `--load-file-formats <list>` | Generate multiple formats | none | `dat,opt,csv` |
-| `--folders <N>` | Directory folder count | `1` | `1` to `100` |
-| `--distribution <pattern>` | Folder distribution | `proportional` | `proportional`, `gaussian`, `exponential` |
-| `--with-metadata` | Standard metadata columns | `false` | Flag |
-| `--with-text` | Extracted text files | `false` | Flag |
-| `--bates-prefix <prefix>` | Bates prefix | none | e.g. `CLIENT001` |
-| `--bates-start <N>` | Starting Bates number | `1` | Integer |
-| `--bates-digits <N>` | Bates digit padding | `8` | e.g. `8` (`CLIENT00000001`) |
-| `--column-profile <name>` | Metadata column profile | none | `minimal`, `standard`, `litigation`, `full` |
-| `--production-set` | Enable Production Set output | `false` | Flag (requires `--bates-prefix`) |
-| `--loadfile-only` | Standalone Load File output | `false` | Flag |
+| Argument | Default | Accepted Values / Range | Description |
+|----------|---------|-------------------------|-------------|
+| `--type` | `pdf` | `pdf`, `jpg`, `tiff`, `eml`, `docx`, `xlsx` | File type to generate |
+| `--types` | none | comma-separated `type:weight` (e.g. `pdf:70,eml:30`) | File type mix weights |
+| `--input-csv` | none | file path | Source-driven generation from CSV |
+| `--directory-template` | none | directory path | Source-driven generation mirroring directory structure |
+| `--count` | **required** | positive integer | Total number of files/records to generate |
+| `--output-path` | **required** | directory path | Target output directory |
+| `--folders` | `1` | `1` to `100` | Number of subfolders for file distribution |
+| `--encoding` | `UTF-8` | `UTF-8`, `UTF-16`, `ANSI` | Text encoding for Load Files |
+| `--distribution` | `proportional` | `proportional`, `gaussian`, `exponential` | Folder distribution algorithm |
+| `--with-metadata` | `false` | flag | Include standard metadata columns |
+| `--with-collection-metadata` | `false` | flag | Include e-discovery collection metadata columns |
+| `--with-text` | `false` | flag | Generate companion extracted text files |
+| `--attachment-rate` | `0` | `0` to `100` | Percentage of Emails containing attachments |
+| `--target-zip-size` | none | e.g. `500MB`, `10GB` | Target padded Archive size |
+| `--include-load-file` | `false` | flag | Include Load File inside ZIP Archive |
+| `--load-file-format` | `dat` | `dat`, `opt`, `csv`, `edrm-xml`, `concordance` | Single Load File format |
+| `--load-file-formats` | none | comma-separated list (e.g. `dat,opt,csv`) | Multiple simultaneous Load File formats |
+| `--loadfile-format` | `dat` | `dat`, `opt` | Alias for `--load-file-format` in Loadfile-Only mode |
+| `--dat-delimiters` | `standard` | `standard`, `csv` | Preset delimiter style for DAT format |
+| `--delimiter-column` | ASCII 20 | ASCII code or single character | Custom column delimiter |
+| `--delimiter-quote` | ASCII 254 | ASCII code or single character | Custom quote delimiter |
+| `--delimiter-newline` | ASCII 174 | ASCII code or single character | Custom newline replacement |
+| `--bates-prefix` | none | string (or comma-separated list) | Bates numbering prefix |
+| `--bates-start` | `1` | non-negative integer | Starting Bates number |
+| `--bates-digits` | `8` | `1` to `20` | Bates number digit padding count |
+| `--tiff-pages` | `1-1` | min-max range (e.g. `1-20`) | Page count range for TIFF files |
+| `--column-profile` | none | `minimal`, `standard`, `litigation`, `full`, or file path | Metadata column profile |
+| `--seed` | none | integer | Random seed for reproducible runs |
+| `--date-format` | `yyyy-MM-dd` | format string | Override date format string |
+| `--empty-percentage` | `15` | `0` to `100` | Percentage of empty values for optional fields |
+| `--custodian-count` | `10` | `1` to `1000` | Number of custodians in data pool |
+| `--with-families` | `false` | flag | Generate parent-child attachment relationships |
+| `--loadfile-only` | `false` | flag | Standalone Load File generation (no Archive) |
+| `--eol` | `CRLF` | `CRLF`, `LF`, `CR` | Line ending format for Load Files |
+| `--col-delim` | ASCII 20 | `ascii:N` or `char:C` | Column delimiter (strict-prefix format) |
+| `--quote-delim` | ASCII 254 | `ascii:N`, `char:C`, or `none` | Quote delimiter (strict-prefix format) |
+| `--newline-delim` | ASCII 174 | `ascii:N` or `char:C` | Newline replacement (strict-prefix format) |
+| `--multi-delim` | `;` | `ascii:N` or `char:C` | Multi-value separator |
+| `--nested-delim` | `\` | `ascii:N` or `char:C` | Nested value separator |
+| `--chaos-mode` | `false` | flag | Enable Chaos Engine anomaly injection |
+| `--chaos-amount` | `1%` | exact count `N` or percentage `N%` | Anomaly target count/percentage |
+| `--chaos-types` | all | comma-separated list | Filter specific chaos anomaly types |
+| `--chaos-scenario` | none | scenario name | Predefined chaos scenario |
+| `--chaos-list` | `false` | flag | Print available chaos scenarios and exit |
+| `--production-set` | `false` | flag | Structured Production Set output |
+| `--volume-size` | `5000` | positive integer | Maximum documents per volume subfolder |
+| `--production-id` | auto | string | Production volume set identifier |
+| `--rolling-count` | `1` | positive integer | Generate multiple rolling production sets |
+| `--rolling-bates-mode` | `continuous` | `continuous`, `restart` | Bates sequence behavior across rolling sets |
+| `--source-path-mode` | `bates` | `bates`, `preserve`, `originals` | Source path placement policy |
+| `--production-zip` | `false` | flag | Wrap Production Set output in ZIP Archive |
+| `--redacted-production` | `false` | flag | Redacted production placeholders |
+| `--withheld-native-policy` | `keep-native` | `keep-native`, `omit-native-path`, `replace-with-placeholder` | Redacted mode native path handling policy |
+| `--supplemental-production` | `false` | flag | Supplemental Production Set generation |
+| `--prior-manifest` | none | comma-separated paths | Paths to prior production `_manifest.json` files |
+| `--supplemental-gap-policy` | `reject` | `reject`, `allow` | Gap validation policy for supplemental sets |
+| `--compare-production-manifests` | none | comma-separated paths | Compare Production Set manifests |
+| `--comparison-mode` | none | `replacement`, `supplemental`, `reproduction` | Production Manifest comparison ruleset |
+| `--comparison-output` | none | file path | Report JSON output path |
+| `--hash-mode` | none | `actual`, `simulated`, `none` | Document hash computation mode |
+| `--hash-algorithms` | `md5` | `md5`, `sha1`, `sha256` | Comma-separated hash algorithms |
+| `--benchmark` | `false` | flag | Run performance benchmark suite and exit |
+| `--version` | `false` | flag | Print version string and exit |
 
-For complete argument interactions, delimiter options, Chaos Engine flags, and audit schemas, see the [Advanced CLI & Reference Guide](docs/advanced-guide.md).
+For in-depth explanations, delimiter syntax, argument interaction rules, and audit schemas, see the [Advanced CLI & Reference Guide](docs/advanced-guide.md).
 
 ---
 
 ## Performance & Benchmarks
 
-Zipper utilizes multi-threaded parallel generation, object memory pooling, and streaming buffered I/O to achieve high throughput:
+Zipper utilizes multi-threaded parallel generation, object memory pooling, and streaming buffered I/O to achieve high throughput across Windows, macOS, and Linux:
 
 | File Count | Typical Time | Files / Second |
 |------------|--------------|----------------|
@@ -110,15 +165,15 @@ zipper --benchmark
 ## Contributing & Developer Setup
 
 We welcome contributions! Please see our [Contributing Guide](docs/contributing.md) for instructions on:
-- Setting up the development environment
-- Running unit, analyzer, and E2E smoke tests
+- Setting up the development environment on Windows, macOS, or Linux
+- Running unit, analyzer, and E2E smoke tests across platforms
 - Architectural invariants and critical principles (`AGENTS.md`)
 
 ---
 
 ## Documentation Index
 
-- [Contributing Guide](docs/contributing.md) — Build, test, and developer workflow
+- [Contributing Guide](docs/contributing.md) — Build, test, and developer workflow (Windows, macOS, Linux)
 - [Advanced CLI & Reference Guide](docs/advanced-guide.md) — Complete flag reference, Chaos Engine, delimiter tuning, and schemas
 - [Architecture Specifications](docs/architecture.md) — Core system design, seams, and pipeline architecture
 - [Requirements & Specifications](Requirements.md) — Immutable functional requirement definitions (`REQ-XXX`)

--- a/docs/advanced-guide.md
+++ b/docs/advanced-guide.md
@@ -136,12 +136,50 @@ Written at the root of Production Sets. Records Bates ranges, volume layout, loa
 
 ## 3. Argument Interactions Reference
 
+> [!IMPORTANT]
+> Some arguments have dependencies or conflicts. Review these rules when combining options.
+
 | Interaction | Behavior |
 |-------------|----------|
 | `--column-profile` + `--with-metadata` | Column profile takes precedence; `--with-metadata` is ignored with a warning |
 | `--column-profile` + `--production-set` | **Conflict**: `--column-profile` is not supported with `--production-set` |
-| `--types` | Mutually exclusive with `--type`, `--loadfile-only`, and `--column-profile` |
-| `--input-csv` / `--directory-template` | Mutually exclusive with each other and with `--type`/`--types`. Requires no `--count` (or `--count` matching source record count) |
-| `--chaos-mode` | Requires `--loadfile-only` and `dat`/`opt` format |
+| `--column-profile` + `--with-collection-metadata` | Collection metadata columns are merged into the profile; profile values take precedence with synthetic fallback |
+| `--with-collection-metadata` + `--with-metadata` | Both add their own disjoint column sets; no conflict |
+| `--with-collection-metadata` + Production Set | Silently ignored (no columns added) |
+| `--with-collection-metadata` + `--loadfile-only` (no `--column-profile`) | Silently ignored (no columns added) |
+| `--with-collection-metadata` + OPT or EDRM-XML | Silently ignored (not applicable to these formats) |
+| `--target-zip-size` | Requires `--count` or source input (`--input-csv` / `--directory-template`) |
+| `--types` | Mutually exclusive with `--type`, `--loadfile-only`, and `--column-profile`. Weights must be positive integers (max 1,000,000 each). When `jpg` or `tiff` participate, DAT+OPT are the default formats. Standard-mode Load Files gain a File Type column; Production Set DAT writes FILE_TYPE per record. Email Metadata columns apply only to Email records; Page Count applies only to TIFF records |
+| `--input-csv` / `--directory-template` | Mutually exclusive with each other and with `--type` and `--types`. Satisfies the `--type` requirement; `--count` becomes optional but must match the Source Record count when given. Multiple source File Types behave like a File Type Mix (File Type column, per-record Email Metadata and Page Count gating, DAT+OPT default when `jpg`/`tiff` participate). `ControlNumber`/`BatesNumber` columns override per-record identity (BatesNumber requires `--bates-prefix`); extra columns map through `--column-profile` (DAT, Standard and Loadfile-Only modes). With `--production-set`, the `BatesNumber` column is rejected, identity stays Bates-based, and `--source-path-mode` controls Native File placement. In Standard mode `--folders` and `--distribution` are ignored (source paths define the structure) |
+| `--source-path-mode` | Requires `--production-set` and source input (`--input-csv` / `--directory-template`) |
+| `--attachment-rate` | Only meaningful when `--type eml` (Email File Type) or when `eml` participates in `--types` |
+| `--with-families` | Only meaningful when `--type eml` (or `eml` participates in `--types`) and `--attachment-rate > 0` (emits a soft warning to stderr otherwise) |
+| `--tiff-pages` | Only meaningful when `--type tiff` or when `tiff` participates in `--types` |
+| `--bates-start`, `--bates-digits` | Only meaningful when `--bates-prefix` is specified |
+| `--date-format`, `--empty-percentage`, `--custodian-count` | Only meaningful when `--column-profile` is specified |
+| `--load-file-formats` vs `--load-file-format` | Multi-format list takes precedence over single format |
+| `--include-load-file` + `--load-file-formats` | All specified formats are included in the ZIP |
+| `--delimiter-*` + `--dat-delimiters` | Specific delimiter flags override the preset for that delimiter only |
+| Strict-prefix `--col-delim`/`--quote-delim`/etc. + old-style flags or preset | Strict-prefix arguments win per delimiter; full chain: defaults → `--dat-delimiters` preset → `--delimiter-*` → strict-prefix. Preset and old-style flags are DAT-only; strict-prefix work in all generation modes but affect only DAT output |
+| `--load-file-format csv` vs `--dat-delimiters csv` | Distinct: former selects a true `.csv` (RFC 4180) writer; latter only swaps a `.dat` file's delimiters to comma/quote |
+| `--hash-algorithms` | Requires `--hash-mode` to be `actual` or `simulated` |
+| `--hash-mode actual` + `--loadfile-only` | **Conflict**: cannot compute actual hashes without generated Native Files |
+| `--loadfile-only` + `--target-zip-size` | **Conflict**: cannot use both |
+| `--loadfile-only` + `--include-load-file` | **Conflict**: cannot use both |
+| `--col-delim`, `--quote-delim`, etc. | Use `ascii:N` or `char:C` prefix (works in all modes) |
+| `--chaos-mode` | Requires `--loadfile-only` |
+| `--chaos-mode` + `--production-set` | **Conflict**: chaos requires `--loadfile-only` |
+| `--chaos-amount`, `--chaos-types` | Require `--chaos-mode` |
+| `--chaos-scenario` | Requires `--chaos-mode`; conflicts with `--chaos-types` |
+| `--chaos-scenario` + format | Some scenarios require specific `--loadfile-format` (e.g., `broken-boundaries` requires `opt`) |
 | `--production-set` | Requires `--bates-prefix`; conflicts with `--loadfile-only` |
-| `--redacted-production` | Requires `--production-set`; text placeholders require `--with-text` |
+| `--redacted-production` | Requires `--production-set`; conflicts with `--loadfile-only`. Redacted text files are only written when `--with-text` is enabled; without it, `REDACTED_TEXT_PATH` is empty in the Load File. |
+| `--withheld-native-policy` | Requires `--redacted-production` |
+| `--production-set` + `--load-file-format / --load-file-formats` | Ignored. Production Set always generates DAT+OPT regardless. |
+| `--production-zip`, `--volume-size` | Require `--production-set` |
+| `--supplemental-production` | Requires `--production-set` and `--prior-manifest` |
+| `--prior-manifest`, `--supplemental-gap-policy` | Require `--supplemental-production` |
+| `--rolling-count`, `--rolling-bates-mode`, `--production-id` | Require `--production-set` |
+| `--compare-production-manifests` | Requires `--comparison-mode` and `--comparison-output`. Bypasses normal file generation and validation. |
+| `--comparison-mode`, `--comparison-output` | Require `--compare-production-manifests` |
+| `--with-families` + non-dat format | Supported. Generates parent-child columns/relationships in CSV, Concordance, and EDRM-XML. |


### PR DESCRIPTION
Comprehensively audits all 56 CLI flags parsed in `CliParser.cs` against the documentation. Adds explicit cross-platform usage commands for Windows (`zipper.exe` on Command Prompt/PowerShell) and Linux/macOS, and restores the full 56-parameter Arguments Quick Reference table in `README.md`.

## Release Notes
Restored complete 56-parameter Arguments Quick Reference table in README.md and added explicit Windows, macOS, and Linux CLI examples.