### PR TITLE
refactor: migrate StandardRowValues 28-case switch to IColumnValueGenerator registry

### DIFF
--- a/src/LoadFiles/DatStandardComposer.cs
+++ b/src/LoadFiles/DatStandardComposer.cs
@@ -1,4 +1,5 @@
 using Zipper.Profiles;
+using Zipper.Profiles.Generation;
 
 namespace Zipper.LoadFiles;
 
@@ -14,6 +15,7 @@ internal sealed class DatStandardComposer
     private readonly IReadOnlyList<string> headerColumns;
     private readonly DataGenerator? profileGenerator;
     private readonly List<string>? profileColumnNames;
+    private readonly bool hasTextPathColumn;
 
     public DatStandardComposer(
         FileGenerationRequest request,
@@ -27,6 +29,8 @@ internal sealed class DatStandardComposer
         this.headerColumns = headerColumns;
         this.profileGenerator = profileGenerator;
         this.profileColumnNames = profileColumnNames;
+        this.hasTextPathColumn = profileColumnNames?.Any(
+            n => StandardRowValueGenerators.ByName.TryGetValue(n, out var gen) && gen is TextPathGenerator) ?? false;
     }
 
     /// <summary>
@@ -207,93 +211,53 @@ internal sealed class DatStandardComposer
             string controlIdentity = (!ctx.IsChild && wi.ControlNumberOverride is not null) ? wi.ControlNumberOverride : batesIdentity;
             var fileSize = ctx.FileSizeOverride ?? (ctx.IsChild ? null : fileData.DataLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
+            var standard = new StandardRowResolution
+            {
+                ControlIdentity = controlIdentity,
+                BatesIdentity = batesIdentity,
+                NativePath = ctx.FilePathOverride ?? wi.FilePathInZip,
+                FileSize = fileSize,
+                TextPath = this.request.Output.WithText && this.hasTextPathColumn ? this.StandardTextPath(fileData, ctx) : string.Empty,
+                PageCount = fileData.PageCount,
+                IsChild = ctx.IsChild,
+                WithFamilies = this.request.Metadata.WithFamilies,
+                WithText = this.request.Output.WithText,
+                BegAttach = ctx.BegAttach,
+                EndAttach = ctx.EndAttach,
+                ParentDocId = ctx.ParentDocId,
+            };
+
+#pragma warning disable S2245
+            var baseCtx = new ColumnGenerationContext
+            {
+                NativeFileIndex = wi.Index,
+                FolderNumber = wi.FolderNumber,
+                DocumentIndex = 0,
+                Seeded = Random.Shared,
+                Now = DatComposerShared.EffectiveNow(this.request),
+                FileData = fileData,
+            };
+#pragma warning restore S2245
+
             var result = new List<string>(this.profileColumnNames.Count);
             for (int i = 0; i < this.profileColumnNames.Count; i++)
             {
                 var n = this.profileColumnNames[i];
-                var upper = n.ToUpperInvariant();
-
-                string val;
-                switch (upper)
+                if (StandardRowValueGenerators.ByName.TryGetValue(n, out var generator))
                 {
-                    case "DOCID":
-                    case "CONTROLNUMBER":
-                    case "CONTROL_NUMBER":
-                    case "CONTROL NUMBER":
-                        val = controlIdentity;
-                        break;
-                    case "BEGBATES":
-                    case "ENDBATES":
-                        val = batesIdentity;
-                        break;
-                    case "FILEPATH":
-                    case "FILE_PATH":
-                    case "FILE PATH":
-                    case "NATIVEPATH":
-                    case "NATIVE_PATH":
-                    case "NATIVE PATH":
-                        val = ctx.FilePathOverride ?? wi.FilePathInZip;
-                        break;
-                    case "FILESIZE":
-                    case "FILE_SIZE":
-                    case "FILE SIZE":
-                        val = fileSize ?? (profileValues.TryGetValue(n, out var fs) ? fs : string.Empty);
-                        break;
-                    case "BEGATTACH":
-                    case "BEG_ATTACH":
-                    case "BEG ATTACH":
-                        val = this.request.Metadata.WithFamilies ? ctx.BegAttach : (profileValues.TryGetValue(n, out var ba) ? ba : string.Empty);
-                        break;
-                    case "ENDATTACH":
-                    case "END_ATTACH":
-                    case "END ATTACH":
-                        val = this.request.Metadata.WithFamilies ? ctx.EndAttach : (profileValues.TryGetValue(n, out var ea) ? ea : string.Empty);
-                        break;
-                    case "PARENTDOCID":
-                    case "PARENT_DOC_ID":
-                    case "PARENT DOC ID":
-                        val = this.request.Metadata.WithFamilies ? ctx.ParentDocId : (profileValues.TryGetValue(n, out var pd) ? pd : string.Empty);
-                        break;
-                    case "DATESENT":
-                    case "DATE_SENT":
-                    case "DATE SENT":
-                    case "AUTHOR":
-                    case "EMAILTO":
-                    case "EMAIL_TO":
-                    case "EMAIL TO":
-                    case "EMAILFROM":
-                    case "EMAIL_FROM":
-                    case "EMAIL FROM":
-                    case "EMAILCC":
-                    case "EMAIL_CC":
-                    case "EMAIL CC":
-                    case "EMAILSUBJECT":
-                    case "EMAIL_SUBJECT":
-                    case "EMAIL SUBJECT":
-                    case "EMAILSENTDATE":
-                    case "EMAIL_SENT_DATE":
-                    case "EMAIL SENT DATE":
-                    case "EMAILATTACHMENT":
-                    case "EMAIL_ATTACHMENT":
-                    case "EMAIL ATTACHMENT":
-                        val = ctx.IsChild ? string.Empty : (profileValues.TryGetValue(n, out var ce) ? ce : string.Empty);
-                        break;
-                    case "PAGECOUNT":
-                    case "PAGE_COUNT":
-                    case "PAGE COUNT":
-                        val = ctx.IsChild ? "1" : fileData.PageCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                        break;
-                    case "TEXTPATH":
-                    case "TEXT_PATH":
-                    case "TEXT PATH":
-                        val = this.request.Output.WithText ? this.StandardTextPath(fileData, ctx) : (profileValues.TryGetValue(n, out var tp) ? tp : string.Empty);
-                        break;
-                    default:
-                        val = DatComposerShared.ResolveHashColumn(upper, fileData) ?? (profileValues.TryGetValue(n, out var x) ? x : string.Empty);
-                        break;
+                    var generationCtx = baseCtx with
+                    {
+                        StandardRow = standard,
+                        ProfileValue = profileValues.TryGetValue(n, out var profileValue) ? profileValue : null,
+                    };
+                    result.Add(generator.Generate(generationCtx));
                 }
-                result.Add(val);
+                else
+                {
+                    result.Add(DatComposerShared.ResolveHashColumn(n.ToUpperInvariant(), fileData) ?? (profileValues.TryGetValue(n, out var x) ? x : string.Empty));
+                }
             }
+
             return result;
         }
 

