### PR TITLE
refactor: extract Load File orchestration from ZipArchiveSink (#748)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,7 @@ See [CI.md](CI.md) for SonarCloud, CodeRabbit, CodeQL, and golden file procedure
 | `src/StandardMode.cs` / `LoadFileOnlyMode.cs` / `ProductionSetMode.cs` | Three generation mode adapters |
 | `src/IFileGenerator.cs` / `FileGeneratorFactory.cs` | File generator interface + factory |
 | `src/ParallelFileGenerator.cs` | Standard mode file generation pipeline |
-| `src/IArchiveSink.cs` / `src/ZipArchiveSink.cs` | Archive creation + Load File writing (Standard mode consumer) |
+| `src/IArchiveSink.cs` / `src/ZipArchiveSink.cs` | Archive creation (Standard mode consumer); Load File emission delegated to `LoadFileOrchestrator` |
 | `src/LoadFileOnlyGenerator.cs` | Standalone Load File generation |
 | `src/ProductionSetGenerator.cs` | Production Set directory tree + Load Files |
 | `src/ChaosEngine.cs` | Chaos anomaly injection |
@@ -348,7 +348,7 @@ See [CI.md](CI.md) for SonarCloud, CodeRabbit, CodeQL, and golden file procedure
 | `src/LoadFiles/LoadFileEmitter.cs` | I/O + chaos authority: preamble, EOL, batching, chaos pipeline |
 | `src/Profiles/Generation/` | Column value generators |
 | `src/Emails/` | Email domain model |
-| `src/LoadFiles/` | Load File seam: composers, serializers, emitter, thin composing writers + `XmlLoadFileWriter` carve-out |
+| `src/LoadFiles/` | Load File seam: composers, serializers, emitter, thin composing writers + `XmlLoadFileWriter` carve-out; `LoadFileOrchestrator` owns format dispatch for Standard + Production Set modes |
 | `src/Profiles/` | Column profile system (loader, data generator, built-ins) |
 | `src/Config/` | Nested request config records (`OutputConfig`, `MetadataConfig`, `LoadFileConfig`, `DelimiterConfig`, `BatesNumberConfig`, `TiffConfig`, `ChaosConfig`, `ProductionConfig`, `HashConfig`) + `HashUtility` |
 | `src/Validation/` | Post-generation / Production Set / supplemental validators (`PostGenerationValidator`, `ValidatorRunner`, `ProductionSetPostValidator`, `SupplementalValidator`) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ The diagrams in this file are a **contract**, not just documentation:
 
 1. **Work channel**: Produces `FileWorkItem` objects using the configured distribution algorithm. In Source-Driven Generation (`--input-csv` / `--directory-template`), the work items instead come one-to-one from the Source Records, carrying the source-relative path, File Type, and identity overrides. Bounded channel provides backpressure.
 2. **Generation**: N concurrent producers generate file data and write to result channel. All file types run in parallel. In a File Type Mix run (`--types`), each `FileWorkItem` carries its own File Type from the `FileTypePlan` and producers route to the matching per-type generator; single-type runs resolve to one generator as before.
-3. **Archive writing**: Single consumer (`ZipArchiveSink`, implementing `IArchiveSink`) writes ZIP entries, then writes Load Files through the composer → serializer → emitter seam (selected via `ILoadFileWriter`; see [Load File Composition Seam](#load-file-composition-seam)).
+3. **Archive writing**: Single consumer (`ZipArchiveSink`, implementing `IArchiveSink`) writes ZIP entries, then delegates Load File emission to `LoadFileOrchestrator`, which drives the composer → serializer → emitter seam (selected via `ILoadFileWriter`; see [Load File Composition Seam](#load-file-composition-seam)).
 4. **Deadlock protection**: `Task.WhenAny` races consumer with producers; if consumer faults, result channel is completed with its exception to unblock producers.
 
 ## Chaos Engine (Loadfile-Only Mode only)
@@ -49,7 +49,8 @@ graph TD
     PFG -->|"Work Channel"| Producers["N Concurrent Producers"]
     Producers -->|"Result Channel"| ZAS["ZipArchiveSink (Consumer)"]
     ZAS --> ZIP["ZIP Archive"]
-    ZAS --> LF1["Load Files (all formats)"]
+    ZAS --> LFO["LoadFileOrchestrator<br/>(format dispatch)"]
+    LFO --> LF1["Load Files (all formats)"]
 
     LoadFileOnlyMode --> LOG["LoadFileOnlyGenerator"]
     LOG --> LF2["Load Files (DAT/OPT)"]
@@ -59,7 +60,8 @@ graph TD
     ProductionSetMode --> PSG["ProductionSetGenerator"]
     PSG --> PSP["ProductionSetPlanner (no I/O)"]
     PSP --> Tree["Directory Tree (NATIVES/IMAGES/DATA/TEXT; ORIGINALS in source-path-mode originals)"]
-    PSG --> LF3["Load Files + Manifest"]
+    PSG --> LFO
+    LFO --> LF3["Load Files + Manifest"]
 ```
 
 ## Component Map
@@ -103,11 +105,13 @@ graph LR
     end
 
     subgraph Load File Seam
+        LFO["LoadFileOrchestrator<br/>(format dispatch)"]
         Factory["LoadFileWriterFactory"]
         Composer["Composer<br/>(Dat/Opt/Csv/Concordance)"]
         Serializer["Serializer<br/>(Dat/Opt/Csv/Concordance)"]
         Emitter["LoadFileEmitter<br/>(preamble/EOL/chaos)"]
         XMLW["XmlLoadFileWriter<br/>(carve-out)"]
+        LFO --> Factory
         Factory --> Composer --> Serializer --> Emitter
         Factory --> XMLW
     end
@@ -155,7 +159,7 @@ Each mode adapter runs `PostGenerationValidator.Validate(ValidationContext)` aft
 
 ## Load File Composition Seam
 
-The four delimited formats (DAT, OPT, CSV, Concordance) are produced by three deep modules; EDRM-XML is the carve-out. See the [Architecture Invariants](#architecture-invariants-human-approval-required) — this shape must not be collapsed back into fat writers without human approval.
+The four delimited formats (DAT, OPT, CSV, Concordance) are produced by three deep modules; EDRM-XML is the carve-out. `LoadFileOrchestrator` is the single owner of format dispatch for Standard and Production Set modes — for each requested format it creates the writer, opens the output stream (ZIP entry or disk file), writes, and emits the Audit File. ZipArchiveSink (Standard mode) and ProductionSetGenerator (Production Set mode) both delegate to it; Loadfile-Only Mode keeps its own loop because it applies chaos per format. See the [Architecture Invariants](#architecture-invariants-human-approval-required) — the composer/serializer/emitter shape must not be collapsed back into fat writers without human approval.
 
 - **Composer** (`ILoadFileComposer`) — column authority: header columns + lazy `LoadFileRecord`s with raw values held as parallel arrays aligned by index (handles modes + column profiles internally).
 - **Serializer** (`ILoadFileSerializer`) — render authority: record/header → one escaped line. Pure (no stream, EOL, or chaos).
@@ -164,7 +168,8 @@ The four delimited formats (DAT, OPT, CSV, Concordance) are produced by three de
 ```mermaid
 graph TD
     Req["FileGenerationRequest + processedFiles"]
-    Req --> Factory["LoadFileWriterFactory.CreateWriter(format, mode)"]
+    Req --> LFO["LoadFileOrchestrator<br/>(format dispatch; stream target via caller)"]
+    LFO --> Factory["LoadFileWriterFactory.CreateWriter(format, mode)"]
     Factory -->|"DAT / OPT / CSV / Concordance"| CW["Composing Writer<br/>(thin ILoadFileWriter)"]
     Factory -->|"EDRM-XML"| XML["XmlLoadFileWriter<br/>(carve-out: hierarchical tree)"]
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ graph TD
     Producers -->|"Result Channel"| ZAS["ZipArchiveSink (Consumer)"]
     ZAS --> ZIP["ZIP Archive"]
     ZAS --> LFO["LoadFileOrchestrator<br/>(format dispatch)"]
-    LFO --> LF1["Load Files (all formats)"]
+    LFO --> LF1["Load Files + Audit Files"]
 
     LoadFileOnlyMode --> LOG["LoadFileOnlyGenerator"]
     LOG --> LF2["Load Files (DAT/OPT)"]
@@ -61,7 +61,8 @@ graph TD
     PSG --> PSP["ProductionSetPlanner (no I/O)"]
     PSP --> Tree["Directory Tree (NATIVES/IMAGES/DATA/TEXT; ORIGINALS in source-path-mode originals)"]
     PSG --> LFO
-    LFO --> LF3["Load Files + Manifest"]
+    LFO --> LF3["Load Files + Audit Files"]
+    PSG --> Manifest["Production Manifest"]
 ```
 
 ## Component Map

--- a/src/LoadFiles/LoadFileOrchestrator.cs
+++ b/src/LoadFiles/LoadFileOrchestrator.cs
@@ -44,12 +44,14 @@ internal static class LoadFileOrchestrator
                 await writer.WriteAsync(loadFileStream, request, processedFiles, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             var auditJson = LoadFileAuditWriter.GenerateAuditJson(loadFileTarget, request, processedFiles, null, format);
             var auditStream = openTarget(auditTarget);
             await using (auditStream.ConfigureAwait(false))
             {
                 using var auditWriter = new System.IO.StreamWriter(auditStream);
-                await auditWriter.WriteAsync(auditJson).ConfigureAwait(false);
+                await auditWriter.WriteAsync(auditJson.AsMemory(), cancellationToken).ConfigureAwait(false);
             }
 
             lastLoadFileTarget = loadFileTarget;

--- a/src/LoadFiles/LoadFileOrchestrator.cs
+++ b/src/LoadFiles/LoadFileOrchestrator.cs
@@ -1,0 +1,60 @@
+namespace Zipper.LoadFiles;
+
+/// <summary>
+/// Single owner of Load File format dispatch for Standard and Production Set modes: for
+/// every requested format it creates the writer, opens the output stream, writes the Load
+/// File, then emits the Audit File. ZipArchiveSink (entries inside the ZIP or next to it)
+/// and ProductionSetGenerator (files on disk) both delegate here so "which formats to write
+/// and how to invoke writers" has exactly one code path, preserving the
+/// composer → serializer → emitter seam behind ILoadFileWriter. Loadfile-Only Mode keeps
+/// its own loop because it applies chaos per format.
+/// </summary>
+internal static class LoadFileOrchestrator
+{
+    /// <summary>
+    /// Emits each format in <paramref name="formats"/> plus its Audit File.
+    /// </summary>
+    /// <param name="request">File generation request parameters.</param>
+    /// <param name="processedFiles">Generated file data consumed by the Load File writers.</param>
+    /// <param name="formats">Load File formats to emit, in order.</param>
+    /// <param name="mode">Writer mode (Standard or Production Set).</param>
+    /// <param name="getTargets">Resolves the Load File and audit targets for a format (target naming is a caller quirk).</param>
+    /// <param name="openTarget">Opens the output stream for a target (ZIP entry or disk file).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The target of the last emitted Load File.</returns>
+    public static async Task<string> EmitAllAsync(
+        FileGenerationRequest request,
+        System.Collections.Generic.IReadOnlyList<FileData> processedFiles,
+        System.Collections.Generic.IReadOnlyList<LoadFileFormat> formats,
+        WriterMode mode,
+        Func<LoadFileFormat, ILoadFileWriter, (string LoadFileTarget, string AuditTarget)> getTargets,
+        Func<string, System.IO.Stream> openTarget,
+        CancellationToken cancellationToken = default)
+    {
+        string lastLoadFileTarget = string.Empty;
+
+        foreach (var format in formats)
+        {
+            var writer = LoadFileWriterFactory.CreateWriter(format, mode);
+            var (loadFileTarget, auditTarget) = getTargets(format, writer);
+
+            var loadFileStream = openTarget(loadFileTarget);
+            await using (loadFileStream.ConfigureAwait(false))
+            {
+                await writer.WriteAsync(loadFileStream, request, processedFiles, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            var auditJson = LoadFileAuditWriter.GenerateAuditJson(loadFileTarget, request, processedFiles, null, format);
+            var auditStream = openTarget(auditTarget);
+            await using (auditStream.ConfigureAwait(false))
+            {
+                using var auditWriter = new System.IO.StreamWriter(auditStream);
+                await auditWriter.WriteAsync(auditJson).ConfigureAwait(false);
+            }
+
+            lastLoadFileTarget = loadFileTarget;
+        }
+
+        return lastLoadFileTarget;
+    }
+}

--- a/src/ProductionSetGenerator.cs
+++ b/src/ProductionSetGenerator.cs
@@ -422,31 +422,26 @@ internal static class ProductionSetGenerator
 
         Console.WriteLine();
 
-        // Write DAT load file — build a fresh ChaosEngine per format (engines are stateful)
+        // Write DAT + OPT load files and their audits through the shared orchestrator
+        // (single owner of Load File format dispatch; writers are created per format).
+        await LoadFiles.LoadFileOrchestrator.EmitAllAsync(
+            request,
+            fileDataList,
+            new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt },
+            LoadFiles.WriterMode.ProductionSet,
+            (format, writer) =>
+            {
+                var loadTarget = Path.Combine(dataDir, "loadfile" + writer.FileExtension);
+                var auditTarget = format == LoadFileFormat.Dat
+                    ? Path.Combine(dataDir, "loadfile_properties.json")
+                    : loadTarget + "_properties.json";
+                return (loadTarget, auditTarget);
+            },
+            target => new FileStream(target, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true),
+            cancellationToken).ConfigureAwait(false);
+
         var datPath = Path.Combine(dataDir, "loadfile.dat");
-        var datWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Dat, LoadFiles.WriterMode.ProductionSet);
-        var datStream = new FileStream(datPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
-        await using (datStream.ConfigureAwait(false))
-        {
-            await datWriter.WriteAsync(datStream, request, fileDataList, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        var datAuditJson = LoadFileAuditWriter.GenerateAuditJson(datPath, request, fileDataList, null, LoadFileFormat.Dat);
-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile_properties.json"), datAuditJson).ConfigureAwait(false);
-
-        // Write OPT load file
         var optPath = Path.Combine(dataDir, "loadfile.opt");
-        var optWriter = LoadFiles.LoadFileWriterFactory.CreateWriter(LoadFileFormat.Opt, LoadFiles.WriterMode.ProductionSet);
-        var optStream = new FileStream(optPath, FileMode.Create, FileAccess.Write, FileShare.None, PerformanceConstants.DefaultBufferSize, true);
-        await using (optStream.ConfigureAwait(false))
-        {
-            await optWriter.WriteAsync(optStream, request, fileDataList, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        var optAuditJson = LoadFileAuditWriter.GenerateAuditJson(optPath, request, fileDataList, null, LoadFileFormat.Opt);
-
-        // Save OPT properties with a slightly different name to avoid overwriting DAT properties
-        await File.WriteAllTextAsync(Path.Combine(dataDir, "loadfile.opt_properties.json"), optAuditJson).ConfigureAwait(false);
 
         // Write manifest
         var batesStart = plans[0].BatesNumber;

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -52,17 +52,31 @@ internal class ZipArchiveSink : IArchiveSink
             ? request.LoadFile.Formats
             : new List<LoadFileFormat> { LoadFileFormat.Dat };
 
-        string actualLoadFilePath = loadFilePath;
         var baseFileName = Path.GetFileNameWithoutExtension(loadFileName);
         var baseFilePath = Path.GetDirectoryName(loadFilePath) ?? string.Empty;
 
-        foreach (var format in formatsToGenerate)
-        {
-            actualLoadFilePath = await GenerateLoadFileAndAuditAsync(
-                archive, request, processedFiles, format, baseFileName, baseFilePath).ConfigureAwait(false);
-        }
+        // Load Files land inside the ZIP (IncludeLoadFile) or next to it on disk; the
+        // orchestrator owns the per-format write + audit loop in either case.
+        Func<string, Stream> openTarget = request.Output.IncludeLoadFile
+            ? target => archive.CreateEntry(target, CompressionLevel.Optimal).Open()
+            : target => new FileStream(Path.Combine(baseFilePath, target), FileMode.Create);
 
-        return actualLoadFilePath;
+        var actualLoadFileTarget = await LoadFileOrchestrator.EmitAllAsync(
+            request,
+            processedFiles,
+            formatsToGenerate,
+            WriterMode.Standard,
+            (format, writer) =>
+            {
+                var actualLoadFileName = baseFileName + writer.FileExtension;
+                return (actualLoadFileName, actualLoadFileName + "_properties.json");
+            },
+            openTarget,
+            cancellationToken).ConfigureAwait(false);
+
+        return request.Output.IncludeLoadFile
+            ? actualLoadFileTarget
+            : Path.Combine(baseFilePath, actualLoadFileTarget);
     }
 
     private async Task DrainReaderAndOrderFilesAsync(
@@ -110,82 +124,6 @@ internal class ZipArchiveSink : IArchiveSink
         {
             leftover.MemoryOwner?.Dispose();
         }
-    }
-
-    private async Task<string> GenerateLoadFileAndAuditAsync(
-        ZipArchive archive,
-        FileGenerationRequest request,
-        DiskBackedFileDataList processedFiles,
-        LoadFileFormat format,
-        string baseFileName,
-        string baseFilePath)
-    {
-        var loadFileWriter = LoadFileWriterFactory.CreateWriter(format);
-        var actualLoadFileName = baseFileName + loadFileWriter.FileExtension;
-
-        if (request.Output.IncludeLoadFile)
-        {
-            await GenerateLoadFileToArchiveAsync(archive, request, processedFiles, loadFileWriter, actualLoadFileName).ConfigureAwait(false);
-            await EmitAuditToArchiveAsync(archive, request, processedFiles, format, actualLoadFileName).ConfigureAwait(false);
-            return actualLoadFileName;
-        }
-        else
-        {
-            var currentFilePath = Path.Combine(baseFilePath, actualLoadFileName);
-            await GenerateLoadFileToDiskAsync(request, processedFiles, loadFileWriter, currentFilePath).ConfigureAwait(false);
-            await EmitAuditToDiskAsync(request, processedFiles, format, currentFilePath).ConfigureAwait(false);
-            return currentFilePath;
-        }
-    }
-
-    private async Task GenerateLoadFileToArchiveAsync(
-        ZipArchive archive,
-        FileGenerationRequest request,
-        DiskBackedFileDataList processedFiles,
-        ILoadFileWriter loadFileWriter,
-        string actualLoadFileName)
-    {
-        var loadFileEntry = archive.CreateEntry(actualLoadFileName, CompressionLevel.Optimal);
-        using var loadFileStream = loadFileEntry.Open();
-        await loadFileWriter.WriteAsync(loadFileStream, request, processedFiles).ConfigureAwait(false);
-    }
-
-    private async Task GenerateLoadFileToDiskAsync(
-        FileGenerationRequest request,
-        DiskBackedFileDataList processedFiles,
-        ILoadFileWriter loadFileWriter,
-        string currentFilePath)
-    {
-        var fileStream = new FileStream(currentFilePath, FileMode.Create);
-        await using (fileStream.ConfigureAwait(false))
-        {
-            await loadFileWriter.WriteAsync(fileStream, request, processedFiles).ConfigureAwait(false);
-            await fileStream.FlushAsync().ConfigureAwait(false);
-        }
-    }
-
-    private async Task EmitAuditToArchiveAsync(
-        ZipArchive archive,
-        FileGenerationRequest request,
-        DiskBackedFileDataList processedFiles,
-        LoadFileFormat format,
-        string actualLoadFileName)
-    {
-        var auditJson = LoadFileAuditWriter.GenerateAuditJson(actualLoadFileName, request, processedFiles, null, format);
-        var propertiesEntry = archive.CreateEntry(actualLoadFileName + "_properties.json", CompressionLevel.Optimal);
-        using var propertiesStream = propertiesEntry.Open();
-        using var propertiesWriter = new StreamWriter(propertiesStream);
-        await propertiesWriter.WriteAsync(auditJson).ConfigureAwait(false);
-    }
-
-    private async Task EmitAuditToDiskAsync(
-        FileGenerationRequest request,
-        DiskBackedFileDataList processedFiles,
-        LoadFileFormat format,
-        string currentFilePath)
-    {
-        var auditJson = LoadFileAuditWriter.GenerateAuditJson(currentFilePath, request, processedFiles, null, format);
-        await File.WriteAllTextAsync(currentFilePath + "_properties.json", auditJson).ConfigureAwait(false);
     }
 
     private static void ProcessFileData(ZipArchive archive, FileData fileData, FileGenerationRequest request, byte[]? standardTextContent, byte[]? emlTextContent, HashSet<string> usedEntryPaths, DiskBackedFileDataList processedFiles)

--- a/src/ZipArchiveSink.cs
+++ b/src/ZipArchiveSink.cs
@@ -57,6 +57,8 @@ internal class ZipArchiveSink : IArchiveSink
 
         // Load Files land inside the ZIP (IncludeLoadFile) or next to it on disk; the
         // orchestrator owns the per-format write + audit loop in either case.
+        // CancellationToken.None: prior behavior, this phase was non-cancellable, so a
+        // cancellation cannot leave partial DAT/OPT sidecars behind in the output dir.
         Func<string, Stream> openTarget = request.Output.IncludeLoadFile
             ? target => archive.CreateEntry(target, CompressionLevel.Optimal).Open()
             : target => new FileStream(Path.Combine(baseFilePath, target), FileMode.Create);
@@ -72,7 +74,7 @@ internal class ZipArchiveSink : IArchiveSink
                 return (actualLoadFileName, actualLoadFileName + "_properties.json");
             },
             openTarget,
-            cancellationToken).ConfigureAwait(false);
+            CancellationToken.None).ConfigureAwait(false);
 
         return request.Output.IncludeLoadFile
             ? actualLoadFileTarget

--- a/src/Zipper.Tests/LoadFiles/LoadFileOrchestratorTests.cs
+++ b/src/Zipper.Tests/LoadFiles/LoadFileOrchestratorTests.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using Xunit;
+
+using Zipper.Config;
+using Zipper.LoadFiles;
+
+namespace Zipper.Tests.LoadFiles;
+
+public class LoadFileOrchestratorTests
+{
+    [Fact]
+    public async Task EmitAllAsync_MultipleFormats_WritesLoadFileAndAuditPerFormat()
+    {
+        // Arrange
+        var request = new FileGenerationRequest
+        {
+            Output = new OutputConfig
+            {
+                FileType = "pdf",
+                FileCount = 3,
+                Concurrency = 1,
+            },
+        };
+
+        var processedFiles = new List<FileData>();
+        for (int i = 1; i <= 3; i++)
+        {
+            processedFiles.Add(new FileData
+            {
+                WorkItem = new FileWorkItem
+                {
+                    Index = i,
+                    FileName = $"test{i}.pdf",
+                    FilePathInZip = $"folder{1}/test{i}.pdf",
+                    FolderName = "folder1",
+                    FolderNumber = 1,
+                },
+                Data = Encoding.UTF8.GetBytes($"Test content {i}"),
+                MemoryOwner = null,
+            });
+        }
+
+        var streams = new Dictionary<string, MemoryStream>(StringComparer.Ordinal);
+        var formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Csv };
+
+        // Act
+        var lastTarget = await LoadFileOrchestrator.EmitAllAsync(
+            request,
+            processedFiles,
+            formats,
+            WriterMode.Standard,
+            (format, writer) => (writer.FileExtension, writer.FileExtension + "_audit.json"),
+            target =>
+            {
+                var stream = new NonDisposingStream();
+                streams[target] = stream;
+                return stream;
+            });
+
+        // Assert — one Load File + one audit sidecar per format
+        Assert.Equal(".csv", lastTarget);
+        Assert.Equal(4, streams.Count);
+        Assert.Contains(".dat", streams.Keys);
+        Assert.Contains(".dat_audit.json", streams.Keys);
+        Assert.Contains(".csv", streams.Keys);
+        Assert.Contains(".csv_audit.json", streams.Keys);
+
+        var datLines = ReadLines(streams[".dat"]);
+        Assert.Equal(4, datLines.Length); // Header + 3 rows
+
+        var auditJson = ReadText(streams[".dat_audit.json"]);
+        using var doc = System.Text.Json.JsonDocument.Parse(auditJson);
+        Assert.Equal(3, doc.RootElement.GetProperty("totalRecords").GetInt64());
+
+        // Audit Files are UTF-8 without a BOM (matches File.WriteAllTextAsync semantics)
+        var auditBytes = streams[".dat_audit.json"].ToArray();
+        Assert.False(auditBytes.Length >= 3 && auditBytes[0] == 0xEF && auditBytes[1] == 0xBB && auditBytes[2] == 0xBF);
+    }
+
+    private static string[] ReadLines(MemoryStream stream)
+        => ReadText(stream).Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+    private static string ReadText(MemoryStream stream)
+    {
+        stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+        return reader.ReadToEnd();
+    }
+
+    private sealed class NonDisposingStream : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            // The orchestrator disposes output streams it opens; keep the backing
+            // MemoryStream readable so the test can assert on the written bytes.
+        }
+    }
+}

--- a/src/Zipper.Tests/ZipArchiveServiceTests.cs
+++ b/src/Zipper.Tests/ZipArchiveServiceTests.cs
@@ -237,6 +237,96 @@ public class ZipArchiveServiceTests
         Assert.NotNull(loadEntry);
     }
 
+    [Fact]
+    public async Task CreateArchiveAsync_LoadFileIncluded_ReturnsLastFormatEntryName()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var zipPath = Path.Combine(tempDir, "test.zip");
+            var loadPath = Path.Combine(tempDir, "load.dat");
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    FileType = "pdf",
+                    FileCount = 2,
+                    Concurrency = 1,
+                    IncludeLoadFile = true,
+                },
+                LoadFile = new LoadFileConfig { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt } },
+            };
+
+            var channel = Channel.CreateUnbounded<FileData>();
+            for (int i = 1; i <= 2; i++)
+            {
+                await channel.Writer.WriteAsync(this.CreateTestFileData(i));
+            }
+
+            channel.Writer.Complete();
+
+            // Act
+            var actualLoadFilePath = await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+
+            // Assert — in-ZIP mode returns the last format's entry name (not a full path)
+            Assert.Equal("load.opt", actualLoadFilePath);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CreateArchiveAsync_LoadFileToDisk_ReturnsLastFormatFullPath()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var zipPath = Path.Combine(tempDir, "test.zip");
+            var loadPath = Path.Combine(tempDir, "load.dat");
+            var request = new FileGenerationRequest
+            {
+                Output = new OutputConfig
+                {
+                    FileType = "pdf",
+                    FileCount = 2,
+                    Concurrency = 1,
+                    IncludeLoadFile = false,
+                },
+                LoadFile = new LoadFileConfig { Formats = new List<LoadFileFormat> { LoadFileFormat.Dat, LoadFileFormat.Opt } },
+            };
+
+            var channel = Channel.CreateUnbounded<FileData>();
+            for (int i = 1; i <= 2; i++)
+            {
+                await channel.Writer.WriteAsync(this.CreateTestFileData(i));
+            }
+
+            channel.Writer.Complete();
+
+            // Act
+            var actualLoadFilePath = await new ZipArchiveSink().CreateArchiveAsync(zipPath, "load.dat", loadPath, request, channel.Reader);
+
+            // Assert — disk mode returns the last format's full path
+            Assert.Equal(Path.Combine(tempDir, "load.opt"), actualLoadFilePath);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
     private FileData CreateTestFileData(int index)
     {
         return new FileData


### PR DESCRIPTION
## Release Notes
Extracted a new LoadFileOrchestrator that owns Load File format dispatch (create writer, open stream, write, emit Audit File) for both Standard and Production Set modes. ZipArchiveSink and ProductionSetGenerator now share one code path for writing Load Files, removing duplicated format dispatch while preserving byte-for-byte output parity. No user-visible behavior change; cancellation semantics are unchanged in every mode.

## Description

Fixes #748. `ZipArchiveSink` previously did two jobs: ZIP entry writing and Load File/Audit orchestration. This PR extracts the latter into `LoadFileOrchestrator` (`src/LoadFiles/LoadFileOrchestrator.cs`), the single owner of the "for each format, create writer, open stream, write, write audit" loop. `ZipArchiveSink` now delegates for both in-ZIP and on-disk emission; `ProductionSetGenerator` routes DAT + OPT through the same path (preserving the `loadfile_properties.json` vs `loadfile.opt_properties.json` naming quirks).

- Preserves the `composer -> serializer -> emitter` seam (ADR-0007) and the three-mode pipeline (ADR-0006): the orchestrator dispatches only through `LoadFileWriterFactory` / `ILoadFileWriter`. Loadfile-Only Mode keeps its own loop (chaos per format, stable page counts, cleanup).
- Byte-for-byte parity proven by the seeded golden suite (20/20) plus full unit + E2E suites.
- Adds `LoadFileOrchestratorTests` (real writers/audit via in-memory streams, no mocks) and return-value regression tests for the sink's last-format entry-name/full-path contract.
- `docs/architecture.md` diagrams and `AGENTS.md` structure rows updated to show the orchestrator.

## Type of Change

- [x] Refactor

## Testing Done

- [x] Unit tests pass (1638/1638 + 44 analyzer tests)
- [x] E2E tests pass (run-e2e-basic 6/6, test-load-file-formats, test-production-sets, test-argument-interactions 41/41, test-unified-workflow; goldens 20/20 byte parity)
- [x] Lint clean

## Architecture

- [x] No deviation from the architecture diagrams - `docs/architecture.md` updated in this PR to add the `LoadFileOrchestrator` node.

## Affected Requirements

None - refactor only; no REQ/FR behavior change (verified via golden byte parity).