--- a/src/Profiles/Generation/ColumnGenerationContext.cs
+++ b/src/Profiles/Generation/ColumnGenerationContext.cs
@@ -15,4 +15,16 @@ internal sealed record ColumnGenerationContext
     public FileData? FileData { get; init; }
 
     public ColumnDefinition? ProfileColumn { get; init; }
+
+    /// <summary>
+    /// Set by the DAT Standard composer's profile path to carry the row-level file context
+    /// to the standard-row value generators; null for ordinary profile generation.
+    /// </summary>
+    public StandardRowResolution? StandardRow { get; init; }
+
+    /// <summary>
+    /// The Column Profile value for the current column, used as the fallback for columns whose
+    /// file-context value is not applicable; null for ordinary profile generation.
+    /// </summary>
+    public string? ProfileValue { get; init; }
 }

--- a/src/Profiles/Generation/StandardRowValueGenerators.cs
+++ b/src/Profiles/Generation/StandardRowValueGenerators.cs
@@ -1,0 +1,147 @@
+namespace Zipper.Profiles.Generation;
+
+/// <summary>
+/// Row-level resolution data for the profile-path standard row values in the DAT Standard
+/// composer. Carries the file-context identities, overrides, and family values resolved by the
+/// standard-row value generators; the Column Profile value for the current column travels on
+/// <see cref="ColumnGenerationContext.ProfileValue"/> and serves as the fallback for columns
+/// whose file-context value is not applicable.
+/// </summary>
+internal sealed record StandardRowResolution
+{
+    /// <summary>Control Number identity (child-aware override, else Bates identity).</summary>
+    public required string ControlIdentity { get; init; }
+
+    /// <summary>Bates identity (IdOverride, else formatted sequence / DOC-index fallback).</summary>
+    public required string BatesIdentity { get; init; }
+
+    /// <summary>Native path (FilePathOverride, else the work item's in-ZIP path).</summary>
+    public required string NativePath { get; init; }
+
+    /// <summary>File size (FileSizeOverride, else DataLength; null for child records).</summary>
+    public string? FileSize { get; init; }
+
+    /// <summary>Resolved text path for the record (empty when text output is off).</summary>
+    public required string TextPath { get; init; }
+
+    /// <summary>Page count of the parent record.</summary>
+    public required int PageCount { get; init; }
+
+    public required bool IsChild { get; init; }
+
+    public required bool WithFamilies { get; init; }
+
+    public required bool WithText { get; init; }
+
+    public required string BegAttach { get; init; }
+
+    public required string EndAttach { get; init; }
+
+    public required string ParentDocId { get; init; }
+}
+
+/// <summary>Resolves the DOCID / CONTROLNUMBER column to the record's Control Number identity.</summary>
+internal sealed class ControlNumberGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) => context.StandardRow!.ControlIdentity;
+}
+
+/// <summary>Resolves the BEGBATES / ENDBATES columns to the record's Bates identity.</summary>
+internal sealed class BatesNumberGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) => context.StandardRow!.BatesIdentity;
+}
+
+/// <summary>Resolves the FILEPATH / NATIVEPATH columns to the record's native path.</summary>
+internal sealed class NativePathGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) => context.StandardRow!.NativePath;
+}
+
+/// <summary>Resolves the FILESIZE column to the record's file size, falling back to the profile value.</summary>
+internal sealed class FileSizeGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) => context.StandardRow!.FileSize ?? context.ProfileValue ?? string.Empty;
+}
+
+/// <summary>
+/// Resolves a family column (BEGATTACH / ENDATTACH / PARENTDOCID) to its family value when
+/// family columns are enabled, else the profile value.
+/// </summary>
+internal sealed class FamilyValueGenerator : IColumnValueGenerator
+{
+    private readonly Func<StandardRowResolution, string> selector;
+
+    public FamilyValueGenerator(Func<StandardRowResolution, string> selector)
+    {
+        this.selector = selector;
+    }
+
+    public string Generate(ColumnGenerationContext context) =>
+        context.StandardRow!.WithFamilies ? this.selector(context.StandardRow) : context.ProfileValue ?? string.Empty;
+}
+
+/// <summary>
+/// Resolves the email metadata and Date Sent / Author columns to the profile value, blank on
+/// child (attachment) records.
+/// </summary>
+internal sealed class ProfileValueUnlessChildGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) =>
+        context.StandardRow!.IsChild ? string.Empty : context.ProfileValue ?? string.Empty;
+}
+
+/// <summary>Resolves the PAGECOUNT column to 1 on child records, else the parent's page count.</summary>
+internal sealed class PageCountGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) =>
+        context.StandardRow!.IsChild ? "1" : context.StandardRow.PageCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}
+
+/// <summary>Resolves the TEXTPATH column to the resolved text path when text is on, else the profile value.</summary>
+internal sealed class TextPathGenerator : IColumnValueGenerator
+{
+    public string Generate(ColumnGenerationContext context) =>
+        context.StandardRow!.WithText ? context.StandardRow.TextPath : context.ProfileValue ?? string.Empty;
+}
+
+/// <summary>
+/// Registry mapping profile-path column names (looked up case-insensitively by the caller) to
+/// the standard-row value generators, per ADR-0004. Column names not present here fall through
+/// to hash resolution then the profile value.
+/// </summary>
+internal static class StandardRowValueGenerators
+{
+    public static readonly IReadOnlyDictionary<string, IColumnValueGenerator> ByName = Create();
+
+    private static Dictionary<string, IColumnValueGenerator> Create()
+    {
+        var map = new Dictionary<string, IColumnValueGenerator>(StringComparer.OrdinalIgnoreCase);
+        Add(map, new ControlNumberGenerator(), "DOCID", "CONTROLNUMBER", "CONTROL_NUMBER", "CONTROL NUMBER");
+        Add(map, new BatesNumberGenerator(), "BEGBATES", "ENDBATES");
+        Add(map, new NativePathGenerator(), "FILEPATH", "FILE_PATH", "FILE PATH", "NATIVEPATH", "NATIVE_PATH", "NATIVE PATH");
+        Add(map, new FileSizeGenerator(), "FILESIZE", "FILE_SIZE", "FILE SIZE");
+        Add(map, new FamilyValueGenerator(s => s.BegAttach), "BEGATTACH", "BEG_ATTACH", "BEG ATTACH");
+        Add(map, new FamilyValueGenerator(s => s.EndAttach), "ENDATTACH", "END_ATTACH", "END ATTACH");
+        Add(map, new FamilyValueGenerator(s => s.ParentDocId), "PARENTDOCID", "PARENT_DOC_ID", "PARENT DOC ID");
+        Add(map, new ProfileValueUnlessChildGenerator(),
+            "DATESENT", "DATE_SENT", "DATE SENT", "AUTHOR",
+            "EMAILTO", "EMAIL_TO", "EMAIL TO",
+            "EMAILFROM", "EMAIL_FROM", "EMAIL FROM",
+            "EMAILCC", "EMAIL_CC", "EMAIL CC",
+            "EMAILSUBJECT", "EMAIL_SUBJECT", "EMAIL SUBJECT",
+            "EMAILSENTDATE", "EMAIL_SENT_DATE", "EMAIL SENT DATE",
+            "EMAILATTACHMENT", "EMAIL_ATTACHMENT", "EMAIL ATTACHMENT");
+        Add(map, new PageCountGenerator(), "PAGECOUNT", "PAGE_COUNT", "PAGE COUNT");
+        Add(map, new TextPathGenerator(), "TEXTPATH", "TEXT_PATH", "TEXT PATH");
+        return map;
+    }
+
+    private static void Add(Dictionary<string, IColumnValueGenerator> map, IColumnValueGenerator generator, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            map[name] = generator;
+        }
+    }
+}

--- a/src/Zipper.Tests/Profiles/Generation/StandardRowValueGeneratorsTests.cs
+++ b/src/Zipper.Tests/Profiles/Generation/StandardRowValueGeneratorsTests.cs
@@ -1,0 +1,254 @@
+using Xunit;
+using Zipper.Profiles.Generation;
+
+namespace Zipper.Tests;
+
+/// <summary>
+/// Tests for the standard-row value generators used by the DAT Standard composer's profile path
+/// (ADR-0004 registry, issue #747).
+/// </summary>
+public class StandardRowValueGeneratorsTests
+{
+    private static StandardRowResolution MakeResolution(
+        string controlIdentity = "CTRL42",
+        string batesIdentity = "BATES42",
+        string nativePath = "NATIVES/001/DOC00000001.pdf",
+        string? fileSize = null,
+        string textPath = "TEXT/DOC00000001.txt",
+        int pageCount = 7,
+        bool isChild = false,
+        bool withFamilies = false,
+        bool withText = false,
+        string begAttach = "B1",
+        string endAttach = "E1",
+        string parentDocId = "P1")
+        => new()
+        {
+            ControlIdentity = controlIdentity,
+            BatesIdentity = batesIdentity,
+            NativePath = nativePath,
+            FileSize = fileSize,
+            TextPath = textPath,
+            PageCount = pageCount,
+            IsChild = isChild,
+            WithFamilies = withFamilies,
+            WithText = withText,
+            BegAttach = begAttach,
+            EndAttach = endAttach,
+            ParentDocId = parentDocId,
+        };
+
+    private static ColumnGenerationContext MakeContext(StandardRowResolution resolution, string? profileValue = null)
+    {
+#pragma warning disable S2245
+        return new ColumnGenerationContext
+        {
+            NativeFileIndex = 1,
+            FolderNumber = 1,
+            DocumentIndex = 0,
+            Seeded = new Random(42),
+            Now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            FileData = new FileData
+            {
+                WorkItem = new FileWorkItem { Index = 1, FolderNumber = 1 },
+                DataLength = 2048,
+                PageCount = 7,
+            },
+            StandardRow = resolution,
+            ProfileValue = profileValue,
+        };
+#pragma warning restore S2245
+    }
+
+    [Fact]
+    public void ControlNumberGenerator_ReturnsControlIdentity()
+    {
+        var gen = new ControlNumberGenerator();
+        Assert.Equal("CTRL42", gen.Generate(MakeContext(MakeResolution(controlIdentity: "CTRL42"))));
+    }
+
+    [Fact]
+    public void BatesNumberGenerator_ReturnsBatesIdentity()
+    {
+        var gen = new BatesNumberGenerator();
+        Assert.Equal("BATES42", gen.Generate(MakeContext(MakeResolution(batesIdentity: "BATES42"))));
+    }
+
+    [Fact]
+    public void NativePathGenerator_ReturnsNativePath()
+    {
+        var gen = new NativePathGenerator();
+        Assert.Equal("NATIVES/001/DOC00000001.pdf", gen.Generate(MakeContext(MakeResolution(nativePath: "NATIVES/001/DOC00000001.pdf"))));
+    }
+
+    [Fact]
+    public void FileSizeGenerator_FileSizePreferred_OverProfileValue()
+    {
+        var gen = new FileSizeGenerator();
+        var ctx = MakeContext(MakeResolution(fileSize: "2048"), profileValue: "9999");
+        Assert.Equal("2048", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void FileSizeGenerator_MissingFileSize_FallsBackToProfileValue()
+    {
+        var gen = new FileSizeGenerator();
+        var ctx = MakeContext(MakeResolution(fileSize: null), profileValue: "9999");
+        Assert.Equal("9999", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void FileSizeGenerator_MissingBoth_ReturnsEmpty()
+    {
+        var gen = new FileSizeGenerator();
+        Assert.Equal(string.Empty, gen.Generate(MakeContext(MakeResolution(fileSize: null))));
+    }
+
+    [Fact]
+    public void BegAttachGenerator_WithFamilies_UsesContextValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.BegAttach);
+        var ctx = MakeContext(MakeResolution(withFamilies: true, begAttach: "B1"), profileValue: "PV");
+        Assert.Equal("B1", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void BegAttachGenerator_WithoutFamilies_UsesProfileValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.BegAttach);
+        var ctx = MakeContext(MakeResolution(withFamilies: false, begAttach: "B1"), profileValue: "PV");
+        Assert.Equal("PV", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void EndAttachGenerator_WithFamilies_UsesContextValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.EndAttach);
+        var ctx = MakeContext(MakeResolution(withFamilies: true, endAttach: "E1"), profileValue: "PV");
+        Assert.Equal("E1", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void EndAttachGenerator_WithoutFamilies_UsesProfileValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.EndAttach);
+        var ctx = MakeContext(MakeResolution(withFamilies: false, endAttach: "E1"), profileValue: "PV");
+        Assert.Equal("PV", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void ParentDocIdGenerator_WithFamilies_UsesContextValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.ParentDocId);
+        var ctx = MakeContext(MakeResolution(withFamilies: true, parentDocId: "P1"), profileValue: "PV");
+        Assert.Equal("P1", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void ParentDocIdGenerator_WithoutFamilies_UsesProfileValue()
+    {
+        var gen = new FamilyValueGenerator(s => s.ParentDocId);
+        var ctx = MakeContext(MakeResolution(withFamilies: false, parentDocId: "P1"), profileValue: "PV");
+        Assert.Equal("PV", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void ProfileValueUnlessChildGenerator_Child_ReturnsEmpty()
+    {
+        var gen = new ProfileValueUnlessChildGenerator();
+        var ctx = MakeContext(MakeResolution(isChild: true), profileValue: "X");
+        Assert.Equal(string.Empty, gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void ProfileValueUnlessChildGenerator_NotChild_ReturnsProfileValue()
+    {
+        var gen = new ProfileValueUnlessChildGenerator();
+        var ctx = MakeContext(MakeResolution(isChild: false), profileValue: "X");
+        Assert.Equal("X", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void PageCountGenerator_Child_ReturnsOne()
+    {
+        var gen = new PageCountGenerator();
+        var ctx = MakeContext(MakeResolution(isChild: true, pageCount: 7));
+        Assert.Equal("1", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void PageCountGenerator_NotChild_ReturnsPageCount()
+    {
+        var gen = new PageCountGenerator();
+        var ctx = MakeContext(MakeResolution(isChild: false, pageCount: 7));
+        Assert.Equal("7", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void TextPathGenerator_WithText_UsesResolvedTextPath()
+    {
+        var gen = new TextPathGenerator();
+        var ctx = MakeContext(MakeResolution(withText: true, textPath: "TEXT/DOC00000001.txt"), profileValue: "PV");
+        Assert.Equal("TEXT/DOC00000001.txt", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void TextPathGenerator_WithoutText_UsesProfileValue()
+    {
+        var gen = new TextPathGenerator();
+        var ctx = MakeContext(MakeResolution(withText: false, textPath: "TEXT/DOC00000001.txt"), profileValue: "PV");
+        Assert.Equal("PV", gen.Generate(ctx));
+    }
+
+    [Fact]
+    public void ByName_ContainsEveryProfilePathSwitchAlias()
+    {
+        foreach (var name in new[]
+        {
+            "DOCID", "CONTROLNUMBER", "CONTROL_NUMBER", "CONTROL NUMBER",
+            "BEGBATES", "ENDBATES",
+            "FILEPATH", "FILE_PATH", "FILE PATH", "NATIVEPATH", "NATIVE_PATH", "NATIVE PATH",
+            "FILESIZE", "FILE_SIZE", "FILE SIZE",
+            "BEGATTACH", "BEG_ATTACH", "BEG ATTACH",
+            "ENDATTACH", "END_ATTACH", "END ATTACH",
+            "PARENTDOCID", "PARENT_DOC_ID", "PARENT DOC ID",
+            "DATESENT", "DATE_SENT", "DATE SENT", "AUTHOR",
+            "EMAILTO", "EMAIL_TO", "EMAIL TO",
+            "EMAILFROM", "EMAIL_FROM", "EMAIL FROM",
+            "EMAILCC", "EMAIL_CC", "EMAIL CC",
+            "EMAILSUBJECT", "EMAIL_SUBJECT", "EMAIL SUBJECT",
+            "EMAILSENTDATE", "EMAIL_SENT_DATE", "EMAIL SENT DATE",
+            "EMAILATTACHMENT", "EMAIL_ATTACHMENT", "EMAIL ATTACHMENT",
+            "PAGECOUNT", "PAGE_COUNT", "PAGE COUNT",
+            "TEXTPATH", "TEXT_PATH", "TEXT PATH",
+        })
+        {
+            Assert.True(StandardRowValueGenerators.ByName.ContainsKey(name), $"registry missing alias: {name}");
+        }
+    }
+
+    [Fact]
+    public void ByName_BindsAliasesToExpectedGenerators()
+    {
+        Assert.IsType<ControlNumberGenerator>(StandardRowValueGenerators.ByName["CONTROL NUMBER"]);
+        Assert.IsType<BatesNumberGenerator>(StandardRowValueGenerators.ByName["BEGBATES"]);
+        Assert.IsType<NativePathGenerator>(StandardRowValueGenerators.ByName["NATIVE PATH"]);
+        Assert.IsType<FileSizeGenerator>(StandardRowValueGenerators.ByName["FILE SIZE"]);
+        Assert.IsType<FamilyValueGenerator>(StandardRowValueGenerators.ByName["BEGATTACH"]);
+        Assert.IsType<FamilyValueGenerator>(StandardRowValueGenerators.ByName["ENDATTACH"]);
+        Assert.IsType<FamilyValueGenerator>(StandardRowValueGenerators.ByName["PARENTDOCID"]);
+        Assert.IsType<ProfileValueUnlessChildGenerator>(StandardRowValueGenerators.ByName["DATESENT"]);
+        Assert.IsType<ProfileValueUnlessChildGenerator>(StandardRowValueGenerators.ByName["AUTHOR"]);
+        Assert.IsType<PageCountGenerator>(StandardRowValueGenerators.ByName["PAGE COUNT"]);
+        Assert.IsType<TextPathGenerator>(StandardRowValueGenerators.ByName["TEXT PATH"]);
+    }
+
+    [Fact]
+    public void ByName_DoesNotContainHashOrArbitraryColumns()
+    {
+        Assert.False(StandardRowValueGenerators.ByName.ContainsKey("MD5HASH"));
+        Assert.False(StandardRowValueGenerators.ByName.ContainsKey("SHA256HASH"));
+        Assert.False(StandardRowValueGenerators.ByName.ContainsKey("CUSTODIAN"));
+        Assert.False(StandardRowValueGenerators.ByName.ContainsKey("DOESNOTEXIST"));
+    }
+}


### PR DESCRIPTION
## Release Notes
Replaced the 28-case column-type switch in `DatStandardComposer.StandardRowValues` with an `IColumnValueGenerator` registry (ADR-0004), so standard-path DAT row values now resolve through the same extensibility point as other column generators. Output is byte-for-byte identical to the previous implementation, verified by a seeded golden harness.

## Description

Issue #747: `DatStandardComposer.StandardRowValues` was a ~190-line god method whose profile path contained a 28-case `switch` mapping Column Profile column names to value-resolution logic — the opposite of Open/Closed. This PR migrates each case to a registered `IColumnValueGenerator` (per ADR-0004).

**What changed:**
- `src/Profiles/Generation/StandardRowValueGenerators.cs` (new) — `StandardRowResolution` (row-level identities/overrides/family values) + 8 generator types (`ControlNumber`, `BatesNumber`, `NativePath`, `FileSize`, `FamilyValue`, `ProfileValueUnlessChild`, `PageCount`, `TextPath`) + the `StandardRowValueGenerators.ByName` registry with the exact alias set of the removed switch.
- `src/LoadFiles/DatStandardComposer.cs` — profile path of `StandardRowValues` is now a loop: per column, look up the generator (case-insensitive) and call it; unknown columns fall through to hash resolution then the profile value, exactly as the old `default` case did.
- `src/Profiles/Generation/ColumnGenerationContext.cs` — added `StandardRow` + `ProfileValue` so generators receive row context and the per-column profile fallback.
- `src/Zipper.Tests/Profiles/Generation/StandardRowValueGeneratorsTests.cs` (new) — 21 unit tests covering every generator branch, alias completeness, alias→generator binding, and the registry absence of hash/arbitrary columns.

**Equivalence:** all 28 switch cases map 1:1 (same precedence, fallbacks, child/parent gating, and `ToUpperInvariant`-equivalent case-insensitive lookup). Verified byte-for-byte against a seeded golden baseline across 4 profile-path scenarios (standard/litigation/full/collection-meta, incl. attachments, families, Bates, text) — all identical.

**Review:** ran the repo autoreview (5 specialists: correctness, adversarial, performance, testing, maintainability). All agreed the patch is correct; accepted fixes removed a dead per-row `Random` allocation, made `StandardTextPath` lazy, dropped a redundant per-column `ToUpperInvariant`, added an alias→generator binding test, and updated stale doc comments.

## Type of Change

- [x] Refactor

## Testing Done

- [x] Unit tests pass — 1659 `Zipper.Tests`, 44 `Zipper.Analyzers.Tests`
- [ ] E2E tests pass (`bash tests/run-tests.sh`) — not run; golden parity harness run instead (4/4 scenarios byte-identical), per Critical Rule 6
- [x] Lint clean (`dotnet format --verify-no-changes src/`)

## Architecture

- [x] No deviation from the [architecture diagrams](../docs/architecture.md#architecture-invariants-human-approval-required) — migration to the existing ADR-0004 `IColumnValueGenerator` contract; the `composer → serializer → emitter` seam is untouched.

## Affected Requirements

No REQ/FR identifiers changed — output-preserving internal refactor (parity verified).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating standard profile columns, including control and Bates numbers, native paths, file sizes, family metadata, page counts, and text paths.
  * Added handling for child-document values and column aliases.

* **Bug Fixes**
  * Improved fallback handling when standard column values are unavailable.

* **Tests**
  * Added comprehensive coverage for standard column generation, aliases, fallbacks, and child-document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->